### PR TITLE
Add independent gamepad Y-axis look inversion

### DIFF
--- a/engine/Poseidon/Input/GamepadState.hpp
+++ b/engine/Poseidon/Input/GamepadState.hpp
@@ -20,6 +20,7 @@ struct GamepadState
 
     // Configuration (persisted to UserInfo.cfg)
     bool enabled = true;
+    bool reverseYStick = false;
     float deadzoneStick = 0.21f;
     float deadzoneTrigger = 0.10f;
     float lookSensitivity = 1.0f;

--- a/engine/Poseidon/Input/InputProcessingSdl.cpp
+++ b/engine/Poseidon/Input/InputProcessingSdl.cpp
@@ -504,7 +504,7 @@ void ProcessJoystick_SDL()
         if (GInput.gameFocusLost <= 0)
         {
             GInput.cursor.aimDeltaX += moveX;
-            GInput.cursor.aimDeltaY += GInput.mouse.reverseY ? -moveY : moveY;
+            GInput.cursor.aimDeltaY += GInput.gamepad.reverseYStick ? -moveY : moveY;
         }
         GInput.cursor.cursorX += moveX;
         GInput.cursor.cursorY += moveY;

--- a/engine/Poseidon/Input/InputSubsystem.cpp
+++ b/engine/Poseidon/Input/InputSubsystem.cpp
@@ -1071,6 +1071,7 @@ void InputSubsystem::LoadKeys()
     GInput.mouse.tuning.extendedRange = mouse.extendedRange;
 
     GInput.gamepad.enabled = gamepad.enabled;
+    GInput.gamepad.reverseYStick = gamepad.reverseYStick;
     GInput.gamepad.deadzoneStick = gamepad.deadzoneStick;
     GInput.gamepad.deadzoneTrigger = gamepad.deadzoneTrigger;
     GInput.gamepad.lookSensitivity = gamepad.lookSensitivity;
@@ -1083,6 +1084,7 @@ void InputSubsystem::SaveKeys()
 
     GamepadConfig gamepad;
     gamepad.enabled = GInput.gamepad.enabled;
+    gamepad.reverseYStick = GInput.gamepad.reverseYStick;
     gamepad.deadzoneStick = GInput.gamepad.deadzoneStick;
     gamepad.deadzoneTrigger = GInput.gamepad.deadzoneTrigger;
     gamepad.lookSensitivity = GInput.gamepad.lookSensitivity;
