### PR TITLE
Improvements to CI artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,18 +30,37 @@ jobs:
             vcpkg_triplet: x64-linux-clang
             build_dir: build/linux-x64-clang-rwdi
             ctest_exclude: 'PoseidonTests - OAL -'
-            binaries_upload: 'Linux-x64-rwdi'
+            artifact_prefix: 'Linux-x64-rwdi'
+            dist_dir: dist/x64-linux-rwdi
+            game_artifact_path: dist/x64-linux-rwdi/PoseidonGame
+            game_demo_artifact_path: dist/x64-linux-rwdi/PoseidonGameDemo
+            server_artifact_path: dist/x64-linux-rwdi/PoseidonServer
           - name: Windows RelWithDebInfo
             os: windows-2022
             preset: win-x64-clang-rwdi
             vcpkg_triplet: x64-windows-clang
             build_dir: build/win-x64-clang-rwdi
             ctest_exclude: 'PoseidonTests - (OAL -|PAAEncoder -|Image - Save to \.paa|World state file format --|PreviewImage - saveToFile writes|PreviewImageRGB - saveToFile writes)'
-            binaries_upload: 'Windows-x64-rwdi'
+            artifact_prefix: 'Windows-x64-rwdi'
+            dist_dir: dist/x64-win-rwdi
+            game_artifact_path: |
+              dist/x64-win-rwdi/PoseidonGame.exe
+              dist/x64-win-rwdi/OpenAL32.dll
+              dist/x64-win-rwdi/OpenAL-Soft.LICENSE.txt
+            game_demo_artifact_path: |
+              dist/x64-win-rwdi/PoseidonGameDemo.exe
+              dist/x64-win-rwdi/OpenAL32.dll
+              dist/x64-win-rwdi/OpenAL-Soft.LICENSE.txt
+            server_artifact_path: dist/x64-win-rwdi/PoseidonServer.exe
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Build metadata
+        id: build_metadata
+        shell: bash
+        run: echo "sha_short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Install Linux system packages
         if: runner.os == 'Linux'
@@ -116,23 +135,43 @@ jobs:
       - name: Build
         run: cmake --build ${{ matrix.build_dir }} --parallel 2
 
-      - name: Upload binaries
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.binaries_upload }}
-          path: |
-            ${{ matrix.build_dir }}/apps/cwr/Game/PoseidonGame
-            ${{ matrix.build_dir }}/apps/cwr/Game/PoseidonGame.exe
-            ${{ matrix.build_dir }}/apps/cwr/GameDemo/PoseidonGameDemo
-            ${{ matrix.build_dir }}/apps/cwr/GameDemo/PoseidonGameDemo.exe
-            ${{ matrix.build_dir }}/apps/cwr/Server/PoseidonServer
-            ${{ matrix.build_dir }}/apps/cwr/Server/PoseidonServer.exe
-
       - name: Test
         shell: pwsh
         env:
           CTEST_EXCLUDE: ${{ matrix.ctest_exclude }}
         run: ctest --test-dir '${{ matrix.build_dir }}' --output-on-failure -E "$env:CTEST_EXCLUDE"
+
+      - name: Upload Game
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact_prefix }}-Game-${{ steps.build_metadata.outputs.sha_short }}
+          path: ${{ matrix.game_artifact_path }}
+          if-no-files-found: error
+
+      - name: Upload GameDemo
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact_prefix }}-GameDemo-${{ steps.build_metadata.outputs.sha_short }}
+          path: ${{ matrix.game_demo_artifact_path }}
+          if-no-files-found: error
+
+      - name: Upload Server
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact_prefix }}-Server-${{ steps.build_metadata.outputs.sha_short }}
+          path: ${{ matrix.server_artifact_path }}
+          if-no-files-found: error
+
+      - name: Upload symbols
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact_prefix }}-Symbols-${{ steps.build_metadata.outputs.sha_short }}
+          path: |
+            ${{ matrix.dist_dir }}/PoseidonGame.pdb
+            ${{ matrix.dist_dir }}/PoseidonGameDemo.pdb
+            ${{ matrix.dist_dir }}/PoseidonServer.pdb
+          if-no-files-found: error
 
   steamrt4:
     name: SteamRT4 Release

--- a/cmake/DistCopy.cmake
+++ b/cmake/DistCopy.cmake
@@ -35,7 +35,16 @@ function(dist_copy TARGET)
     endif()
 
     # Copy runtime DLLs (e.g., OpenAL32.dll — LGPL dynamic linkage)
-    if(WIN32 AND TARGET OpenAL::OpenAL)
+    set(_copy_openal_runtime OFF)
+    get_target_property(_link_libraries ${TARGET} LINK_LIBRARIES)
+    if(_link_libraries)
+        foreach(_link_library IN LISTS _link_libraries)
+            if(_link_library STREQUAL "PoseidonOpenAL" OR _link_library STREQUAL "OpenAL::OpenAL")
+                set(_copy_openal_runtime ON)
+            endif()
+        endforeach()
+    endif()
+    if(WIN32 AND TARGET OpenAL::OpenAL AND _copy_openal_runtime)
         get_target_property(_openal_dll OpenAL::OpenAL IMPORTED_LOCATION)
         if(NOT _openal_dll)
             get_target_property(_openal_dll OpenAL::OpenAL IMPORTED_LOCATION_RELEASE)
@@ -46,9 +55,26 @@ function(dist_copy TARGET)
                     "${_openal_dll}" "${DIST_DIR}"
                 VERBATIM
             )
+
+            get_filename_component(_openal_bin_dir "${_openal_dll}" DIRECTORY)
+            get_filename_component(_openal_triplet_dir "${_openal_bin_dir}" DIRECTORY)
+            set(_openal_copyright "${_openal_triplet_dir}/share/openal-soft/copyright")
+            if(EXISTS "${_openal_copyright}")
+                add_custom_command(TARGET ${TARGET} POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        "${_openal_copyright}" "${DIST_DIR}/OpenAL-Soft.LICENSE.txt"
+                    VERBATIM
+                )
+            endif()
         endif()
         unset(_openal_dll)
+        unset(_openal_bin_dir)
+        unset(_openal_triplet_dir)
+        unset(_openal_copyright)
     endif()
+    unset(_copy_openal_runtime)
+    unset(_link_libraries)
+    unset(_link_library)
 
     # Copy extra files from the target's source directory
     foreach(_extra ${ARG_EXTRA})


### PR DESCRIPTION
Added short SHA suffixes to all artifact names and separate per app/system (+ symbols).
                                               
Example names now look like:                   
                                               
Windows-x64-rwdi-Game-abc1234
Windows-x64-rwdi-GameDemo-abc1234
Windows-x64-rwdi-Server-abc1234
Windows-x64-rwdi-Symbols-abc1234