### PR TITLE
Add simple fixes from the Status Quo mod to CWR

### DIFF
--- a/engine/Poseidon/AI/AIGroup.cpp
+++ b/engine/Poseidon/AI/AIGroup.cpp
@@ -1311,7 +1311,12 @@ bool AIGroup::Think()
             {
                 continue;
             }
-            if (!unit->IsUnit())
+            EntityAI* veh = unit->GetVehicleIn();
+            if (!veh)
+            {
+                continue;
+            }
+            if (!unit->IsUnit() && (veh->GetGroup() == this || veh->GunnerUnit() != unit))
             {
                 continue;
             }

--- a/engine/Poseidon/AI/AIGroupImpl.cpp
+++ b/engine/Poseidon/AI/AIGroupImpl.cpp
@@ -465,7 +465,12 @@ bool AIGroup::CreateTargetList(bool initialize, bool report)
         {
             continue;
         }
-        if (!unit->IsUnit())
+        EntityAI* veh = unit->GetVehicle();
+        if (!veh)
+        {
+            continue;
+        }
+        if (!unit->IsUnit() && (veh->GetGroup() == this || veh->GunnerUnit() != unit))
         {
             continue;
         }

--- a/engine/Poseidon/AI/VehicleAICombat.cpp
+++ b/engine/Poseidon/AI/VehicleAICombat.cpp
@@ -2447,7 +2447,7 @@ bool EntityAI::FireWeapon(int weapon, TargetType* target)
 
     if (magazine->_burstLeft == 1 || mode->_burst == 0)
     {
-        AIUnit* unit = GunnerUnit();
+        AIUnit* unit = EffectiveGunnerUnit();
         if (!unit)
         {
             unit = CommanderUnit();

--- a/engine/Poseidon/Network/NetworkServerIntegrity.cpp
+++ b/engine/Poseidon/Network/NetworkServerIntegrity.cpp
@@ -750,6 +750,23 @@ void NetworkServer::OnPlayerDestroy(int dpid)
             }
         }
     }
+
+    if (_dedicated)
+    {
+        for (int i = 0; i < _votings.Size(); i++)
+        {
+            Voting& voting = _votings.Set(i);
+            for (int j = 0; j < voting.Size(); j++)
+            {
+                if(voting.Get(j).player == dpid)
+                {
+                    voting.Delete(j);
+                    j--;
+                }
+            }
+        }
+    }
+
     for (int i = 0; i < _playerRoles.Size(); i++)
     {
         PlayerRole& role = _playerRoles[i];

--- a/engine/Poseidon/UI/InGame/InGameUIDraw.cpp
+++ b/engine/Poseidon/UI/InGame/InGameUIDraw.cpp
@@ -1142,21 +1142,33 @@ void InGameUI::DrawCompass(EntityAI* vehicle)
     GLOB_ENGINE->DrawLine(Line2DPixel(xPos, coY * h, xPos + xSize, coY * h - ySize), col, col, compassClip);
     GLOB_ENGINE->DrawLine(Line2DPixel(xPos, coY * h, xPos - xSize, coY * h - ySize), col, col, compassClip);
 
-    int weapon = vehicle->SelectedWeapon();
-    if (weapon >= 0)
+    AIUnit* unit = GWorld->FocusOn();
+    PoseidonAssert(unit);
+
+    Vector3 vehDir = VZero;
+    if (unit && unit == vehicle->PilotUnit())
     {
-        // draw turret direction
-
-        Vector3Val dir = vehicle->DirectionWorldToModel(vehicle->GetWeaponDirection(weapon));
-
-        if (dir.SquareSizeXZ() > 0.1)
+        int weapon = vehicle->SelectedWeapon();
+        if (weapon >= 0)
         {
-            xAngle = atan2(dir.X(), dir.Z());
-            float xPos = (coX + 0.5 * coW + xAngle * coW * INV_W) * w;
-            PackedColor col = compassTurretDirColor;
-            GLOB_ENGINE->DrawLine(Line2DPixel(xPos, coY * h, xPos + xSize, coY * h - ySize), col, col, compassClip);
-            GLOB_ENGINE->DrawLine(Line2DPixel(xPos, coY * h, xPos - xSize, coY * h - ySize), col, col, compassClip);
+            // draw turret direction
+
+            vehDir = Vector3(VRotate, cam.GetInvTransform(), vehicle->GetWeaponDirection(weapon));
         }
+    }
+    else
+    {
+        // draw vehicle direction
+        vehDir = Vector3(VRotate, cam.GetInvTransform(), vehicle->Direction());
+    }
+
+    if (vehDir.SquareSizeXZ() > 0.1)
+    {
+        xAngle = atan2(vehDir.X(), vehDir.Z());
+        float xPos = (coX + 0.5 * coW + xAngle * coW * INV_W) * w;
+        PackedColor col = compassTurretDirColor;
+        GLOB_ENGINE->DrawLine(Line2DPixel(xPos, coY * h, xPos + xSize, coY * h - ySize), col, col, compassClip);
+        GLOB_ENGINE->DrawLine(Line2DPixel(xPos, coY * h, xPos - xSize, coY * h - ySize), col, col, compassClip);
     }
 }
 

