### PR TITLE
Support custom mouse DPI settings.

### DIFF
--- a/engine/Poseidon/Dev/Debug/DebugOverlay.cpp
+++ b/engine/Poseidon/Dev/Debug/DebugOverlay.cpp
@@ -1483,6 +1483,119 @@ void DrawRenderTab()
     ImGui::Text("target  scale %.2fx, %dx MSAA", GEngine->GetRenderScale(), GEngine->GetMsaaSamples());
     ImGui::TextDisabled("settings are session-only; persist via graphics.cfg");
 }
+void DrawMouseTab()
+{
+    // Plain field writes into live GInput.mouse — no Defer needed (cf. DrawCheatsTab).
+    auto& sub = InputSubsystem::Instance();
+    MouseTuning& t = sub.GetMouseTuning();
+
+    ImGui::TextUnformatted("Player settings (final)");
+    ImGui::Separator();
+
+    int dpiIdx = 0; // Off
+    if (t.dpiNormalize)
+    {
+        int bestDiff = 1 << 30;
+        for (int i = 1; i < kMouseDpiPresetCount; ++i)
+        {
+            int d = t.mouseDpi - kMouseDpiPresets[i];
+            if (d < 0)
+                d = -d;
+            if (d < bestDiff)
+            {
+                bestDiff = d;
+                dpiIdx = i;
+            }
+        }
+    }
+    if (ImGui::Combo("Mouse DPI", &dpiIdx, kMouseDpiLabels, kMouseDpiPresetCount))
+    {
+        t.dpiNormalize = dpiIdx > 0;
+        if (dpiIdx > 0)
+            t.mouseDpi = kMouseDpiPresets[dpiIdx];
+    }
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Set this to your mouse's DPI. The game then feels like %d DPI at any hardware.\n"
+                          "Off = classic (no compensation).",
+                          t.referenceDpi);
+
+    float sx = sub.GetMouseSensitivityX();
+    if (ImGui::SliderFloat("Sensitivity X", &sx, t.SensMin(), t.SensMax(), "%.3f"))
+        sub.SetMouseSensitivityX(sx);
+    float sy = sub.GetMouseSensitivityY();
+    if (ImGui::SliderFloat("Sensitivity Y", &sy, t.SensMin(), t.SensMax(), "%.3f"))
+        sub.SetMouseSensitivityY(sy);
+
+    bool rev = sub.IsReverseMouse();
+    if (ImGui::Checkbox("Invert Y axis", &rev))
+        sub.SetReverseMouse(rev);
+    bool swap = sub.IsMouseButtonsReversed();
+    if (ImGui::Checkbox("Swap mouse buttons", &swap))
+        sub.SetMouseButtonsReversed(swap);
+
+    ImGui::Spacing();
+    ImGui::TextUnformatted("Final values (live)");
+    ImGui::Separator();
+
+    // Cursor math mirrors MouseState::Update (kCursorScaleX = 1/200; screen = 2 NDC).
+    const float dpiF = t.DpiFactor();
+    const float perCountX = sx * t.baseScale * dpiF / 200.0f;
+    ImGui::Text("Reference DPI: %d   |   DPI factor: %.3f", t.referenceDpi, dpiF);
+    ImGui::Text("Effective sensitivity X (x baseScale): %.3f", sx * t.baseScale * dpiF);
+    if (perCountX > 0.0f)
+    {
+        const float countsCrossX = 2.0f / perCountX;
+        ImGui::Text("Counts to cross screen (X): %.0f", countsCrossX);
+        if (t.dpiNormalize && t.mouseDpi > 0)
+        {
+            // Normalized: physical hand travel is DPI-independent (mouseDpi cancels).
+            const float inch = countsCrossX / static_cast<float>(t.mouseDpi);
+            ImGui::Text("Hand travel to cross screen (X): %.2f in / %.1f cm", inch, inch * 2.54f);
+            ImGui::TextDisabled("  same physical feel at every DPI — normalization working");
+        }
+        else
+        {
+            ImGui::TextDisabled("  Off: raw counts — physical feel depends on your hardware DPI");
+        }
+    }
+    if (s_window)
+        ImGui::Text("SDL display scale: %.2f   pixel density: %.2f", SDL_GetWindowDisplayScale(s_window),
+                    SDL_GetWindowPixelDensity(s_window));
+    ImGui::TextDisabled("Mouse moves over this panel are captured by ImGui — close it to feel changes in game.");
+
+    ImGui::Spacing();
+    if (ImGui::CollapsingHeader("Advanced (dev only)"))
+    {
+        ImGui::SliderFloat("Base scale", &t.baseScale, 0.1f, 3.0f, "%.3f");
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Master look scale (was the hard-coded 1.5).");
+        ImGui::SliderInt("Reference DPI", &t.referenceDpi, 100, 3200);
+        ImGui::SliderFloat("Smoothing", &t.smoothing, 0.0f, 0.95f, "%.2f");
+        ImGui::Checkbox("Acceleration", &t.acceleration);
+        ImGui::BeginDisabled(!t.acceleration);
+        ImGui::SliderFloat("Accel exponent", &t.accelExponent, 1.0f, 2.0f, "%.2f");
+        ImGui::EndDisabled();
+        ImGui::SliderFloat("Menu cursor scale", &t.menuCursorScale, 0.1f, 4.0f, "%.2f");
+        if (ImGui::Checkbox("Extended sensitivity range", &t.extendedRange))
+        {
+            sub.SetMouseSensitivityX(std::clamp(sub.GetMouseSensitivityX(), t.SensMin(), t.SensMax()));
+            sub.SetMouseSensitivityY(std::clamp(sub.GetMouseSensitivityY(), t.SensMin(), t.SensMax()));
+        }
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Off = legacy 0.5..2.0 sensitivity range. On = 0.05..3.0.");
+    }
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    if (ImGui::Button("Reset tuning to classic"))
+        t = MouseTuning{};
+    ImGui::SameLine();
+    if (ImGui::Button("Save to mouse.cfg"))
+        Defer([] { InputSubsystem::Instance().SaveKeys(); });
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Persist sensitivity + tuning to mouse.cfg (also written for old builds).");
+}
+
 void DrawMainWindow()
 {
     ImGui::SetNextWindowSize(ImVec2(560, 480), ImGuiCond_FirstUseEver);
@@ -1503,6 +1616,11 @@ void DrawMainWindow()
         if (ImGui::BeginTabItem("Game"))
         {
             DrawGameTab();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Mouse"))
+        {
+            DrawMouseTab();
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Console"))

--- a/engine/Poseidon/Game/Commands/GameStateExtTestViewer.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestViewer.cpp
@@ -163,7 +163,7 @@ GameValue TriMouseDelta(const GameState* /*state*/, GameValuePar arg)
     // pump's reset (deltaX = bufDeltaX_ * sensitivity).  Sensitivity
     // is divided out so dx=200 yields ~200 px of effective drag,
     // matching what production code sees from a real SDL motion event.
-    constexpr float kSens = 1.5f; // matches kSensitivityScale in MouseState.cpp
+    constexpr float kSens = 1.5f; // matches the default MouseTuning::baseScale
     GInput.mouse.TestInjectMotion(dx / kSens, dy / kSens);
     LOG_INFO(Core, "[tri] triMouseDelta dx={} dy={}", dx, dy);
     return GameValue("OK");

--- a/engine/Poseidon/Input/InputSubsystem.cpp
+++ b/engine/Poseidon/Input/InputSubsystem.cpp
@@ -1060,6 +1060,15 @@ void InputSubsystem::LoadKeys()
     GInput.mouse.buttonsReversed = mouse.buttonsReversed;
     GInput.mouse.sensitivityX = mouse.sensitivityX;
     GInput.mouse.sensitivityY = mouse.sensitivityY;
+    GInput.mouse.tuning.baseScale = mouse.baseScale;
+    GInput.mouse.tuning.dpiNormalize = mouse.dpiNormalize;
+    GInput.mouse.tuning.mouseDpi = mouse.mouseDpi;
+    GInput.mouse.tuning.referenceDpi = mouse.referenceDpi;
+    GInput.mouse.tuning.smoothing = mouse.smoothing;
+    GInput.mouse.tuning.acceleration = mouse.acceleration;
+    GInput.mouse.tuning.accelExponent = mouse.accelExponent;
+    GInput.mouse.tuning.menuCursorScale = mouse.menuCursorScale;
+    GInput.mouse.tuning.extendedRange = mouse.extendedRange;
 
     GInput.gamepad.enabled = gamepad.enabled;
     GInput.gamepad.deadzoneStick = gamepad.deadzoneStick;
@@ -1084,6 +1093,15 @@ void InputSubsystem::SaveKeys()
     mouse.buttonsReversed = GInput.mouse.buttonsReversed;
     mouse.sensitivityX = GInput.mouse.sensitivityX;
     mouse.sensitivityY = GInput.mouse.sensitivityY;
+    mouse.baseScale = GInput.mouse.tuning.baseScale;
+    mouse.dpiNormalize = GInput.mouse.tuning.dpiNormalize;
+    mouse.mouseDpi = GInput.mouse.tuning.mouseDpi;
+    mouse.referenceDpi = GInput.mouse.tuning.referenceDpi;
+    mouse.smoothing = GInput.mouse.tuning.smoothing;
+    mouse.acceleration = GInput.mouse.tuning.acceleration;
+    mouse.accelExponent = GInput.mouse.tuning.accelExponent;
+    mouse.menuCursorScale = GInput.mouse.tuning.menuCursorScale;
+    mouse.extendedRange = GInput.mouse.tuning.extendedRange;
     mouse.Save(MouseCfgPath());
 }
 
@@ -1273,6 +1291,14 @@ void InputSubsystem::SetMouseSensitivityX(float v)
 void InputSubsystem::SetMouseSensitivityY(float v)
 {
     GInput.mouse.sensitivityY = v;
+}
+MouseTuning& InputSubsystem::GetMouseTuning()
+{
+    return GInput.mouse.tuning;
+}
+const MouseTuning& InputSubsystem::GetMouseTuning() const
+{
+    return GInput.mouse.tuning;
 }
 
 const AutoArray<int>& InputSubsystem::GetUserKeys(UserAction action) const

--- a/engine/Poseidon/Input/InputSubsystem.hpp
+++ b/engine/Poseidon/Input/InputSubsystem.hpp
@@ -4,6 +4,7 @@
 #include <Poseidon/Input/InputCode.hpp>
 #include <Poseidon/Input/InputContext.hpp>
 #include <Poseidon/Input/InputProfile.hpp>
+#include <Poseidon/Input/MouseTuning.hpp>
 #include <Poseidon/Input/UserAction.hpp>
 #include <SDL3/SDL_scancode.h>
 #include <array>
@@ -176,6 +177,10 @@ class InputSubsystem
     float GetMouseSensitivityY() const;
     void SetMouseSensitivityX(float v);
     void SetMouseSensitivityY(float v);
+
+    // Live mouse-feel tuning read by MouseState each frame; the dev Mouse tab edits it.
+    MouseTuning& GetMouseTuning();
+    const MouseTuning& GetMouseTuning() const;
 
     // Key binding access
     const AutoArray<int>& GetUserKeys(UserAction action) const;

--- a/engine/Poseidon/Input/MouseState.cpp
+++ b/engine/Poseidon/Input/MouseState.cpp
@@ -30,6 +30,7 @@ void MouseState::DiscardBuffered()
 {
     btnCount_ = 0;
     bufDeltaX_ = bufDeltaY_ = bufWheel_ = 0;
+    smoothX_ = smoothY_ = 0;
 }
 
 bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundEnabled, UITime currentTime,
@@ -84,11 +85,39 @@ bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundE
     }
     btnCount_ = 0;
 
-    // Apply mouse movement (float precision — no int truncation)
     rawDeltaX = bufDeltaX_;
     rawDeltaY = bufDeltaY_;
-    deltaX = bufDeltaX_ * sensitivityX * kSensitivityScale;
-    deltaY = bufDeltaY_ * sensitivityY * kSensitivityScale;
+
+    // Tuning pipeline, each stage a no-op at default tuning: smoothing → DPI → accel → sens·baseScale.
+    float inX = bufDeltaX_;
+    float inY = bufDeltaY_;
+
+    if (tuning.smoothing > 0.0f)
+    {
+        const float alpha = 1.0f - tuning.smoothing;
+        smoothX_ += (inX - smoothX_) * alpha;
+        smoothY_ += (inY - smoothY_) * alpha;
+        inX = smoothX_;
+        inY = smoothY_;
+    }
+    else
+    {
+        smoothX_ = inX; // keep state coherent if smoothing is enabled later
+        smoothY_ = inY;
+    }
+
+    const float dpi = tuning.DpiFactor();
+
+    if (tuning.acceleration && tuning.accelExponent > 1.0f)
+    {
+        const float speed = std::sqrt(inX * inX + inY * inY);
+        const float mult = std::pow(1.0f + speed, tuning.accelExponent - 1.0f);
+        inX *= mult;
+        inY *= mult;
+    }
+
+    deltaX = inX * sensitivityX * tuning.baseScale * dpi;
+    deltaY = inY * sensitivityY * tuning.baseScale * dpi;
     deltaZ = bufWheel_;
     bufDeltaX_ = bufDeltaY_ = bufWheel_ = 0;
 
@@ -115,8 +144,10 @@ bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundE
         else
             cursor.aimDeltaY += moveY;
     }
