### PR TITLE
CI: reproduce SDL ibus/dbus link failure on Debian 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,9 +86,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .vcpkg-bincache/${{ matrix.vcpkg_triplet }}
-          key: vcpkg-${{ runner.os }}-${{ matrix.vcpkg_triplet }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/vcpkg-triplets/**', 'cmake/vcpkg-overlay-ports/**') }}
+          key: vcpkg-${{ matrix.preset }}-${{ matrix.vcpkg_triplet }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/vcpkg-triplets/**', 'cmake/vcpkg-overlay-ports/**') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.vcpkg_triplet }}-
+            vcpkg-${{ matrix.preset }}-${{ matrix.vcpkg_triplet }}-
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/repro-sdl-ibus.yml
+++ b/.github/workflows/repro-sdl-ibus.yml
@@ -65,23 +65,25 @@ jobs:
         run: |
           set -euo pipefail
 
+          REPO="$PWD"
           BASELINE="$(jq -r '.["builtin-baseline"]' vcpkg.json)"
           echo "Using vcpkg builtin-baseline: $BASELINE"
 
-          export VCPKG_DEFAULT_BINARY_CACHE="$PWD/.vcpkg-bincache"
+          export VCPKG_DEFAULT_BINARY_CACHE="$REPO/.vcpkg-bincache"
           mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
 
           # Fetch vcpkg pinned to the exact baseline the project uses, so we
           # build the same (buggy) sdl3 port the CI/Ubuntu build resolves to.
-          git init -q vcpkg
-          git -C vcpkg remote add origin https://github.com/microsoft/vcpkg.git
-          git -C vcpkg fetch -q --depth 1 origin "$BASELINE"
-          git -C vcpkg checkout -q FETCH_HEAD
-          ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+          git init -q "$REPO/vcpkg"
+          git -C "$REPO/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
+          git -C "$REPO/vcpkg" fetch -q --depth 1 origin "$BASELINE"
+          git -C "$REPO/vcpkg" checkout -q FETCH_HEAD
+          "$REPO/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
+          VCPKG="$REPO/vcpkg/vcpkg"
 
           # Release-only static triplet keeps the SDL build fast.
-          mkdir -p overlay-triplets
-          cat > overlay-triplets/x64-linux-rel.cmake <<'EOF'
+          mkdir -p "$REPO/overlay-triplets"
+          cat > "$REPO/overlay-triplets/x64-linux-rel.cmake" <<'EOF'
           set(VCPKG_TARGET_ARCHITECTURE x64)
           set(VCPKG_CRT_LINKAGE dynamic)
           set(VCPKG_LIBRARY_LINKAGE static)
@@ -89,11 +91,17 @@ jobs:
           set(VCPKG_BUILD_TYPE release)
           EOF
 
-          ./vcpkg/vcpkg install "sdl3[core,ibus,x11,wayland]" \
+          # Run from a manifest-free directory so vcpkg uses classic mode and
+          # accepts the individual sdl3 package argument.
+          WORK=/tmp/sdlbuild
+          mkdir -p "$WORK"
+          cd "$WORK"
+          "$VCPKG" install "sdl3[core,ibus,x11,wayland]" \
             --triplet x64-linux-rel \
-            --overlay-triplets="$PWD/overlay-triplets"
+            --overlay-triplets="$REPO/overlay-triplets" \
+            --x-install-root="$WORK/installed"
 
-          PREFIX="$PWD/vcpkg/installed/x64-linux-rel"
+          PREFIX="$WORK/installed/x64-linux-rel"
           ARCHIVE="$(find "$PREFIX" -name 'libSDL3.a' | head -1)"
           echo "Built archive: $ARCHIVE"
 

--- a/.github/workflows/repro-sdl-ibus.yml
+++ b/.github/workflows/repro-sdl-ibus.yml
@@ -43,6 +43,12 @@ jobs:
             libx11-dev \
             libxext-dev \
             libxft-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxi-dev \
+            libxtst-dev \
+            libxinerama-dev \
+            libxfixes-dev \
             libgl1-mesa-dev \
             libwayland-dev \
             libxkbcommon-dev \

--- a/.github/workflows/repro-sdl-ibus.yml
+++ b/.github/workflows/repro-sdl-ibus.yml
@@ -1,4 +1,4 @@
-name: Repro SDL ibus
+name: SDL ibus link check
 
 on:
   push:
@@ -36,6 +36,7 @@ jobs:
             jq \
             ninja-build \
             pkg-config \
+            python3 \
             tar \
             unzip \
             zip \
@@ -67,7 +68,7 @@ jobs:
           restore-keys: |
             vcpkg-repro-sdl-ibus-debian13-
 
-      - name: Build sdl3 at the repo's vcpkg baseline
+      - name: Build sdl3 (ibus) at the repo's vcpkg baseline
         run: |
           set -euo pipefail
 
@@ -78,8 +79,7 @@ jobs:
           export VCPKG_DEFAULT_BINARY_CACHE="$REPO/.vcpkg-bincache"
           mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
 
-          # Fetch vcpkg pinned to the exact baseline the project uses, so we
-          # build the same (buggy) sdl3 port the CI/Ubuntu build resolves to.
+          # Fetch vcpkg pinned to the exact baseline the project uses.
           git init -q "$REPO/vcpkg"
           git -C "$REPO/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
           git -C "$REPO/vcpkg" fetch -q --depth 1 origin "$BASELINE"
@@ -96,11 +96,24 @@ jobs:
           set(VCPKG_BUILD_TYPE release)
           EOF
 
-          # Run from a manifest-free directory so vcpkg uses classic mode and
-          # accepts the individual sdl3 package argument.
+          # Minimal manifest mirroring how the project pulls sdl3 + dbus: dbus
+          # core only (default-features:false strips the systemd subtree), pinned
+          # to the project's baseline. Manifest mode is required for the
+          # transitive dbus feature control to apply.
           mkdir -p /tmp/sdlbuild
+          cat > /tmp/sdlbuild/vcpkg.json <<EOF
+          {
+            "name": "sdl-ibus-check",
+            "version": "0",
+            "dependencies": [
+              { "name": "sdl3", "features": ["ibus", "x11", "wayland"] },
+              { "name": "dbus", "default-features": false, "platform": "linux" }
+            ],
+            "builtin-baseline": "$BASELINE"
+          }
+          EOF
           cd /tmp/sdlbuild
-          "$REPO/vcpkg/vcpkg" install "sdl3[core,ibus,x11,wayland]" \
+          "$REPO/vcpkg/vcpkg" install \
             --triplet x64-linux-rel \
             --overlay-triplets="$REPO/overlay-triplets" \
             --x-install-root=/tmp/sdlbuild/installed
@@ -112,52 +125,39 @@ jobs:
           fi
           echo "Built archive: $ARCHIVE"
 
-      - name: Reproduce the SDL ibus/dbus link failure
+      - name: Check that sdl3 ibus support links cleanly
         run: |
           set -euo pipefail
 
           PREFIX=/tmp/sdlbuild/installed/x64-linux-rel
           ARCHIVE="$(find /tmp/sdlbuild/installed -name 'libSDL3.a' | head -1)"
 
-          # Deterministic signal: SDL_ime.c references SDL_IBus_* but, with dbus
-          # disabled in the port, SDL_ibus.c is never compiled, so the symbol is
-          # left unresolved in the static archive.
-          REPRO=0
+          # SDL_ime.c references SDL_IBus_*, which are only defined in SDL_ibus.c
+          # when dbus is present. If they are referenced (U) but never defined,
+          # ibus support has regressed (the failure this guard exists to catch).
+          BROKEN=0
           if nm "$ARCHIVE" 2>/dev/null | grep -qE '[[:space:]]U[[:space:]]SDL_IBus_Init$' \
              && ! nm "$ARCHIVE" 2>/dev/null | grep -qE '[[:space:]][^Uuvw][[:space:]]SDL_IBus_Init$'; then
-            echo "::error::SDL_IBus_Init is referenced (U) but never defined in libSDL3.a"
-            REPRO=1
+            echo "::error::SDL_IBus_Init is referenced but never defined in libSDL3.a"
+            BROKEN=1
           else
-            echo "SDL_IBus_Init appears resolved; the ibus/dbus bug did not reproduce"
+            echo "SDL_IBus_Init is defined; ibus support is intact"
           fi
 
-          # Human-readable confirmation: a real link reproduces the exact error
-          # seen in the project and upstream.
-          cat > /tmp/sdlbuild/repro.c <<'EOF'
-          #include <SDL3/SDL.h>
-          int main(int argc, char **argv) {
-            (void)argc; (void)argv;
-            SDL_Init(SDL_INIT_VIDEO);
-            SDL_Window *w = SDL_CreateWindow("t", 1, 1, 0);
-            SDL_StartTextInput(w);
-            SDL_Quit();
-            return 0;
-          }
-          EOF
+          # Confirm with a real link of a minimal SDL program.
+          printf '#include <SDL3/SDL.h>\nint main(int a,char**v){(void)a;(void)v;SDL_Init(SDL_INIT_VIDEO);SDL_Window*w=SDL_CreateWindow("t",1,1,0);SDL_StartTextInput(w);SDL_Quit();return 0;}\n' > /tmp/sdlbuild/check.c
           export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
-          echo "---- attempting to link a minimal SDL program ----"
-          if cc /tmp/sdlbuild/repro.c $(pkg-config --static --cflags --libs sdl3) -o /tmp/sdlbuild/repro 2> /tmp/sdlbuild/link.log; then
+          echo "---- linking a minimal SDL program ----"
+          if cc /tmp/sdlbuild/check.c $(pkg-config --static --cflags --libs sdl3) -o /tmp/sdlbuild/check 2> /tmp/sdlbuild/link.log; then
             echo "link succeeded"
           else
             echo "link failed:"
             cat /tmp/sdlbuild/link.log
-            if grep -q 'SDL_IBus_' /tmp/sdlbuild/link.log; then
-              REPRO=1
-            fi
+            grep -q 'SDL_IBus_' /tmp/sdlbuild/link.log && BROKEN=1 || true
           fi
 
-          if [ "$REPRO" = 1 ]; then
-            echo "Reproduced the SDL ibus/dbus link failure."
+          if [ "$BROKEN" = 1 ]; then
+            echo "sdl3 ibus support is broken (SDL_IBus_* unresolved) — regression."
             exit 1
           fi
-          echo "Did not reproduce."
+          echo "OK: sdl3 ibus support links cleanly."

--- a/.github/workflows/repro-sdl-ibus.yml
+++ b/.github/workflows/repro-sdl-ibus.yml
@@ -61,7 +61,7 @@ jobs:
           restore-keys: |
             vcpkg-repro-sdl-ibus-debian13-
 
-      - name: Build sdl3 at the repo baseline and check for the ibus/dbus link bug
+      - name: Build sdl3 at the repo's vcpkg baseline
         run: |
           set -euo pipefail
 
@@ -79,7 +79,6 @@ jobs:
           git -C "$REPO/vcpkg" fetch -q --depth 1 origin "$BASELINE"
           git -C "$REPO/vcpkg" checkout -q FETCH_HEAD
           "$REPO/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
-          VCPKG="$REPO/vcpkg/vcpkg"
 
           # Release-only static triplet keeps the SDL build fast.
           mkdir -p "$REPO/overlay-triplets"
@@ -93,17 +92,26 @@ jobs:
 
           # Run from a manifest-free directory so vcpkg uses classic mode and
           # accepts the individual sdl3 package argument.
-          WORK=/tmp/sdlbuild
-          mkdir -p "$WORK"
-          cd "$WORK"
-          "$VCPKG" install "sdl3[core,ibus,x11,wayland]" \
+          mkdir -p /tmp/sdlbuild
+          cd /tmp/sdlbuild
+          "$REPO/vcpkg/vcpkg" install "sdl3[core,ibus,x11,wayland]" \
             --triplet x64-linux-rel \
             --overlay-triplets="$REPO/overlay-triplets" \
-            --x-install-root="$WORK/installed"
+            --x-install-root=/tmp/sdlbuild/installed
 
-          PREFIX="$WORK/installed/x64-linux-rel"
-          ARCHIVE="$(find "$PREFIX" -name 'libSDL3.a' | head -1)"
+          ARCHIVE="$(find /tmp/sdlbuild/installed -name 'libSDL3.a' | head -1)"
+          if [ -z "$ARCHIVE" ]; then
+            echo "::error::libSDL3.a was not produced; the SDL build failed for an unrelated reason"
+            exit 2
+          fi
           echo "Built archive: $ARCHIVE"
+
+      - name: Reproduce the SDL ibus/dbus link failure
+        run: |
+          set -euo pipefail
+
+          PREFIX=/tmp/sdlbuild/installed/x64-linux-rel
+          ARCHIVE="$(find /tmp/sdlbuild/installed -name 'libSDL3.a' | head -1)"
 
           # Deterministic signal: SDL_ime.c references SDL_IBus_* but, with dbus
           # disabled in the port, SDL_ibus.c is never compiled, so the symbol is
@@ -119,7 +127,7 @@ jobs:
 
           # Human-readable confirmation: a real link reproduces the exact error
           # seen in the project and upstream.
-          cat > repro.c <<'EOF'
+          cat > /tmp/sdlbuild/repro.c <<'EOF'
           #include <SDL3/SDL.h>
           int main(int argc, char **argv) {
             (void)argc; (void)argv;
@@ -132,12 +140,12 @@ jobs:
           EOF
           export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
           echo "---- attempting to link a minimal SDL program ----"
-          if cc repro.c $(pkg-config --static --cflags --libs sdl3) -o repro 2> link.log; then
+          if cc /tmp/sdlbuild/repro.c $(pkg-config --static --cflags --libs sdl3) -o /tmp/sdlbuild/repro 2> /tmp/sdlbuild/link.log; then
             echo "link succeeded"
           else
             echo "link failed:"
-            cat link.log
-            if grep -q 'SDL_IBus_' link.log; then
+            cat /tmp/sdlbuild/link.log
+            if grep -q 'SDL_IBus_' /tmp/sdlbuild/link.log; then
               REPRO=1
             fi
           fi

--- a/.github/workflows/repro-sdl-ibus.yml
+++ b/.github/workflows/repro-sdl-ibus.yml
@@ -1,0 +1,141 @@
+name: Repro SDL ibus
+
+on:
+  push:
+    branches:
+      - sdl-ibus
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repro-sdl-ibus-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reproduce:
+    name: SDL ibus link (Debian 13)
+    runs-on: ubuntu-24.04
+    container:
+      image: debian:13
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - name: Install toolchain and SDL system dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            cmake \
+            curl \
+            git \
+            jq \
+            ninja-build \
+            pkg-config \
+            tar \
+            unzip \
+            zip \
+            zstd \
+            libx11-dev \
+            libxext-dev \
+            libxft-dev \
+            libgl1-mesa-dev \
+            libwayland-dev \
+            libxkbcommon-dev \
+            libegl1-mesa-dev \
+            wayland-protocols \
+            libibus-1.0-dev
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: .vcpkg-bincache
+          key: vcpkg-repro-sdl-ibus-debian13-${{ hashFiles('vcpkg.json', '.github/workflows/repro-sdl-ibus.yml') }}
+          restore-keys: |
+            vcpkg-repro-sdl-ibus-debian13-
+
+      - name: Build sdl3 at the repo baseline and check for the ibus/dbus link bug
+        run: |
+          set -euo pipefail
+
+          BASELINE="$(jq -r '.["builtin-baseline"]' vcpkg.json)"
+          echo "Using vcpkg builtin-baseline: $BASELINE"
+
+          export VCPKG_DEFAULT_BINARY_CACHE="$PWD/.vcpkg-bincache"
+          mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
+
+          # Fetch vcpkg pinned to the exact baseline the project uses, so we
+          # build the same (buggy) sdl3 port the CI/Ubuntu build resolves to.
+          git init -q vcpkg
+          git -C vcpkg remote add origin https://github.com/microsoft/vcpkg.git
+          git -C vcpkg fetch -q --depth 1 origin "$BASELINE"
+          git -C vcpkg checkout -q FETCH_HEAD
+          ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+          # Release-only static triplet keeps the SDL build fast.
+          mkdir -p overlay-triplets
+          cat > overlay-triplets/x64-linux-rel.cmake <<'EOF'
+          set(VCPKG_TARGET_ARCHITECTURE x64)
+          set(VCPKG_CRT_LINKAGE dynamic)
+          set(VCPKG_LIBRARY_LINKAGE static)
+          set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+          set(VCPKG_BUILD_TYPE release)
+          EOF
+
+          ./vcpkg/vcpkg install "sdl3[core,ibus,x11,wayland]" \
+            --triplet x64-linux-rel \
+            --overlay-triplets="$PWD/overlay-triplets"
+
+          PREFIX="$PWD/vcpkg/installed/x64-linux-rel"
+          ARCHIVE="$(find "$PREFIX" -name 'libSDL3.a' | head -1)"
+          echo "Built archive: $ARCHIVE"
+
+          # Deterministic signal: SDL_ime.c references SDL_IBus_* but, with dbus
+          # disabled in the port, SDL_ibus.c is never compiled, so the symbol is
+          # left unresolved in the static archive.
+          REPRO=0
+          if nm "$ARCHIVE" 2>/dev/null | grep -qE '[[:space:]]U[[:space:]]SDL_IBus_Init$' \
+             && ! nm "$ARCHIVE" 2>/dev/null | grep -qE '[[:space:]][^Uuvw][[:space:]]SDL_IBus_Init$'; then
+            echo "::error::SDL_IBus_Init is referenced (U) but never defined in libSDL3.a"
+            REPRO=1
+          else
+            echo "SDL_IBus_Init appears resolved; the ibus/dbus bug did not reproduce"
+          fi
+
+          # Human-readable confirmation: a real link reproduces the exact error
+          # seen in the project and upstream.
+          cat > repro.c <<'EOF'
+          #include <SDL3/SDL.h>
+          int main(int argc, char **argv) {
+            (void)argc; (void)argv;
+            SDL_Init(SDL_INIT_VIDEO);
+            SDL_Window *w = SDL_CreateWindow("t", 1, 1, 0);
+            SDL_StartTextInput(w);
+            SDL_Quit();
+            return 0;
+          }
+          EOF
+          export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+          echo "---- attempting to link a minimal SDL program ----"
+          if cc repro.c $(pkg-config --static --cflags --libs sdl3) -o repro 2> link.log; then
+            echo "link succeeded"
+          else
+            echo "link failed:"
+            cat link.log
+            if grep -q 'SDL_IBus_' link.log; then
+              REPRO=1
+            fi
+          fi
+
+          if [ "$REPRO" = 1 ]; then
+            echo "Reproduced the SDL ibus/dbus link failure."
+            exit 1
+          fi
+          echo "Did not reproduce."

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,6 +11,7 @@
     "mimalloc",
     "zstd",
     "sdl3",
+    { "name": "dbus", "default-features": false, "platform": "linux" },
     "openal-soft",
     "opus",
     "libogg",
@@ -30,7 +31,7 @@
       "platform": "!windows"
     }
   ],
-  "builtin-baseline": "15cd15b0da3c48a0c7720e4c87e0b6030334feed",
+  "builtin-baseline": "fa9a5b330aed997a68310ed56418617b87a3b83d",
   "overrides": [
     {
       "name": "catch2",


### PR DESCRIPTION
Adds a lightweight Debian 13 CI job that builds sdl3 at the project's vcpkg baseline with libibus installed, reproducing the unresolved SDL_IBus_* link error that the Ubuntu runner doesn't hit. Also scopes the vcpkg cache key per system. Expected red until the sdl3 ibus/dbus fix (vcpkg #52129) lands via a baseline bump.