### PR TITLE
Specify minimum SDL3 version

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,7 +10,7 @@
     "stb",
     "mimalloc",
     "zstd",
-    "sdl3",
+    { "name": "sdl3", "version>=": "3.4.10#1" },
     "openal-soft",
     "opus",
     "libogg",


### PR DESCRIPTION
This works around an SDL linking issue that seems to be caused by vcpkg pulling an older SDL version in some cases (on Linux).

This is an alternate solution to what #18 was attempting to solve.