-    cursor.cursorX += moveX;
-    cursor.cursorY += moveY;
+    // The menu cursor can be scaled independently of look (menuCursorScale 1.0
+    // == classic: cursor and aim move together).
+    cursor.cursorX += moveX * tuning.menuCursorScale;
+    cursor.cursorY += moveY * tuning.menuCursorScale;
 
     cursor.aimDeltaZ += kWheelToCursorScale * deltaZ;
 

--- a/engine/Poseidon/Input/MouseState.hpp
+++ b/engine/Poseidon/Input/MouseState.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Poseidon/Input/InputDeviceConstants.hpp>
+#include <Poseidon/Input/MouseTuning.hpp>
 #include <Poseidon/Foundation/Time/Time.hpp>
 
 namespace Poseidon
@@ -35,6 +36,10 @@ struct MouseState
     // Config
     bool reverseY = false;
     bool buttonsReversed = false;
+
+    // Live feel tuning (DPI normalize, smoothing, accel, menu cursor scale,
+    // master baseScale).  Defaults reproduce classic behavior exactly.
+    MouseTuning tuning;
 
     // Activity timestamps
     Foundation::UITime cursorLastActive = UITIME_MIN;
@@ -96,7 +101,6 @@ struct MouseState
   private:
     static constexpr int kButtonBufferSize = 16;
     static constexpr int kDoubleClickWindowMs = 400;
-    static constexpr float kSensitivityScale = 1.5f;
     static constexpr float kCursorScaleX = 1.0f / 200.0f;
     static constexpr float kCursorScaleY = 1.0f / 150.0f;
     static constexpr float kCursorLimitX = 0.6f;
@@ -116,6 +120,8 @@ struct MouseState
     int buttonLastPressedMs_[N_MOUSE_BUTTONS] = {};
     float bufDeltaX_ = 0, bufDeltaY_ = 0;
     float bufWheel_ = 0;
+    // Smoothing low-pass state (only used when tuning.smoothing > 0).
+    float smoothX_ = 0, smoothY_ = 0;
 };
 } // namespace Poseidon
 

