### PR TITLE
Add list of build requirements to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ In short: the code is free software, the name is not, and the game data comes se
 
 ## Quick Start
 
+### Build Requirements
+
+- [Clang](https://clang.llvm.org/)
+- [CMake](https://cmake.org/)
+- [Ninja](https://ninja-build.org/)
+- [vcpkg](https://vcpkg.io/)
+
+### Compiling
+
 ```sh
 cmake --preset win-x64-clang-rwdi
 cmake --build build/win-x64-clang-rwdi

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ In short: the code is free software, the name is not, and the game data comes se
 - [Ninja](https://ninja-build.org/)
 - [vcpkg](https://vcpkg.io/)
 
+On Windows, run `winget install Kitware.CMake LLVM.LLVM Ninja-build.Ninja`
+and follow the instructions for [setting up
+vcpkg](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-powershell)
+to get the required software.
+
 ### Compiling
 
 ```sh


### PR DESCRIPTION
I've seen a lot of confusion on how to build the project. Having a simple list of the basic build requirements is a lightweight way to guide people in the right direction, regardless of their experience with compiling software.

More detailed information and/or step-by-step guides might belong in a separate document.