@@ -1263,6 +1265,18 @@ void InputSubsystem::SetJoystickEnabled(bool v)
 void InputSubsystem::ToggleJoystickEnabled()
 {
     GInput.gamepad.enabled = !GInput.gamepad.enabled;
+}
+bool InputSubsystem::IsReverseJoystick() const
+{
+    return GInput.gamepad.reverseYStick;
+}
+void InputSubsystem::SetReverseJoystick(bool v)
+{
+    GInput.gamepad.reverseYStick = v;
+}
+void InputSubsystem::ToggleReverseJoystick()
+{
+    GInput.gamepad.reverseYStick = !GInput.gamepad.reverseYStick;
 }
 bool InputSubsystem::IsMouseButtonsReversed() const
 {

--- a/engine/Poseidon/Input/InputSubsystem.hpp
+++ b/engine/Poseidon/Input/InputSubsystem.hpp
@@ -170,6 +170,9 @@ class InputSubsystem
     void ToggleReverseMouse();
     void SetJoystickEnabled(bool v);
     void ToggleJoystickEnabled();
+    bool IsReverseJoystick() const;
+    void SetReverseJoystick(bool v);
+    void ToggleReverseJoystick();
     bool IsMouseButtonsReversed() const;
     void SetMouseButtonsReversed(bool v);
     void ToggleMouseButtonsReversed();

--- a/engine/Poseidon/UI/Options/GamepadTuningPage.cpp
+++ b/engine/Poseidon/UI/Options/GamepadTuningPage.cpp
@@ -47,6 +47,8 @@ const char* GamepadTuningPage::GamepadProvider::RowLabel(int row) const
     {
         case kRowEnabled:
             return LocalizeString("STR_DISP_OPT_CTL_GAMEPAD_ENABLED");
+        case kRowReverseYStick:
+            return LocalizeStringWithFallback("STR_DISP_OPT_CTL_GAMEPAD_REVERSE_Y", "Y-axis inversion");
         case kRowDeadzoneStick:
             return LocalizeString("STR_DISP_OPT_CTL_GAMEPAD_STICK_DEADZONE");
         case kRowDeadzoneTrigger:
@@ -64,6 +66,9 @@ const char* GamepadTuningPage::GamepadProvider::RowDescription(int row) const
     {
         case kRowEnabled:
             return LocalizeString("STR_DISP_OPT_CTL_GAMEPAD_ENABLED_DESC");
+        case kRowReverseYStick:
+            return LocalizeStringWithFallback("STR_DISP_OPT_CTL_GAMEPAD_REVERSE_Y_DESC",
+                                              "Invert vertical stick motion - pushing the stick forward looks down.");
         case kRowDeadzoneStick:
             return LocalizeString("STR_DISP_OPT_CTL_GAMEPAD_STICK_DEADZONE_DESC");
         case kRowDeadzoneTrigger:
@@ -82,6 +87,8 @@ OptionsScrollList::RowDef GamepadTuningPage::GamepadProvider::RowFor(int row) co
     {
         case kRowEnabled:
             return {602, m_toggleOptions.data(), 2};
+        case kRowReverseYStick:
+            return {642, m_toggleOptions.data(), 2};
         case kRowDeadzoneStick:
             return {612, nullptr, -1};
         case kRowDeadzoneTrigger:
@@ -134,6 +141,8 @@ int GamepadTuningPage::GamepadProvider::RowValue(int row) const
     {
         case kRowEnabled:
             return GInput.gamepad.enabled ? 1 : 0;
+        case kRowReverseYStick:
+            return GInput.gamepad.reverseYStick ? 1 : 0;
         case kRowDeadzoneStick:
             return GamepadTuningPage::DeadzoneToPercent(GInput.gamepad.deadzoneStick);
         case kRowDeadzoneTrigger:
@@ -153,6 +162,11 @@ void GamepadTuningPage::GamepadProvider::SetRowValue(int row, int value)
             if (value < 0 || value >= 2)
                 return;
             GInput.gamepad.enabled = (value != 0);
+            return;
+        case kRowReverseYStick:
+            if (value < 0 || value >= 2)
+                return;
+            GInput.gamepad.reverseYStick = (value != 0);
             return;
         case kRowDeadzoneStick:
             GInput.gamepad.deadzoneStick = GamepadTuningPage::PercentToDeadzone(value);

--- a/engine/Poseidon/UI/Options/GamepadTuningPage.hpp
+++ b/engine/Poseidon/UI/Options/GamepadTuningPage.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-// Gamepad scalar settings page — Enable, Stick Deadzone, Trigger
-// Deadzone, Look Sensitivity.  Sibling to MousePage; same lifecycle
-// (apply live, persist on Unmount via SaveKeys → gamepad.cfg).
+// Gamepad scalar settings page — Enable, Y-Axis Inversion, Stick
+// Deadzone, Trigger Deadzone, Look Sensitivity.  Sibling to
+// MousePage; same lifecycle (apply live, persist on Unmount via
+// SaveKeys → gamepad.cfg).
 
 #include <Poseidon/UI/Options/ScrollListPage.hpp>
 
@@ -38,10 +39,11 @@ class GamepadTuningPage : public ScrollListPage
         enum : int
         {
             kRowEnabled         = 0,
-            kRowDeadzoneStick   = 1,
-            kRowDeadzoneTrigger = 2,
-            kRowLookSensitivity = 3,
-            kRowCount           = 4,
+            kRowReverseYStick   = 1,
+            kRowDeadzoneStick   = 2,
+            kRowDeadzoneTrigger = 3,
+            kRowLookSensitivity = 4,
+            kRowCount           = 5,
         };
 
         int RowCount() const override { return kRowCount; }

--- a/engine/Poseidon/UI/Settings/GamepadConfig.cpp
+++ b/engine/Poseidon/UI/Settings/GamepadConfig.cpp
@@ -31,6 +31,7 @@ bool GamepadConfig::IsGamepadCode(int packedCode)
 void GamepadConfig::LoadDefaults()
 {
     enabled = true;
+    reverseYStick = false;
     deadzoneStick = 0.21f;
     deadzoneTrigger = 0.10f;
     lookSensitivity = 1.0f;
@@ -70,6 +71,8 @@ bool GamepadConfig::Load(const std::string& path)
 
     if (auto* e = cfg.FindEntry("enabled"))
         enabled = (bool)*e;
+    if (auto* e = cfg.FindEntry("reverseYStick"))
+        reverseYStick = (bool)*e;
     if (auto* e = cfg.FindEntry("deadzoneStick"))
         deadzoneStick = (float)*e;
     if (auto* e = cfg.FindEntry("deadzoneTrigger"))
@@ -95,6 +98,7 @@ bool GamepadConfig::Save(const std::string& path) const
 
     ParamFile cfg;
     cfg.Add("enabled", enabled);
+    cfg.Add("reverseYStick", reverseYStick);
     cfg.Add("deadzoneStick", deadzoneStick);
     cfg.Add("deadzoneTrigger", deadzoneTrigger);
     cfg.Add("lookSensitivity", lookSensitivity);

--- a/engine/Poseidon/UI/Settings/GamepadConfig.hpp
+++ b/engine/Poseidon/UI/Settings/GamepadConfig.hpp
@@ -5,6 +5,7 @@
 //
 // File shape:
 //   enabled=1;
+//   reverseYStick=0;
 //   deadzoneStick=0.21;
 //   deadzoneTrigger=0.10;
 //   lookSensitivity=1.0;
@@ -28,6 +29,7 @@ class GamepadConfig
 public:
     // Tuning scalars (live values mirrored to GInput.gamepad.*).
     bool  enabled         = true;
+    bool  reverseYStick   = false;
     float deadzoneStick   = 0.21f;
     float deadzoneTrigger = 0.10f;
     float lookSensitivity = 1.0f;

--- a/tests/unit/engine/Poseidon/Input/test_gamepad_state.cpp
+++ b/tests/unit/engine/Poseidon/Input/test_gamepad_state.cpp
@@ -26,6 +26,7 @@ TEST_CASE("GamepadState: default construction zeroes everything", "[input][gamep
     }
 
     REQUIRE(gs.enabled == true);
+    REQUIRE_FALSE(gs.reverseYStick);
     REQUIRE(gs.deadzoneStick == Catch::Approx(0.21f));
     REQUIRE(gs.deadzoneTrigger == Catch::Approx(0.10f));
     REQUIRE(gs.lookSensitivity == Catch::Approx(1.0f));

--- a/tests/unit/engine/Poseidon/Input/test_input_integration.cpp
+++ b/tests/unit/engine/Poseidon/Input/test_input_integration.cpp
@@ -482,6 +482,12 @@ TEST_CASE("InputSubsystem config settings round-trip", "[input][integration]")
     sub.ToggleJoystickEnabled();
     REQUIRE(sub.IsJoystickEnabled() == origJoy);
 
+    bool origRevJoy = sub.IsReverseJoystick();
+    sub.SetReverseJoystick(!origRevJoy);
+    REQUIRE(sub.IsReverseJoystick() == !origRevJoy);
+    sub.ToggleReverseJoystick();
+    REQUIRE(sub.IsReverseJoystick() == origRevJoy);
+
     bool origButtons = sub.IsMouseButtonsReversed();
     sub.SetMouseButtonsReversed(!origButtons);
     REQUIRE(sub.IsMouseButtonsReversed() == !origButtons);

--- a/tests/unit/engine/Poseidon/UI/test_gamepad_page.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_gamepad_page.cpp
@@ -30,6 +30,7 @@ namespace
 struct GamepadStateSnapshot
 {
     bool enabled;
+    bool reverseYStick;
     float deadzoneStick;
     float deadzoneTrigger;
     float lookSensitivity;
@@ -37,6 +38,7 @@ struct GamepadStateSnapshot
     GamepadStateSnapshot()
     {
         enabled = GInput.gamepad.enabled;
+        reverseYStick = GInput.gamepad.reverseYStick;
         deadzoneStick = GInput.gamepad.deadzoneStick;
         deadzoneTrigger = GInput.gamepad.deadzoneTrigger;
         lookSensitivity = GInput.gamepad.lookSensitivity;
@@ -44,6 +46,7 @@ struct GamepadStateSnapshot
     ~GamepadStateSnapshot()
     {
         GInput.gamepad.enabled = enabled;
+        GInput.gamepad.reverseYStick = reverseYStick;
         GInput.gamepad.deadzoneStick = deadzoneStick;
         GInput.gamepad.deadzoneTrigger = deadzoneTrigger;
         GInput.gamepad.lookSensitivity = lookSensitivity;
@@ -276,11 +279,11 @@ TEST_CASE("GamepadPage: grouped freelook capture writes LB-modified right-stick 
 // ---------------------------------------------------------------------------
 // GamepadTuningPage: 4 scalar rows + auto Close.
 
-TEST_CASE("GamepadTuningPage: provider exposes 4 scalar rows + close", "[UI][GamepadTuningPage]")
+TEST_CASE("GamepadTuningPage: provider exposes 5 scalar rows + close", "[UI][GamepadTuningPage]")
 {
     TestableGamepadTuningPage page;
     auto& p = page.Provider();
-    CHECK(p.RowCount() == 5);
+    CHECK(p.RowCount() == 6);
 }
 
 TEST_CASE("GamepadTuningPage: row labels", "[UI][GamepadTuningPage]")
@@ -293,9 +296,10 @@ TEST_CASE("GamepadTuningPage: row labels", "[UI][GamepadTuningPage]")
     CHECK(std::string(bindingsPage.TitleText()) == "Gamepad");
     CHECK(std::string(page.TitleText()) == "Gamepad Tuning");
     CHECK(std::string(p.RowLabel(0)) == "Gamepad enabled");
-    CHECK(std::string(p.RowLabel(1)) == "Stick deadzone");
-    CHECK(std::string(p.RowLabel(2)) == "Trigger deadzone");
-    CHECK(std::string(p.RowLabel(3)) == "Look sensitivity");
+    CHECK(std::string(p.RowLabel(1)) == "Y-axis inversion");
+    CHECK(std::string(p.RowLabel(2)) == "Stick deadzone");
+    CHECK(std::string(p.RowLabel(3)) == "Trigger deadzone");
+    CHECK(std::string(p.RowLabel(4)) == "Look sensitivity");
 }
 
 TEST_CASE("GamepadTuningPage: row descriptions localize from the main menu shard", "[UI][GamepadTuningPage]")
@@ -306,10 +310,11 @@ TEST_CASE("GamepadTuningPage: row descriptions localize from the main menu shard
     auto& p = page.Provider();
     CHECK(std::string(p.RowDescription(0)) ==
           "Master switch for gamepad input. Disable to ignore the controller entirely.");
-    CHECK(std::string(p.RowDescription(1)) ==
+    CHECK(std::string(p.RowDescription(1)) == "Invert vertical stick motion - pushing the stick forward looks down.");
+    CHECK(std::string(p.RowDescription(2)) ==
           "Center deadzone for the analog sticks. Range 0% to 50% of full deflection.");
-    CHECK(std::string(p.RowDescription(2)) == "Activation threshold for the analog triggers. Range 0% to 50%.");
-    CHECK(std::string(p.RowDescription(3)) == "Right-stick look-aim sensitivity. Range 0.1x to 5.0x.");
+    CHECK(std::string(p.RowDescription(3)) == "Activation threshold for the analog triggers. Range 0% to 50%.");
+    CHECK(std::string(p.RowDescription(4)) == "Right-stick look-aim sensitivity. Range 0.1x to 5.0x.");
 }
 
 TEST_CASE("GamepadTuningPage: row kinds - toggle stepper + 3 sliders + close action", "[UI][GamepadTuningPage]")
@@ -317,10 +322,11 @@ TEST_CASE("GamepadTuningPage: row kinds - toggle stepper + 3 sliders + close act
     TestableGamepadTuningPage page;
     auto& p = page.Provider();
     CHECK(p.RowKind(0) == OptionsScrollList::KindStepper); // enabled toggle
-    CHECK(p.RowKind(1) == OptionsScrollList::KindSlider);  // stick deadzone
-    CHECK(p.RowKind(2) == OptionsScrollList::KindSlider);  // trigger deadzone
-    CHECK(p.RowKind(3) == OptionsScrollList::KindSlider);  // look sensitivity
-    CHECK(p.RowKind(4) == OptionsScrollList::KindAction);  // Close
+    CHECK(p.RowKind(1) == OptionsScrollList::KindStepper); // inversion toggle
+    CHECK(p.RowKind(2) == OptionsScrollList::KindSlider);  // stick deadzone
+    CHECK(p.RowKind(3) == OptionsScrollList::KindSlider);  // trigger deadzone
+    CHECK(p.RowKind(4) == OptionsScrollList::KindSlider);  // look sensitivity
+    CHECK(p.RowKind(5) == OptionsScrollList::KindAction);  // Close
 }
 
 TEST_CASE("GamepadTuningPage: enabled toggle round-trips through GInput", "[UI][GamepadTuningPage]")
@@ -341,26 +347,44 @@ TEST_CASE("GamepadTuningPage: enabled toggle round-trips through GInput", "[UI][
     CHECK(GInput.gamepad.enabled == true);
 }
 
+TEST_CASE("GamepadTuningPage: inversion toggle round-trips through GInput", "[UI][GamepadTuningPage]")
+{
+    GamepadStateSnapshot snap;
+    TestableGamepadTuningPage page;
+    auto& p = page.Provider();
+
+    GInput.gamepad.reverseYStick = true;
+    CHECK(p.RowValue(1) == 1);
+    p.SetRowValue(1, 0);
+    CHECK(GInput.gamepad.reverseYStick == false);
+    p.SetRowValue(1, 1);
+    CHECK(GInput.gamepad.reverseYStick == true);
+
+    // Out-of-range rejected.
+    p.SetRowValue(1, 99);
+    CHECK(GInput.gamepad.enabled == true);
+}
+
 TEST_CASE("GamepadTuningPage: deadzone slider maps 0..100 to 0.0..0.5", "[UI][GamepadTuningPage]")
 {
     GamepadStateSnapshot snap;
     TestableGamepadTuningPage page;
     auto& p = page.Provider();
 
-    p.SetRowValue(1, 0);
+    p.SetRowValue(2, 0);
     CHECK(GInput.gamepad.deadzoneStick == 0.0f);
-    p.SetRowValue(1, 100);
+    p.SetRowValue(2, 100);
     CHECK(GInput.gamepad.deadzoneStick == 0.5f);
-    p.SetRowValue(1, 50);
+    p.SetRowValue(2, 50);
     CHECK(GInput.gamepad.deadzoneStick == 0.25f);
 
-    p.SetRowValue(2, 20);
+    p.SetRowValue(3, 20);
     CHECK(GInput.gamepad.deadzoneTrigger == 0.10f);
 
     // Negative / >100 clamp.
-    p.SetRowValue(1, -5);
+    p.SetRowValue(2, -5);
     CHECK(GInput.gamepad.deadzoneStick == 0.0f);
-    p.SetRowValue(1, 200);
+    p.SetRowValue(2, 200);
     CHECK(GInput.gamepad.deadzoneStick == 0.5f);
 }
 
@@ -370,16 +394,16 @@ TEST_CASE("GamepadTuningPage: look sensitivity slider maps 0..100 to 0.1..5.0", 
     TestableGamepadTuningPage page;
     auto& p = page.Provider();
 
-    p.SetRowValue(3, 0);
+    p.SetRowValue(4, 0);
     CHECK(GInput.gamepad.lookSensitivity == 0.1f);
-    p.SetRowValue(3, 100);
+    p.SetRowValue(4, 100);
     CHECK(GInput.gamepad.lookSensitivity == 5.0f);
 
     // Engine default 1.0 reads back at ~18% on the linear slider —
     // documents the (0.1..5.0) chosen range; default isn't at 50%
     // because the range is biased toward higher sensitivities.
     GInput.gamepad.lookSensitivity = 1.0f;
-    int pct = p.RowValue(3);
+    int pct = p.RowValue(4);
     CHECK(pct >= 17);
     CHECK(pct <= 19);
 }


### PR DESCRIPTION
Before this, gamepad Y-axis inversion was dependent on mouse Y-axis inversion. This makes it a separate setting.

This is working now, but in draft until I add unit tests and make sure everything is clean/compliant.