--- a/engine/Poseidon/Input/MouseTuning.hpp
+++ b/engine/Poseidon/Input/MouseTuning.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+// Live, session mouse-feel knobs shared by MouseState (consumer),
+// InputSubsystem (load/save bridge to mouse.cfg) and the dev "Mouse" tab.
+// Every field defaults to classic behavior, so a default-constructed instance
+// keeps mouse.cfg backwards compatible.
+
+namespace Poseidon
+{
+
+// Mouse DPI presets for the "Mouse DPI" selector.  Index 0 = "Off" (off).
+// Adjacent non-Off entries stay within 4x (the 0.5..2.0 sensitivity span), so
+// sensitivity can bridge any gap with no dead zone — locked by a unit test.
+inline constexpr int kMouseDpiPresets[] = {0, 400, 800, 1200, 1600, 2400, 3200, 6400, 12000, 16000, 24000, 32000};
+inline constexpr int kMouseDpiPresetCount = sizeof(kMouseDpiPresets) / sizeof(kMouseDpiPresets[0]);
+inline constexpr const char* kMouseDpiLabels[] = {"Off",   "400",   "800",   "1200",  "1600",  "2400",
+                                                  "3200",  "6400",  "12000", "16000", "24000", "32000"};
+
+struct MouseTuning
+{
+    float baseScale = 1.5f;       // master look scale
+
+    bool  dpiNormalize = false;   // scale raw counts by referenceDpi/mouseDpi (eDPI)
+    int   mouseDpi     = 1600;    // player's hardware DPI
+    int   referenceDpi = 1600;    // DPI the feel is calibrated to
+
+    float smoothing = 0.0f;       // low-pass on per-frame counts, [0,0.95]; 0 = off
+
+    bool  acceleration  = false;
+    float accelExponent = 1.0f;   // [1,2]; 1 = linear
+
+    float menuCursorScale = 1.0f; // menu cursor speed vs look; 1 = classic
+
+    bool  extendedRange = false;  // widen sensitivity range (UI/clamp only, not the motion math)
+
+    // Factor applied to raw counts (1.0 unless normalization is on).
+    float DpiFactor() const
+    {
+        return (dpiNormalize && mouseDpi > 0) ? static_cast<float>(referenceDpi) / static_cast<float>(mouseDpi)
+                                              : 1.0f;
+    }
+
+    float SensMin() const { return extendedRange ? 0.05f : 0.5f; }
+    float SensMax() const { return extendedRange ? 3.0f : 2.0f; }
+
+    // Clamp every field into range.  Returns true if anything changed.
+    bool Normalize()
+    {
+        bool changed = false;
+        auto clampF = [&](float& v, float lo, float hi)
+        {
+            float c = v < lo ? lo : (v > hi ? hi : v);
+            if (c != v)
+            {
+                v = c;
+                changed = true;
+            }
+        };
+        auto clampI = [&](int& v, int lo, int hi)
+        {
+            int c = v < lo ? lo : (v > hi ? hi : v);
+            if (c != v)
+            {
+                v = c;
+                changed = true;
+            }
+        };
+        clampF(baseScale, 0.1f, 3.0f);
+        clampI(mouseDpi, 100, 32000);
+        clampI(referenceDpi, 100, 32000);
+        clampF(smoothing, 0.0f, 0.95f);
+        clampF(accelExponent, 1.0f, 2.0f);
+        clampF(menuCursorScale, 0.1f, 4.0f);
+        return changed;
+    }
+};
+
+} // namespace Poseidon

--- a/engine/Poseidon/UI/Locale/Stringtable/Stringtable.cpp
+++ b/engine/Poseidon/UI/Locale/Stringtable/Stringtable.cpp
@@ -598,6 +598,12 @@ RString LocalizeString(const char* str)
     return GStringTable.Localize(str);
 }
 
+const char* LocalizeStringWithFallback(const char* key, const char* fallback)
+{
+    RString s = LocalizeString(key);
+    return s.GetLength() > 0 ? s.Data() : fallback;
+}
+
 RString Localize(RString str)
 {
     // BIS RV2 convention: "@KEY" — strip the @, look up KEY.

--- a/engine/Poseidon/UI/Locale/Stringtable/Stringtable.hpp
+++ b/engine/Poseidon/UI/Locale/Stringtable/Stringtable.hpp
@@ -25,6 +25,9 @@ int RegisterString(RString name);
 RString LocalizeString(int ids);
 RString LocalizeString(const char* str);
 
+// Localized value for `key`, or `fallback` verbatim if the key is missing/empty.
+const char* LocalizeStringWithFallback(const char* key, const char* fallback);
+
 RString Localize(RString str);
 
 // Open `csvPath` and return the value for `key` in the column matching the

--- a/engine/Poseidon/UI/Options/MousePage.cpp
+++ b/engine/Poseidon/UI/Options/MousePage.cpp
@@ -36,6 +36,35 @@ float MousePage::PercentToSensitivity(int percent)
     return 0.5f + (std::clamp(percent, 0, 100) / 100.0f) * 1.5f;
 }
 
+int MousePage::DpiToIndex(bool normalize, int mouseDpi)
+{
+    if (!normalize)
+        return 0; // Off
+    // Nearest preset, for display only — a hand-edited non-preset mouseDpi maps to
+    // the closest entry but isn't written back unless the user changes the stepper.
+    int best = 1;
+    int bestDiff = 1 << 30;
+    for (int i = 1; i < kMouseDpiPresetCount; ++i)
+    {
+        int d = mouseDpi - kMouseDpiPresets[i];
+        if (d < 0)
+            d = -d;
+        if (d < bestDiff)
+        {
+            bestDiff = d;
+            best = i;
+        }
+    }
+    return best;
+}
+
+int MousePage::IndexToDpi(int index)
+{
+    if (index <= 0 || index >= kMouseDpiPresetCount)
+        return 0; // Off sentinel
+    return kMouseDpiPresets[index];
+}
+
 void MousePage::Mount(OptionsShell& shell)
 {
     auto& sub = InputSubsystem::Instance();
@@ -43,6 +72,8 @@ void MousePage::Mount(OptionsShell& shell)
     m_savedButtonsReversed = sub.IsMouseButtonsReversed();
     m_savedSensitivityX = sub.GetMouseSensitivityX();
     m_savedSensitivityY = sub.GetMouseSensitivityY();
+    m_savedDpiNormalize = sub.GetMouseTuning().dpiNormalize;
+    m_savedMouseDpi = sub.GetMouseTuning().mouseDpi;
     ScrollListPage::Mount(shell);
 }
 
@@ -75,6 +106,8 @@ const char* MousePage::MouseProvider::RowLabel(int row) const
             return LocalizeString("STR_DISP_OPT_MOUSE_SENSITIVITY_X");
         case kRowSensitivityY:
             return LocalizeString("STR_DISP_OPT_MOUSE_SENSITIVITY_Y");
+        case kRowMouseDpi:
+            return LocalizeStringWithFallback("STR_DISP_OPT_MOUSE_DPI", "Mouse DPI");
         default:
             return "";
     }
@@ -92,6 +125,10 @@ const char* MousePage::MouseProvider::RowDescription(int row) const
             return LocalizeString("STR_DISP_OPT_MOUSE_SENSITIVITY_X_DESC");
         case kRowSensitivityY:
             return LocalizeString("STR_DISP_OPT_MOUSE_SENSITIVITY_Y_DESC");
+        case kRowMouseDpi:
+            return LocalizeStringWithFallback(
+                "STR_DISP_OPT_MOUSE_DPI_DESC",
+                "Set this to your mouse's DPI (or close). Fine-tune with sensitivity for a smoother feel.");
         default:
             return "";
     }
@@ -110,6 +147,8 @@ OptionsScrollList::RowDef MousePage::MouseProvider::RowFor(int row) const
             return {522, nullptr, -1};
         case kRowSensitivityY:
             return {532, nullptr, -1};
+        case kRowMouseDpi:
+            return {542, kMouseDpiLabels, kMouseDpiPresetCount};
         default:
             return {-1, nullptr, 0};
     }
@@ -136,6 +175,11 @@ int MousePage::MouseProvider::RowValue(int row) const
             return MousePage::SensitivityToPercent(sub.GetMouseSensitivityX());
         case kRowSensitivityY:
             return MousePage::SensitivityToPercent(sub.GetMouseSensitivityY());
+        case kRowMouseDpi:
+        {
+            const auto& t = sub.GetMouseTuning();
+            return MousePage::DpiToIndex(t.dpiNormalize, t.mouseDpi);
+        }
         default:
             return 0;
     }
@@ -162,6 +206,20 @@ void MousePage::MouseProvider::SetRowValue(int row, int value)
         case kRowSensitivityY:
             sub.SetMouseSensitivityY(MousePage::PercentToSensitivity(value));
             return;
+        case kRowMouseDpi:
+        {
+            auto& t = sub.GetMouseTuning();
+            if (value <= 0 || value >= kMouseDpiPresetCount)
+            {
+                t.dpiNormalize = false; // "Off"
+            }
+            else
+            {
+                t.dpiNormalize = true;
+                t.mouseDpi = kMouseDpiPresets[value];
+            }
+            return;
+        }
     }
 }
 

