### PR TITLE
Stretch 4:3 optic overlays in widescreen stretch mode

### DIFF
--- a/engine/Poseidon/Game/TitEffects.cpp
+++ b/engine/Poseidon/Game/TitEffects.cpp
@@ -6,6 +6,7 @@
 #include <Poseidon/World/Scene/Camera/Camera.hpp>
 #include <Poseidon/World/Terrain/Landscape.hpp>
 #include <Poseidon/UI/Controls/UIControls.hpp>
+#include <Poseidon/UI/Settings/AspectRatio.hpp>
 #include <Poseidon/UI/Locale/Stringtable/CodepageTranscode.hpp>
 #include <Poseidon/UI/Locale/Stringtable/Stringtable.hpp>
 #include <Poseidon/Graphics/Textures/TexturePreload.hpp>
@@ -361,8 +362,10 @@ void TitleEffectBasic::DrawRsc()
 {
     if (_rscOverlayShapes.Size() > 0)
     {
+        // 4:3 model overlay — preserve 4:3 + pillarbox while bars are on, else stretch.
+        const bool preserve4x3 = AspectRatio::ArePillarboxBarsEnabled();
         for (int i = 0; i < _rscOverlayShapes.Size(); ++i)
-            Object::Draw2D(_rscOverlayShapes[i], 0, PackedWhite, /*preserveAspect4x3*/ true);
+            Object::Draw2D(_rscOverlayShapes[i], 0, PackedWhite, /*preserveAspect4x3*/ preserve4x3);
         if (_rscOverlayPillarbox)
             Object::DrawWidescreenPillarbox(/*requireGameplayActive*/ false);
         return;

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
@@ -1,6 +1,7 @@
 #include <Poseidon/World/Entities/Infantry/SoldierOldCommon.hpp>
 #include <Poseidon/Core/Application.hpp>
 #include <Poseidon/Input/InputSubsystem.hpp>
+#include <Poseidon/UI/Settings/AspectRatio.hpp>
 #include <Poseidon/Foundation/Algorithms/Qsort.hpp>
 #include <Poseidon/Foundation/Common/FltOpts.hpp>
 #include <Poseidon/Foundation/Containers/Array.hpp>
@@ -464,8 +465,9 @@ void Man::DrawNVOptics()
         {
             int phase = toIntFloor(5.0f * GRandGen.RandomValue());
             muzzle->_animFire.SetPhase(oShape, 0, phase);
-            // 4:3 vignette — pillarbox the widescreen lateral strips
-            Draw2D(oShape, 0, PackedWhite, /*preserveAspect4x3*/ true);
+            // 4:3 vignette — preserve 4:3 + pillarbox while bars are on, else stretch.
+            const bool preserve4x3 = AspectRatio::ArePillarboxBarsEnabled();
+            Draw2D(oShape, 0, PackedWhite, /*preserveAspect4x3*/ preserve4x3);
             Object::DrawWidescreenPillarbox();
         }
     }
@@ -579,9 +581,10 @@ void Man::Draw(int level, ClipFlags clipFlags, const FrameBase& pos)
                         muzzle->_animFire.Hide(oShape, 0);
                     }
                     _mGunFireFrames--;
-                    // binoculars are a 4:3 vignette; scopes keep full viewport width
+                    // binoculars are a 4:3 vignette (scopes keep full width) — stretch when bars off.
                     const bool isBinocular = BinocularSelected();
-                    Draw2D(oShape, 0, GetOpticsColor(this), /*preserveAspect4x3*/ isBinocular);
+                    const bool preserve4x3 = isBinocular && AspectRatio::ArePillarboxBarsEnabled();
+                    Draw2D(oShape, 0, GetOpticsColor(this), /*preserveAspect4x3*/ preserve4x3);
                     if (isBinocular)
                         Object::DrawWidescreenPillarbox();
                 }