--- a/engine/Poseidon/UI/InGame/InGameUIMenuSim.cpp
+++ b/engine/Poseidon/UI/InGame/InGameUIMenuSim.cpp
@@ -946,7 +946,7 @@ void InGameUI::SimulateHUD(const Camera& camera, EntityAI* vehicle, CameraType c
                             // in not driver, click can be command to driver
                             // rule is to fire only when target is locked
                             (_lockTarget || isPilot) && !GWorld->HasMap() &&
-                            (!ModeIsStrategy(_mode) || _modeAuto == UIStrategyFire) && input.GetMouseLToDo())
+                            (!ModeIsStrategy(_mode) || _modeAuto == UIStrategyFire) && input.GetMouseL())
                         {
                             fire = true;
                         }
@@ -957,7 +957,7 @@ void InGameUI::SimulateHUD(const Camera& camera, EntityAI* vehicle, CameraType c
                         if (
                             // in not driver, click can be command to driver
                             // rule is to fire only when target is locked
-                            (_lockTarget || isPilot) && !GWorld->HasMap() && input.GetMouseL())
+                            (_lockTarget || isPilot) && !GWorld->HasMap() && input.GetMouseLToDo())
                         {
                             fire = true;
                         }

--- a/engine/Poseidon/World/Detection/Target.cpp
+++ b/engine/Poseidon/World/Detection/Target.cpp
@@ -404,7 +404,7 @@ void TargetList::Manage(AIGroup* group)
             {
                 continue;
             }
-            if (!unit->IsUnit())
+            if (unit->IsInCargo())
             {
                 continue;
             }

--- a/engine/Poseidon/World/Scene/Thing.cpp
+++ b/engine/Poseidon/World/Scene/Thing.cpp
@@ -52,7 +52,7 @@ Thing::Thing(VehicleType* name) : base(name), _doCrash(CrashNone)
 
     _isStopped = true;
     _objectContact = true;
-    _landContact = true;
+    _landContact = false;
     SetSimulationPrecision(1.0f / 15);
     _destrType = GetType()->GetDestructType();
 }


### PR DESCRIPTION
Reimplements the following fixes from Status Quo mod:
- fixed incorrect vote counting behavior when clients disconnected after voting
- fixed fully automatic weapons not firing fully automatic when manual fire is enabled and mouse is used
- fixed bug where night vision goggles model was used instead of binoculars in some circumstances
- fixed direction marker to rotate the wrong way when gunner/commander in vehicle
- fixed bug causing ammo casings not to spawn when framerate is high
- fixed multiplayer bug where gunners in vehicles could not see or select targets when the commander is from a different group

Two more fixes are pending but they will touch multiplayer code and it will break compatibility.