--- a/engine/Poseidon/UI/Options/MousePage.hpp
+++ b/engine/Poseidon/UI/Options/MousePage.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-// Mouse settings page — Y-axis inversion, button swap, sensitivity X / Y.
+// Mouse settings page — Y-axis inversion, button swap, sensitivity X / Y, Mouse DPI.
 //
-// 4 rows + auto-appended Close.  All four rows apply live (matching the
+// 5 rows + auto-appended Close.  All apply live (matching the
 // way the RscDisplayConfigure handled them).  Cancel via Close
 // snapshots the values on Mount and restores them — same pattern as
 // DisplayConfigure's `_old*` members, lifted into the page.
@@ -27,6 +27,12 @@ class MousePage : public ScrollListPage
     static int SensitivityToPercent(float value);
     static float PercentToSensitivity(int percent);
 
+    // Mouse DPI stepper mapping (pure, unit-tested).  Index 0 = "Off"; 1..N map to
+    // kMouseDpiPresets.  DpiToIndex returns the nearest preset for display without
+    // changing the stored value, so a hand-edited non-preset DPI survives.
+    static int DpiToIndex(bool normalize, int mouseDpi);
+    static int IndexToDpi(int index);
+
     void Mount(OptionsShell& shell) override;
     void OnReshown(OptionsShell& shell) override;
     void Unmount(OptionsShell& shell) override;
@@ -47,7 +53,8 @@ class MousePage : public ScrollListPage
             kRowButtonsReversed = 1,
             kRowSensitivityX    = 2,
             kRowSensitivityY    = 3,
-            kRowCount           = 4,
+            kRowMouseDpi        = 4,
+            kRowCount           = 5,
         };
 
         int RowCount() const override { return kRowCount; }
@@ -75,6 +82,8 @@ class MousePage : public ScrollListPage
     bool  m_savedButtonsReversed = false;
     float m_savedSensitivityX    = 1.0f;
     float m_savedSensitivityY    = 1.0f;
+    bool  m_savedDpiNormalize    = false;
+    int   m_savedMouseDpi        = 1600;
 };
 
 } // namespace Poseidon

--- a/engine/Poseidon/UI/Settings/MouseConfig.cpp
+++ b/engine/Poseidon/UI/Settings/MouseConfig.cpp
@@ -10,31 +10,55 @@
 namespace Poseidon
 {
 
-namespace
-{
-constexpr float kMinSensitivity = 0.5f;
-constexpr float kMaxSensitivity = 2.0f;
-} // namespace
-
 void MouseConfig::LoadDefaults()
 {
     *this = MouseConfig{};
 }
 
+float MouseConfig::MigrateSensitivity(float legacySens, float legacyBaseScale, float newBaseScale)
+{
+    // Keep newSens * newBaseScale == legacySens * legacyBaseScale.
+    if (newBaseScale <= 0.0f)
+        return legacySens;
+    return legacySens * (legacyBaseScale / newBaseScale);
+}
+
 bool MouseConfig::Normalize()
 {
     bool changed = false;
-    auto clamp = [&](float& v)
+    auto clampF = [&](float& v, float lo, float hi)
     {
-        float c = std::clamp(v, kMinSensitivity, kMaxSensitivity);
+        float c = std::clamp(v, lo, hi);
         if (c != v)
         {
             v = c;
             changed = true;
         }
     };
-    clamp(sensitivityX);
-    clamp(sensitivityY);
+    auto clampI = [&](int& v, int lo, int hi)
+    {
+        int c = std::clamp(v, lo, hi);
+        if (c != v)
+        {
+            v = c;
+            changed = true;
+        }
+    };
+
+    // Sensitivity range widens when extendedRange is enabled.
+    const float sensLo = extendedRange ? 0.05f : 0.5f;
+    const float sensHi = extendedRange ? 3.0f : 2.0f;
+    clampF(sensitivityX, sensLo, sensHi);
+    clampF(sensitivityY, sensLo, sensHi);
+
+    // v2 tuning fields — keep these ranges in sync with MouseTuning::Normalize.
+    clampF(baseScale, 0.1f, 3.0f);
+    clampI(mouseDpi, 100, 32000);
+    clampI(referenceDpi, 100, 32000);
+    clampF(smoothing, 0.0f, 0.95f);
+    clampF(accelExponent, 1.0f, 2.0f);
+    clampF(menuCursorScale, 0.1f, 4.0f);
+
     return changed;
 }
 
@@ -47,6 +71,13 @@ bool MouseConfig::Load(const std::string& path)
     ParamFile cfg;
     cfg.Parse(RString(path.c_str()));
 
+    // Schema version: absent ⇒ legacy v1 file (written before the tuning fields).
+    int ver = 1;
+    if (auto* e = cfg.FindEntry("version"))
+        ver = (int)*e;
+    version = ver;
+
+    // v1 keys — present in every version.
     if (auto* e = cfg.FindEntry("reverseY"))
         reverseY = (bool)*e;
     if (auto* e = cfg.FindEntry("buttonsReversed"))
@@ -55,6 +86,45 @@ bool MouseConfig::Load(const std::string& path)
         sensitivityX = (float)*e;
     if (auto* e = cfg.FindEntry("sensitivityY"))
         sensitivityY = (float)*e;
+
+    if (ver >= 2)
+    {
+        // lookSens* is authoritative (the v1 sensitivityX/Y are a legacy-clamped
+        // mirror for old builds); each tuning key is optional.
+        if (auto* e = cfg.FindEntry("lookSensX"))
+            sensitivityX = (float)*e;
+        if (auto* e = cfg.FindEntry("lookSensY"))
+            sensitivityY = (float)*e;
+
+        if (auto* e = cfg.FindEntry("baseScale"))
+            baseScale = (float)*e;
+        if (auto* e = cfg.FindEntry("dpiNormalize"))
+            dpiNormalize = (bool)*e;
+        if (auto* e = cfg.FindEntry("mouseDpi"))
+            mouseDpi = (int)*e;
+        if (auto* e = cfg.FindEntry("referenceDpi"))
+            referenceDpi = (int)*e;
+        if (auto* e = cfg.FindEntry("smoothing"))
+            smoothing = (float)*e;
+        if (auto* e = cfg.FindEntry("acceleration"))
+            acceleration = (bool)*e;
+        if (auto* e = cfg.FindEntry("accelExponent"))
+            accelExponent = (float)*e;
+        if (auto* e = cfg.FindEntry("menuCursorScale"))
+            menuCursorScale = (float)*e;
+        if (auto* e = cfg.FindEntry("extendedRange"))
+            extendedRange = (bool)*e;
+    }
+    else
+    {
+        // Legacy (v1) file: tuning fields keep their classic defaults; rescale
+        // sensitivity for the current baseScale and stamp the schema to v2.
+        sensitivityX = MigrateSensitivity(sensitivityX, kLegacyBaseScale, baseScale);
+        sensitivityY = MigrateSensitivity(sensitivityY, kLegacyBaseScale, baseScale);
+        if (baseScale != kLegacyBaseScale && (sensitivityX > 2.0f || sensitivityY > 2.0f))
+            extendedRange = true; // keep the migrated value out of the legacy clamp
+        version = kCurrentVersion;
+    }
 
     return true;
 }
@@ -67,10 +137,27 @@ bool MouseConfig::Save(const std::string& path) const
         std::filesystem::create_directories(p.parent_path(), ec);
 
     ParamFile cfg;
+    cfg.Add("version", kCurrentVersion);
+
+    // v1 keys, clamped to the legacy range so a downgraded build reads a sane value.
     cfg.Add("reverseY", reverseY);
     cfg.Add("buttonsReversed", buttonsReversed);
-    cfg.Add("sensitivityX", sensitivityX);
-    cfg.Add("sensitivityY", sensitivityY);
+    cfg.Add("sensitivityX", std::clamp(sensitivityX, 0.5f, 2.0f));
+    cfg.Add("sensitivityY", std::clamp(sensitivityY, 0.5f, 2.0f));
+
+    // Authoritative full-range sensitivity for v2+ readers.
+    cfg.Add("lookSensX", sensitivityX);
+    cfg.Add("lookSensY", sensitivityY);
+
+    cfg.Add("baseScale", baseScale);
+    cfg.Add("dpiNormalize", dpiNormalize);
+    cfg.Add("mouseDpi", mouseDpi);
+    cfg.Add("referenceDpi", referenceDpi);
+    cfg.Add("smoothing", smoothing);
+    cfg.Add("acceleration", acceleration);
+    cfg.Add("accelExponent", accelExponent);
+    cfg.Add("menuCursorScale", menuCursorScale);
+    cfg.Add("extendedRange", extendedRange);
 
     cfg.Save(RString(path.c_str()));
     return std::filesystem::exists(path, ec);