--- a/engine/Poseidon/World/Entities/Vehicles/TransportCore.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/TransportCore.cpp
@@ -3,6 +3,7 @@
 #include <Poseidon/AI/AI.hpp>
 #include <Poseidon/World/Entities/Weapons/ProxyWeapon.hpp>
 #include <Poseidon/World/Entities/Infantry/Person.hpp>
+#include <Poseidon/UI/Settings/AspectRatio.hpp>
 #include <Poseidon/Core/Global.hpp>
 #include <Poseidon/World/World.hpp>
 #include <Poseidon/World/Terrain/Landscape.hpp>
@@ -1887,12 +1888,9 @@ void Transport::Draw(int level, ClipFlags clipFlags, const FrameBase& pos)
             LODShapeWithShadow* oShape = GetOpticsModel(person);
             if (oShape)
             {
-                // Vehicle gunner optics (tank turret periscope,
-                // helicopter HUD, etc.) are 4:3-designed with dark
-                // surround art — same as binoculars.  Draw at the
-                // authored 4:3 proportion (no stretch) and pillarbox
-                // the lateral strips on widescreen.
-                Draw2D(oShape, 0, GetOpticsColor(person), /*preserveAspect4x3*/ true);
+                // vehicle gunner optics are a 4:3 vignette — stretch when bars off.
+                const bool preserve4x3 = AspectRatio::ArePillarboxBarsEnabled();
+                Draw2D(oShape, 0, GetOpticsColor(person), /*preserveAspect4x3*/ preserve4x3);
                 Object::DrawWidescreenPillarbox();
             }
         }

--- a/tests/integration/missions/aspect_overlays.Demo/mission.sqm
+++ b/tests/integration/missions/aspect_overlays.Demo/mission.sqm
@@ -1,0 +1,62 @@
+version=11;
+class Mission
+{
+	randomSeed=12345;
+	class Intel
+	{
+		viewDistance=900;
+		month=7;
+		day=5;
+		hour=10;
+		minute=0;
+	};
+	class Groups
+	{
+		items=1;
+		class Item0
+		{
+			side="WEST";
+			class Vehicles
+			{
+				items=3;
+				class Item0
+				{
+					position[]={6710.527832,82.907585,5408.891602};
+					azimut=355.000000;
+					id=0;
+					side="WEST";
+					vehicle="OfficerWNight";
+					player="PLAYER COMMANDER";
+					leader=1;
+					rank="COLONEL";
+					skill=0.600000;
+				};
+				class Item1
+				{
+					position[]={6719.004883,82.311951,5419.918457};
+					id=1;
+					side="WEST";
+					vehicle="SoldierWG";
+					skill=0.600000;
+				};
+				class Item2
+				{
+					position[]={6720.373535,81.936882,5412.308105};
+					id=2;
+					side="WEST";
+					vehicle="SoldierWMedic";
+					skill=0.600000;
+				};
+			};
+		};
+	};
+};
+class Intro
+{
+};
+class OutroWin
+{
+};
+class OutroLoose
+{
+};

