### PR TITLE
CI - rename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: C++
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: C++
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   clang-format:
-    name: C++ formatting
+    name: Lint
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
Renames the C++ build workflow from Build to C++ so check groups line up with Rust.