--- a/engine/Poseidon/UI/Settings/MouseConfig.hpp
+++ b/engine/Poseidon/UI/Settings/MouseConfig.hpp
@@ -21,24 +21,51 @@ namespace Poseidon
 class MouseConfig
 {
 public:
+    // Schema version.  A file with no `version` key is treated as v1 and
+    // migrated to v2 on load (see Load).  Bump on every schema change.
+    static constexpr int kCurrentVersion = 2;
+    // baseScale the legacy v1 sensitivities were authored against (MigrateSensitivity).
+    static constexpr float kLegacyBaseScale = 1.5f;
+
+    // --- v1 fields (classic; unchanged on disk for downgrade safety) ---
     bool  reverseY            = false;
     bool  buttonsReversed     = false;
     float sensitivityX        = 1.0f;
     float sensitivityY        = 1.0f;
 
+    // --- v2 fields (HiDPI tuning; all default to classic / no-op feel) ---
+    float baseScale       = 1.5f;  // master look scale
+    bool  dpiNormalize    = false;
+    int   mouseDpi        = 1600;
+    int   referenceDpi    = 1600;  // DPI the feel is calibrated to
+    float smoothing       = 0.0f;
+    bool  acceleration    = false;
+    float accelExponent   = 1.0f;
+    float menuCursorScale = 1.0f;
+    bool  extendedRange   = false;
+
+    // Version actually parsed from the file (kCurrentVersion for a fresh
+    // instance / a v2 file; 1 for a legacy file that was migrated).
+    int   version         = kCurrentVersion;
+
     // Reset every field to factory defaults.
     void LoadDefaults();
 
-    // Clamp sensitivities to [0.5, 2.0].  Returns true if any field
-    // was changed.  No Environment — nothing to query here.
+    // Clamp sensitivities (range depends on extendedRange) and the v2 tuning
+    // fields into their supported ranges.  Returns true if any field changed.
     bool Normalize();
 
     // True on successful parse, false if the file doesn't exist or is
-    // unparseable.
+    // unparseable.  A v1 file is migrated to v2 on load.
     bool Load(const std::string& path);
 
-    // Writes via ParamFile.  Returns false on I/O error.
+    // Writes via ParamFile (both v1 and v2 keys, so an older build can still
+    // read the v1 fields).  Returns false on I/O error.
     bool Save(const std::string& path) const;
+
+    // Rescale a legacy sensitivity to preserve feel under a changed baseScale:
+    // newSens = oldSens * (legacyBaseScale / newBaseScale).  Identity while baseScale stays 1.5.
+    static float MigrateSensitivity(float legacySens, float legacyBaseScale, float newBaseScale);
 };
 
 } // namespace Poseidon

--- a/tests/fixtures/stringtable/STRINGTABLE_MAINMENU.utf8.csv
+++ b/tests/fixtures/stringtable/STRINGTABLE_MAINMENU.utf8.csv
@@ -43,3 +43,5 @@ STR_DISP_OPT_MOUSE_REVERSE_Y_DESC,Invert vertical mouse motion - pushing the mou
 STR_DISP_OPT_MOUSE_SWAP_BUTTONS_DESC,Swap left and right mouse buttons.
 STR_DISP_OPT_MOUSE_SENSITIVITY_X_DESC,Horizontal mouse sensitivity. Range 0.5x to 2.0x.
 STR_DISP_OPT_MOUSE_SENSITIVITY_Y_DESC,Vertical mouse sensitivity. Range 0.5x to 2.0x.
+STR_DISP_OPT_MOUSE_DPI,Mouse DPI
+STR_DISP_OPT_MOUSE_DPI_DESC,Set this to your mouse's DPI (or close). Fine-tune with sensitivity for a smoother feel.

--- a/tests/integration/ui/options/controls/mouse_dpi_selector_persists.test.sqf
+++ b/tests/integration/ui/options/controls/mouse_dpi_selector_persists.test.sqf
@@ -1,0 +1,52 @@
+// Mouse DPI selector: the new preset stepper must appear on the Mouse page,
+// cycle through presets, and keep its value across a Back / reopen.
+//
+// Companion to mouse_sensitivity_back_persists — same Back-persistence shape,
+// but for the Mouse DPI stepper added for HiDPI mice.  The row label has a
+// source-side English fallback ("Mouse DPI"), so this passes against
+// unmodified game data even before the stringtable ships the localized key.
+
+#include "../../../helpers/options_preamble.sqf"
+#include "../../../helpers/controls_preamble.sqf"
+
+triClickText "Mouse"
+triAssertEq [(triDisplay), 9099]
+triAssertIncludes [(triVisibleTexts), "Mouse DPI"]
+
+// Mouse DPI is row 4 / slot 4: label 540, stepper value 541, Next arrow 549.
+if ((triControlText 540) != "Mouse DPI") exitWith {
+    format ["FAIL:dpi_label actual='%1'", triControlText 540]
+};
+
+// Default is "Off" (normalization disabled = classic, backwards compatible).
+if ((triControlText 541) != "Off") exitWith {
+    format ["FAIL:dpi_default_not_off actual='%1'", triControlText 541]
+};
+
+// Cycle Next (Off -> 400 -> 800 -> 1200 -> 1600) until the value reads 1600.
+for "_i" from 0 to 9 do { if ((triControlText 541) == "1600") exitWith {}; triClick 549; triSimFrames 2 };
+private _chosen = triControlText 541;
+if (_chosen != "1600") exitWith {
+    format ["FAIL:could_not_select_1600 actual='%1'", _chosen]
+};
+
+// Leave through the pinned Back/Close footer (slot 8 hover IDC 583), using the
+// real pointer path, then confirm we're back on the Controls page.
+triCursorMoveControl 583
+triSimFrames 6
+if ((triAssert [(triGetControlFocused 583)]) != "OK") exitWith { "FAIL:back_footer_not_focused_before_click" };
+triMouseLeft 1
+triSimFrames 6
+triMouseLeft 0
+triAssertIncludes [(triVisibleTexts), "Keyboard & Mouse"]
+
+// Reopen Mouse — the DPI selection must have survived.
+triClickText "Mouse"
+triAssertIncludes [(triVisibleTexts), "Mouse DPI"]
+
+private _afterBack = triControlText 541;
+if (_afterBack != _chosen) exitWith {
+    format ["FAIL:dpi_changed_after_back before=%1 after=%2", _chosen, _afterBack]
+};
+
+triEndTest

--- a/tests/integration/ui/options/controls/mouse_dpi_selector_persists.test.toml
+++ b/tests/integration/ui/options/controls/mouse_dpi_selector_persists.test.toml
@@ -1,0 +1,1 @@
+tags = ["exclusive", "headful"]

--- a/tests/unit/engine/Poseidon/Input/test_mouse_state.cpp
+++ b/tests/unit/engine/Poseidon/Input/test_mouse_state.cpp
@@ -732,3 +732,193 @@ TEST_CASE("MouseState: FlushAndReset also clears raw deltas", "[input][mouse]")
     REQUIRE(ms.rawDeltaX == 0.0f);
     REQUIRE(ms.rawDeltaY == 0.0f);
 }
