### PR TITLE
Improve consistency of directories in file system

### DIFF
--- a/apps/tools/Tools/main.cpp
+++ b/apps/tools/Tools/main.cpp
@@ -89,7 +89,7 @@ int main(int argc, char** argv)
     Poseidon::Foundation::gSoftAssert = true;
     InitLibraryElement();
     Poseidon::InitDefaults();
-    GamePaths::Instance().Initialize("CWR", "ColdWarAssault");
+    GamePaths::Instance().Initialize("CWR", "ColdWarAssault", "Cold War Assault");
     Poseidon::GEngine = Poseidon::CreateEngineDummy();
     static ToolApplication toolApp;
 

--- a/engine/Poseidon/Foundation/Common/PlatformPaths_posix.cpp
+++ b/engine/Poseidon/Foundation/Common/PlatformPaths_posix.cpp
@@ -43,7 +43,9 @@ std::string getUserConfigDir(const char* appName) {
 }
 
 std::string getUserDataDir(const char* appName) {
-    return getXdgDir("XDG_DATA_HOME", ".local/share", appName);
+    // While the XDG data dir is the best match by name, we mostly use the
+    // user data dir for configuration files, so use the XDG config dir.
+    return getXdgDir("XDG_CONFIG_HOME", ".config", appName);
 }
 
 std::string getUserCacheDir(const char* appName) {

--- a/tests/unit/engine/Poseidon/Foundation/Common/test_platformPaths.cpp
+++ b/tests/unit/engine/Poseidon/Foundation/Common/test_platformPaths.cpp
@@ -113,25 +113,29 @@ TEST_CASE("Different app names produce different directories", "[platformPaths]"
     fs::remove_all(dir2);
 }
 
-TEST_CASE("Config, data, and cache dirs are distinct on Linux", "[platformPaths]")
+TEST_CASE("Config/data, doc, and cache dirs are distinct on Linux", "[platformPaths]")
 {
     std::string config = Poseidon::Foundation::getUserConfigDir("TestApp_Distinct");
     std::string data = Poseidon::Foundation::getUserDataDir("TestApp_Distinct");
+    std::string doc = Poseidon::Foundation::getUserDocumentsDir("TestApp_Distinct");
     std::string cache = Poseidon::Foundation::getUserCacheDir("TestApp_Distinct");
 
 #ifndef _WIN32
+    REQUIRE(config == data);
     // On Linux with XDG defaults, these should be different base paths
-    REQUIRE(config != data);
+    REQUIRE(config != doc);
     REQUIRE(config != cache);
     REQUIRE(data != cache);
 #endif
     // All should contain the app name
     REQUIRE(config.find("TestApp_Distinct") != std::string::npos);
     REQUIRE(data.find("TestApp_Distinct") != std::string::npos);
+    REQUIRE(doc.find("TestApp_Distinct") != std::string::npos);
     REQUIRE(cache.find("TestApp_Distinct") != std::string::npos);
 
     fs::remove_all(config);
     fs::remove_all(data);
+    fs::remove_all(doc);
     fs::remove_all(cache);
 }
 
@@ -151,13 +155,27 @@ TEST_CASE("getUserConfigDir respects XDG_CONFIG_HOME", "[platformPaths]")
     fs::remove_all(tmpDir);
 }
 
-TEST_CASE("getUserDataDir respects XDG_DATA_HOME", "[platformPaths]")
+TEST_CASE("getUserDataDir respects XDG_CONFIG_HOME", "[platformPaths]")
+{
+    auto tmpDir = fs::temp_directory_path() / "test_xdg_data";
+    fs::create_directories(tmpDir);
+
+    ScopedEnv env("XDG_CONFIG_HOME", tmpDir.c_str());
+    std::string dir = Poseidon::Foundation::getUserDataDir("TestApp_XDG");
+    REQUIRE(dir.find(tmpDir.string()) == 0);
+    REQUIRE(dir.find("TestApp_XDG") != std::string::npos);
+    REQUIRE(dirExists(dir));
+
+    fs::remove_all(tmpDir);
+}
+
+TEST_CASE("getUserDocumentsDir respects XDG_DATA_HOME", "[platformPaths]")
 {
     auto tmpDir = fs::temp_directory_path() / "test_xdg_data";
     fs::create_directories(tmpDir);
 
     ScopedEnv env("XDG_DATA_HOME", tmpDir.c_str());
-    std::string dir = Poseidon::Foundation::getUserDataDir("TestApp_XDG");
+    std::string dir = Poseidon::Foundation::getUserDocumentsDir("TestApp_XDG");
     REQUIRE(dir.find(tmpDir.string()) == 0);
     REQUIRE(dir.find("TestApp_XDG") != std::string::npos);
     REQUIRE(dirExists(dir));


### PR DESCRIPTION
## Changes

### Tools content dir

Add `productName` to `PoseidonTools` so that it no longer creates a separate `ColdWarAssault` directory. This makes it conform with `GameBase`. Before, there would be a `ColdWarAssault` user content dir created by `PoseidonTools` and a `Cold War Assault` content dir beside it, created by anything that uses `GameBase`.

Example directory structure on Linux before this change, after running the game and the tools:

```
/home/her001/.local/share/Cold War Assault/
/home/her001/.local/share/ColdWarAssault/
```

Example after this change (assuming no preexisting files):

```
/home/her001/.local/share/Cold War Assault/
```

### Linux data dir

Switch user data dir to XDG config dir on Linux, as the user data dir is mostly used for configuration files. See the XDG base directory spec: https://specifications.freedesktop.org/basedir/latest/

Example before this change:

```
/home/her001/.local/share/CWR/
```

Example after:

```
/home/her001/.config/CWR/
```

#### Alternatives

It could be that we don't want to change the data dir on Linux, or that we want to add backwards compatibility/a migration path, since this is a breaking change. However, this isn't a breaking change for many users right now, as most users wouldn't have files in place at all (yet).

## Potential additions

`AppName` is used for reading and writing persistent prefs, and is currently hardcoded to `ARMA:CWA-RE`. That usually means there is a `ARMA:CWA-RE` directory alongside another directory we create, which contains a single file with a single line. With this pull request, that other directory will usually be the user data dir (on both Windows and Linux), so it would be convenient if we could merge them.

I didn't make this change myself because I wasn't sure how we'd want to implement that, if at all.

Example of state with this pull request's changes:

```
/home/her001/.config/CWR/
/home/her001/.config/ARMA:CWA-RE/
```

Example of state if making an additional change to consolidate the prefs file (assuming no preexisting files):

```
/home/her001/.config/CWR/
```