--- a/tests/integration/rendering/aspect_overlays_demo.test.sqf
+++ b/tests/integration/rendering/aspect_overlays_demo.test.sqf
@@ -1,0 +1,79 @@
+// Aspect-ratio overlay coverage on the Demo island (card #272 + follow-ups).
+// The player is "Důstojník (noční)" / OfficerWNight, which carries NVGoggles
+// natively (NV works at any time of day).  One run, three 4:3-overlay paths,
+// each in Modern then stretch (Legacy):
+//   1. intro RscTitles resource binocular  (cutRsc "binocular" -> TitleEffectBasic::DrawRsc)
+//   2. player-held binocular               (Man::Draw)
+//   3. night-vision goggles                (Man::DrawNVOptics)
+//
+// In stretch mode the lateral pillarbox bars are disabled, so each overlay must
+// stretch to fill the viewport; the far edges then show the (dark) overlay frame
+// instead of leaking the lit 3D scene.  The stretch far-edge asserts are the
+// card #272 regression guard.  (The held binocular is NOT asserted in Modern: its
+// pillarbox is gated on IsGameplayActive(), which is off for a harness-loaded
+// mission, so the Modern edges legitimately show the scene.)
+
+triSetLanguage "English"
+triSimFrames 60
+
+// ---------- 1) intro resource binocular (cutRsc) ----------
+player switchCamera "EXTERNAL"
+triSimFrames 40
+triSetDisplayStyle 0
+triSetPillarboxBarsEnabled true
+cutRsc ["binocular", "plain", 0]
+triSimFrames 60
+triScreenshot "00_resource_modern"
+triAssertGt [(triGetPixelMaxChannel [0.5, 0.55]), 10]
+
+triSetDisplayStyle 1
+triSetPillarboxBarsEnabled false
+triSimFrames 30
+cutRsc ["binocular", "plain", 0]
+triSimFrames 60
+triScreenshot "01_resource_stretch"
+triAssertNear [(triSamplePixel [0.02, 0.5]), "0,0,0", 16]
+triAssertNear [(triSamplePixel [0.97, 0.5]), "0,0,0", 16]
+triAssertGt [(triGetPixelMaxChannel [0.5, 0.55]), 10]
+
+cutRsc ["default", "plain", 0]
+triSetDisplayStyle 0
+triSetPillarboxBarsEnabled true
+triSimFrames 30
+
+// ---------- 2) player-held binocular ----------
+player switchCamera "GUNNER"
+player addWeapon "Binocular"
+player selectWeapon "Binocular"
+triSimFrames 90
+triScreenshot "02_player_binoc_modern"
+triAssertGt [(triGetPixelMaxChannel [0.5, 0.55]), 10]
+
+triSetDisplayStyle 1
+triSetPillarboxBarsEnabled false
+triSimFrames 60
+triScreenshot "03_player_binoc_stretch"
+triAssertNear [(triSamplePixel [0.02, 0.5]), "0,0,0", 16]
+triAssertNear [(triSamplePixel [0.97, 0.5]), "0,0,0", 16]
+
+triSetDisplayStyle 0
+triSetPillarboxBarsEnabled true
+triSimFrames 20
+
+// ---------- 3) NVG (night officer's goggles) ----------
+// The player (OfficerWNight) already carries NVGoggles; just toggle night-vision
+// with the N key (UANightVision).  The held binocular's optic only draws in
+// GUNNER cam, so switching to INTERNAL hides it without removing the weapon.
+player switchCamera "INTERNAL"
+triSimFrames 20
+triSendKey 17
+triSimFrames 60
+triScreenshot "04_nvg_modern"
+triAssertGt [(triGetPixelMaxChannel [0.5, 0.5]), 15]
+
+triSetDisplayStyle 1
+triSetPillarboxBarsEnabled false
+triSimFrames 60
+triScreenshot "05_nvg_stretch"
+triAssertGt [(triGetPixelMaxChannel [0.5, 0.5]), 15]
+triEndTest

--- a/tests/integration/rendering/aspect_overlays_demo.test.toml
+++ b/tests/integration/rendering/aspect_overlays_demo.test.toml
@@ -1,0 +1,6 @@
+tags = ["exclusive", "headful", "aspect-ratio", "optics"]
+binary = "PoseidonGame"
+data_dir = "packages/Demo"
+mission = "tests/integration/missions/aspect_overlays.Demo"
+timeout = 180
+extra_args = ["--dev", "--width", "3840", "--height", "1080"]


### PR DESCRIPTION
As was reported, stretch fails sometimes. No idea why people do use this ugly option, but let's fix it.

Binocular (resource + held), NV goggles and vehicle gunner optics now stretch to fill the viewport when the pillarbox bars are off, instead of sitting 4:3-centered with the 3D scene leaking at the edges; adds a Demo-island aspect test covering all three.

<img width="2879" height="981" alt="image" src="https://github.com/user-attachments/assets/42aa47ce-5efa-4bd5-a724-5a0a3ac3e583" />