+
+// --- MouseTuning: pure helpers ---
+
+TEST_CASE("MouseTuning: defaults reproduce classic feel", "[input][mouse][tuning]")
+{
+    MouseTuning t;
+    REQUIRE(t.baseScale == 1.5f); // == the old hard-coded kSensitivityScale
+    REQUIRE_FALSE(t.dpiNormalize);
+    REQUIRE(t.DpiFactor() == 1.0f);
+    REQUIRE(t.smoothing == 0.0f);
+    REQUIRE_FALSE(t.acceleration);
+    REQUIRE(t.menuCursorScale == 1.0f);
+    REQUIRE_FALSE(t.extendedRange);
+    REQUIRE(t.SensMin() == 0.5f);
+    REQUIRE(t.SensMax() == 2.0f);
+}
+
+TEST_CASE("MouseTuning: DpiFactor normalizes against reference DPI", "[input][mouse][tuning]")
+{
+    MouseTuning t;
+    t.dpiNormalize = true;
+    t.referenceDpi = 800;
+
+    t.mouseDpi = 800;
+    REQUIRE(t.DpiFactor() == Catch::Approx(1.0f));
+    t.mouseDpi = 1600;
+    REQUIRE(t.DpiFactor() == Catch::Approx(0.5f)); // 2x DPI → half speed
+    t.mouseDpi = 12000;
+    REQUIRE(t.DpiFactor() == Catch::Approx(800.0f / 12000.0f));
+
+    // Disabled → always 1.0 regardless of DPI.
+    t.dpiNormalize = false;
+    REQUIRE(t.DpiFactor() == 1.0f);
+}
+
+TEST_CASE("MouseTuning: extendedRange widens the sensitivity band", "[input][mouse][tuning]")
+{
+    MouseTuning t;
+    t.extendedRange = true;
+    REQUIRE(t.SensMin() == 0.05f);
+    REQUIRE(t.SensMax() == 3.0f);
+}
+
+TEST_CASE("MouseTuning: Normalize clamps every field", "[input][mouse][tuning]")
+{
+    MouseTuning t;
+    t.baseScale = 99.0f;
+    t.mouseDpi = 0;
+    t.referenceDpi = 999999;
+    t.smoothing = 5.0f;
+    t.accelExponent = 9.0f;
+    t.menuCursorScale = 99.0f;
+    REQUIRE(t.Normalize());
+    REQUIRE(t.baseScale == 3.0f);
+    REQUIRE(t.mouseDpi == 100);
+    REQUIRE(t.referenceDpi == 32000);
+    REQUIRE(t.smoothing == 0.95f);
+    REQUIRE(t.accelExponent == 2.0f);
+    REQUIRE(t.menuCursorScale == 4.0f);
+
+    // Already-in-range is a no-op.
+    MouseTuning ok;
+    REQUIRE_FALSE(ok.Normalize());
+}
+
+TEST_CASE("MouseTuning: referenceDpi defaults to the validated-comfortable 1600", "[input][mouse][tuning]")
+{
+    MouseTuning t;
+    REQUIRE(t.referenceDpi == 1600);
+    REQUIRE(t.mouseDpi == 1600);
+    // At mouseDpi == referenceDpi the factor is 1.0, so turning normalization on
+    // without changing DPI is identical to Off (Off ≡ 1600).
+    t.dpiNormalize = true;
+    REQUIRE(t.DpiFactor() == Catch::Approx(1.0f));
+}
+
+TEST_CASE("MouseTuning: DPI presets stay within the sensitivity coverage span", "[input][mouse][tuning]")
+{
+    // Sensitivity spans 0.5..2.0 → a 4x range.  For there to be no unreachable
+    // "dead zone" between two adjacent DPI presets, their ratio must be ≤ 4 so
+    // the sensitivity slider can always bridge the gap.
+    REQUIRE(kMouseDpiPresets[0] == 0); // index 0 is "Off"
+    REQUIRE(kMouseDpiPresetCount >= 2);
+    // Labels must line up 1:1 with the preset values (the stepper indexes both).
+    REQUIRE(static_cast<int>(sizeof(kMouseDpiLabels) / sizeof(kMouseDpiLabels[0])) == kMouseDpiPresetCount);
+    for (int i = 2; i < kMouseDpiPresetCount; ++i) // ratios between real DPI presets only
+    {
+        REQUIRE(kMouseDpiPresets[i] > kMouseDpiPresets[i - 1]); // strictly increasing
+        const float ratio = static_cast<float>(kMouseDpiPresets[i]) / static_cast<float>(kMouseDpiPresets[i - 1]);
+        REQUIRE(ratio <= 4.0f);
+    }
+}
+
+// --- MouseState: tuning applied in Update ---
+
+TEST_CASE("MouseState: baseScale replaces the legacy 1.5 constant", "[input][mouse][tuning]")
+{
+    MouseState ms;
+    MouseState::CursorAccum cursor;
+    ms.tuning.baseScale = 3.0f;
+
+    ms.BufferMotion(10.0f, 0.0f);
+    ms.Update(cursor, 0, false, UITime(), nullptr);
+
+    REQUIRE(ms.deltaX == Catch::Approx(10.0f * 1.0f * 3.0f));
+}
+
+TEST_CASE("MouseState: DPI normalization scales the delta", "[input][mouse][tuning]")
+{
+    MouseState ms;
+    MouseState::CursorAccum cursor;
+    ms.tuning.dpiNormalize = true;
+    ms.tuning.mouseDpi = 1600;
+    ms.tuning.referenceDpi = 800;
+
+    ms.BufferMotion(10.0f, 0.0f);
+    ms.Update(cursor, 0, false, UITime(), nullptr);
+
+    // 10 * sens(1) * baseScale(1.5) * dpiFactor(0.5)
+    REQUIRE(ms.deltaX == Catch::Approx(10.0f * 1.5f * 0.5f));
+}
+
+TEST_CASE("MouseState: smoothing low-passes motion across frames", "[input][mouse][tuning]")
+{
+    MouseState ms;
+    MouseState::CursorAccum cursor;
+    ms.tuning.smoothing = 0.5f; // alpha = 0.5
+
+    ms.BufferMotion(10.0f, 0.0f);
+    ms.Update(cursor, 0, false, UITime(), nullptr);
+    const float frame1 = ms.deltaX; // smoothX = 5 → 5 * 1.5 = 7.5
+
+    REQUIRE(frame1 == Catch::Approx(5.0f * 1.5f));
+    REQUIRE(frame1 < 10.0f * 1.5f); // less than the un-smoothed value
+
+    ms.BufferMotion(10.0f, 0.0f);
+    ms.Update(cursor, 0, false, UITime(), nullptr);
+    const float frame2 = ms.deltaX; // smoothX = 7.5 → 11.25
+
+    REQUIRE(frame2 == Catch::Approx(7.5f * 1.5f));
+    REQUIRE(frame2 > frame1); // converging toward the steady input
+}
+
+TEST_CASE("MouseState: acceleration amplifies motion, exponent 1 is a no-op", "[input][mouse][tuning]")
+{
+    MouseState::CursorAccum cursor;
+
+    // Exponent 1 (or disabled) → identical to linear.
+    MouseState linear;
+    linear.tuning.acceleration = true;
+    linear.tuning.accelExponent = 1.0f;
+    linear.BufferMotion(10.0f, 0.0f);
+    linear.Update(cursor, 0, false, UITime(), nullptr);
+    REQUIRE(linear.deltaX == Catch::Approx(10.0f * 1.5f));
+
+    // Exponent > 1 → faster-than-linear for the same input.
+    MouseState accel;
+    accel.tuning.acceleration = true;
+    accel.tuning.accelExponent = 2.0f;
+    MouseState::CursorAccum cursor2;
+    accel.BufferMotion(10.0f, 0.0f);
+    accel.Update(cursor2, 0, false, UITime(), nullptr);
+    REQUIRE(accel.deltaX > 10.0f * 1.5f);
+}
+
+TEST_CASE("MouseState: menuCursorScale decouples cursor from aim", "[input][mouse][tuning]")
+{
+    MouseState ms;
+    MouseState::CursorAccum cursor;
+    ms.tuning.menuCursorScale = 2.0f;
+
+    ms.BufferMotion(10.0f, 0.0f); // small move, below the per-frame clamp
+    ms.Update(cursor, 0, false, UITime(), nullptr);
+
+    // Aim uses the unscaled move; the cursor gets menuCursorScale applied.
+    REQUIRE(cursor.aimDeltaX > 0.0f);
+    REQUIRE(cursor.cursorX == Catch::Approx(2.0f * cursor.aimDeltaX));
+}
+
+TEST_CASE("MouseState: default tuning keeps cursor and aim identical", "[input][mouse][tuning]")
+{
+    MouseState ms;
+    MouseState::CursorAccum cursor;
+
+    ms.BufferMotion(10.0f, 0.0f);
+    ms.Update(cursor, 0, false, UITime(), nullptr);
+
+    // menuCursorScale defaults to 1.0 → classic shared movement.
+    REQUIRE(cursor.cursorX == Catch::Approx(cursor.aimDeltaX));
+}

--- a/tests/unit/engine/Poseidon/UI/Locale/Stringtable/test_stringtable.cpp
+++ b/tests/unit/engine/Poseidon/UI/Locale/Stringtable/test_stringtable.cpp
@@ -167,6 +167,16 @@ TEST_CASE("Stringtable - Load global stringtable", "[stringtable][load][global]"
     }
 }
 
+TEST_CASE("Stringtable - LocalizeStringWithFallback", "[stringtable][localize]")
+{
+    Poseidon::ClearStringtable();
+    GLanguage = "English";
+    Poseidon::LoadStringtable("global", GetTestFixturePath("stringtable_test.csv"), 0, true);
+
+    REQUIRE(std::string(Poseidon::LocalizeStringWithFallback("STR_HELLO", "fb")) == "Hello");
+    REQUIRE(std::string(Poseidon::LocalizeStringWithFallback("STR_DOES_NOT_EXIST", "fb")) == "fb");
+}
+
 TEST_CASE("Stringtable - Localize by name", "[stringtable][localize]")
 {
     Poseidon::ClearStringtable();

--- a/tests/unit/engine/Poseidon/UI/Settings/test_mouseConfig.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_mouseConfig.cpp
@@ -2,15 +2,20 @@
 // Covers: defaults, round-trip, Normalize clamps sensitivities,
 // missing-file handling.
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <Poseidon/UI/Settings/MouseConfig.hpp>
+#include <Poseidon/IO/ParamFile/ParamFile.hpp>
+#include <Poseidon/Foundation/Strings/RString.hpp>
 
 #include <filesystem>
 #include <random>
 #include <string>
 
 using Poseidon::MouseConfig;
+using Poseidon::ParamFile;
+using Poseidon::RString;
 
 namespace
 {
@@ -166,4 +171,153 @@ TEST_CASE("MouseConfig: Save then Load round-trips every field", "[Settings][Mou
     CHECK(dst.sensitivityY == 0.6f);
 
     std::filesystem::remove(path);
+}
+
+// --- v2 tuning fields: defaults, migration, dual-write, round-trip ---
+
+TEST_CASE("MouseConfig: v2 tuning fields default to classic / no-op feel", "[Settings][MouseConfig]")
+{
+    MouseConfig c;
+    CHECK(c.version == MouseConfig::kCurrentVersion);
+    CHECK(c.baseScale == 1.5f); // == the legacy MouseState kSensitivityScale
+    CHECK(c.dpiNormalize == false);
+    CHECK(c.mouseDpi == 1600);
+    CHECK(c.referenceDpi == 1600);
+    CHECK(c.smoothing == 0.0f);
+    CHECK(c.acceleration == false);
+    CHECK(c.accelExponent == 1.0f);
+    CHECK(c.menuCursorScale == 1.0f);
+    CHECK(c.extendedRange == false);
+}
+
+TEST_CASE("MouseConfig: MigrateSensitivity preserves feel across baseScale", "[Settings][MouseConfig]")
+{
+    // Identity while the new baseScale equals the legacy one.
+    CHECK(MouseConfig::MigrateSensitivity(1.0f, 1.5f, 1.5f) == Catch::Approx(1.0f));
+    CHECK(MouseConfig::MigrateSensitivity(1.7f, 1.5f, 1.5f) == Catch::Approx(1.7f));
+    // Halving baseScale must double sensitivity to keep the same effective feel.
+    CHECK(MouseConfig::MigrateSensitivity(1.0f, 1.5f, 0.75f) == Catch::Approx(2.0f));
+    // Guard against a zero/negative divisor.
+    CHECK(MouseConfig::MigrateSensitivity(1.0f, 1.5f, 0.0f) == Catch::Approx(1.0f));
+}
+
+TEST_CASE("MouseConfig: a legacy (v1) file is detected and migrated on load", "[Settings][MouseConfig]")
+{
+    const std::string path = TmpPath("legacy_v1.cfg");
+    std::filesystem::remove(path);
+
+    // Hand-build a pre-tuning file: only the v1 keys, NO version key.
+    {
+        ParamFile cfg;
+        cfg.Add("reverseY", true);
+        cfg.Add("buttonsReversed", false);
+        cfg.Add("sensitivityX", 1.7f);
+        cfg.Add("sensitivityY", 0.8f);
+        cfg.Save(RString(path.c_str()));
+    }
+
+    MouseConfig dst;
+    REQUIRE(dst.Load(path));
+
+    // Migrated to the current schema in memory.
+    CHECK(dst.version == MouseConfig::kCurrentVersion);
+    // v1 values preserved (MigrateSensitivity is identity at the default baseScale).
+    CHECK(dst.reverseY == true);
+    CHECK(dst.sensitivityX == Catch::Approx(1.7f));
+    CHECK(dst.sensitivityY == Catch::Approx(0.8f));
+    // New fields take classic defaults → behavior unchanged.
+    CHECK(dst.baseScale == 1.5f);
+    CHECK(dst.dpiNormalize == false);
+    CHECK(dst.menuCursorScale == 1.0f);
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("MouseConfig: v2 round-trips every tuning field", "[Settings][MouseConfig]")
+{
+    const std::string path = TmpPath("v2_roundtrip.cfg");
+    std::filesystem::remove(path);
+
+    MouseConfig src;
+    src.reverseY = true;
+    src.sensitivityX = 2.7f; // extended-range value
+    src.sensitivityY = 0.1f;
+    src.baseScale = 0.75f;
+    src.dpiNormalize = true;
+    src.mouseDpi = 1600;
+    src.referenceDpi = 800;
+    src.smoothing = 0.3f;
+    src.acceleration = true;
+    src.accelExponent = 1.5f;
+    src.menuCursorScale = 0.5f;
+    src.extendedRange = true;
+    REQUIRE(src.Save(path));
+
+    MouseConfig dst;
+    REQUIRE(dst.Load(path));
+    CHECK(dst.version == MouseConfig::kCurrentVersion);
+    CHECK(dst.reverseY == true);
+    CHECK(dst.sensitivityX == Catch::Approx(2.7f)); // full value survives via lookSensX
+    CHECK(dst.sensitivityY == Catch::Approx(0.1f));
+    CHECK(dst.baseScale == Catch::Approx(0.75f));
+    CHECK(dst.dpiNormalize == true);
+    CHECK(dst.mouseDpi == 1600);
+    CHECK(dst.referenceDpi == 800);
+    CHECK(dst.smoothing == Catch::Approx(0.3f));
+    CHECK(dst.acceleration == true);
+    CHECK(dst.accelExponent == Catch::Approx(1.5f));
+    CHECK(dst.menuCursorScale == Catch::Approx(0.5f));
+    CHECK(dst.extendedRange == true);
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("MouseConfig: Save is downgrade-safe (legacy keys clamped, lookSens authoritative)",
+          "[Settings][MouseConfig]")
+{
+    const std::string path = TmpPath("downgrade.cfg");
+    std::filesystem::remove(path);
+
+    MouseConfig src;
+    src.extendedRange = true;
+    src.sensitivityX = 2.7f; // outside the legacy [0.5,2.0] band
+    REQUIRE(src.Save(path));
+
+    // An old build only knows the v1 sensitivityX key — it must see a clamped,
+    // in-range value, never the raw 2.7.  The new lookSensX carries the truth.
+    ParamFile raw;
+    raw.Parse(RString(path.c_str()));
+    REQUIRE(raw.FindEntry("sensitivityX"));
+    REQUIRE(raw.FindEntry("lookSensX"));
+    REQUIRE(raw.FindEntry("version"));
+    CHECK((float)*raw.FindEntry("sensitivityX") == Catch::Approx(2.0f));
+    CHECK((float)*raw.FindEntry("lookSensX") == Catch::Approx(2.7f));
+    CHECK((int)*raw.FindEntry("version") == MouseConfig::kCurrentVersion);
+
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("MouseConfig: Normalize clamps tuning fields and the extended sensitivity band", "[Settings][MouseConfig]")
+{
+    MouseConfig c;
+    c.baseScale = 99.0f;
+    c.mouseDpi = 0;
+    c.smoothing = 5.0f;
+    c.accelExponent = 9.0f;
+    c.menuCursorScale = 99.0f;
+    REQUIRE(c.Normalize());
+    CHECK(c.baseScale == 3.0f);
+    CHECK(c.mouseDpi == 100);
+    CHECK(c.smoothing == 0.95f);
+    CHECK(c.accelExponent == 2.0f);
+    CHECK(c.menuCursorScale == 4.0f);
+
+    // With extendedRange, sensitivity clamps to the wider [0.05, 3.0] band.
+    MouseConfig e;
+    e.extendedRange = true;
+    e.sensitivityX = 2.7f;  // in range → kept
+    e.sensitivityY = 0.01f; // below 0.05 → clamped
+    REQUIRE(e.Normalize());
+    CHECK(e.sensitivityX == Catch::Approx(2.7f));
+    CHECK(e.sensitivityY == Catch::Approx(0.05f));
 }

--- a/tests/unit/engine/Poseidon/UI/test_mouse_page.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_mouse_page.cpp
@@ -26,6 +26,8 @@ class MouseStateSnapshot
         btn = sub.IsMouseButtonsReversed();
         sx = sub.GetMouseSensitivityX();
         sy = sub.GetMouseSensitivityY();
+        norm = sub.GetMouseTuning().dpiNormalize;
+        dpi = sub.GetMouseTuning().mouseDpi;
     }
     ~MouseStateSnapshot()
     {
@@ -34,6 +36,8 @@ class MouseStateSnapshot
         sub.SetMouseButtonsReversed(btn);
         sub.SetMouseSensitivityX(sx);
         sub.SetMouseSensitivityY(sy);
+        sub.GetMouseTuning().dpiNormalize = norm;
+        sub.GetMouseTuning().mouseDpi = dpi;
     }
 
   private:
@@ -41,6 +45,8 @@ class MouseStateSnapshot
     bool btn = false;
     float sx = 1.0f;
     float sy = 1.0f;
+    bool norm = false;
+    int dpi = 1600;
 };
 
 // MousePage's provider is a private member type — re-create the same
@@ -72,12 +78,12 @@ void LoadMainMenuStringtable()
 }
 } // namespace
 
-TEST_CASE("MousePage: provider exposes 4 rows + close", "[UI][MousePage]")
+TEST_CASE("MousePage: provider exposes 5 rows + close", "[UI][MousePage]")
 {
     TestableMousePage page;
     auto& p = page.Provider();
-    // 4 mouse rows + the auto-appended Close row.
-    CHECK(p.RowCount() == 5);
+    // 5 mouse rows (incl. Mouse DPI) + the auto-appended Close row.
+    CHECK(p.RowCount() == 6);
 }
 
 TEST_CASE("MousePage: row labels match the resource bundle expectations", "[UI][MousePage]")
@@ -91,7 +97,8 @@ TEST_CASE("MousePage: row labels match the resource bundle expectations", "[UI][
     CHECK(std::string(p.RowLabel(1)) == "Mouse buttons swap");
     CHECK(std::string(p.RowLabel(2)) == "Mouse sensitivity X");
     CHECK(std::string(p.RowLabel(3)) == "Mouse sensitivity Y");
-    // Row 4 is the Close action — label comes from the localized
+    CHECK(std::string(p.RowLabel(4)) == "Mouse DPI");
+    // Row 5 is the Close action — label comes from the localized
     // STR_DISP_CLOSE which the unit-test environment doesn't populate;
     // structural check (it exists as an action row) covered separately.
 }
@@ -117,7 +124,8 @@ TEST_CASE("MousePage: kind is Stepper for toggles, Slider for sensitivities, Act
     CHECK(p.RowKind(1) == OptionsScrollList::KindStepper); // Buttons swap toggle
     CHECK(p.RowKind(2) == OptionsScrollList::KindSlider);  // Sensitivity X
     CHECK(p.RowKind(3) == OptionsScrollList::KindSlider);  // Sensitivity Y
-    CHECK(p.RowKind(4) == OptionsScrollList::KindAction);  // Close
+    CHECK(p.RowKind(4) == OptionsScrollList::KindStepper); // Mouse DPI (preset select)
+    CHECK(p.RowKind(5) == OptionsScrollList::KindAction);  // Close
 }
 
 TEST_CASE("MousePage: toggle rows round-trip through the InputSubsystem", "[UI][MousePage]")
@@ -185,6 +193,67 @@ TEST_CASE("MousePage: sensitivity readback inverts cleanly", "[UI][MousePage]")
     // (matches the legacy slider math) we want this test to lock in.
     sub.SetMouseSensitivityY(1.0f);
     CHECK(p.RowValue(3) == 33);
+}
+
+TEST_CASE("MousePage: Mouse DPI helpers map index <-> preset", "[UI][MousePage]")
+{
+    // Off when normalization is disabled, regardless of stored DPI.
+    CHECK(MousePage::DpiToIndex(false, 1600) == 0);
+    CHECK(MousePage::DpiToIndex(false, 400) == 0);
+    // Exact presets map to their index (kMouseDpiPresets: 0,400,800,1200,1600,...).
+    CHECK(MousePage::DpiToIndex(true, 400) == 1);
+    CHECK(MousePage::DpiToIndex(true, 1600) == 4);
+    CHECK(MousePage::DpiToIndex(true, 16000) == 9);
+    // A non-preset value snaps to the NEAREST preset for display (5000 → 6400 = idx 7).
+    CHECK(MousePage::DpiToIndex(true, 5000) == 7);
+
+    CHECK(MousePage::IndexToDpi(0) == 0); // Off sentinel
+    CHECK(MousePage::IndexToDpi(1) == 400);
+    CHECK(MousePage::IndexToDpi(4) == 1600);
+    CHECK(MousePage::IndexToDpi(9) == 16000);
+    CHECK(MousePage::IndexToDpi(99) == 0); // out of range → Off
+}
+
+TEST_CASE("MousePage: Mouse DPI row round-trips through the tuning", "[UI][MousePage]")
+{
+    MouseStateSnapshot snap;
+    TestableMousePage page;
+    auto& p = page.Provider();
+    auto& sub = InputSubsystem::Instance();
+
+    // Row 4 is Mouse DPI.  Index 0 = Off → normalization disabled.
+    p.SetRowValue(4, 0);
+    CHECK(sub.GetMouseTuning().dpiNormalize == false);
+    CHECK(p.RowValue(4) == 0);
+
+    // Index 4 = 1600 → normalization on, mouseDpi 1600.
+    p.SetRowValue(4, 4);
+    CHECK(sub.GetMouseTuning().dpiNormalize == true);
+    CHECK(sub.GetMouseTuning().mouseDpi == 1600);
+    CHECK(p.RowValue(4) == 4);
+
+    // Index 9 = 16000.
+    p.SetRowValue(4, 9);
+    CHECK(sub.GetMouseTuning().mouseDpi == 16000);
+    CHECK(p.RowValue(4) == 9);
+}
+
+TEST_CASE("MousePage: a hand-edited non-preset DPI is preserved on read", "[UI][MousePage]")
+{
+    MouseStateSnapshot snap;
+    TestableMousePage page;
+    auto& p = page.Provider();
+    auto& sub = InputSubsystem::Instance();
+
+    // Simulate a value hand-edited into mouse.cfg that isn't a menu preset.
+    sub.GetMouseTuning().dpiNormalize = true;
+    sub.GetMouseTuning().mouseDpi = 5000;
+
+    // Reading the row for display returns the nearest preset index...
+    CHECK(p.RowValue(4) == 7); // nearest to 5000 is 6400
+    // ...but must NOT mutate the stored custom value.
+    CHECK(sub.GetMouseTuning().mouseDpi == 5000);
+    CHECK(sub.GetMouseTuning().dpiNormalize == true);
 }
 
 TEST_CASE("MousePage: sensitivity helpers clamp the supported 0.5x..2.0x range", "[UI][MousePage]")


### PR DESCRIPTION
It was reported by few players that their hidpi mice are not working properly with the released Demo. Let's add DPI setting to calibre and keep sensitivity to "micro-tweak". Backwards compatible with original setting.

## new DPI setting

<img width="784" height="597" alt="image" src="https://github.com/user-attachments/assets/0b1970fd-4ce3-4351-bb2a-2cdcd1c6930f" />

## debug panel

<img width="689" height="493" alt="image" src="https://github.com/user-attachments/assets/ee70ec38-b06b-4e03-9d4b-493a3be4364d" />