### PR TITLE
Apply server difficulty to multiplayer clients

### DIFF
--- a/engine/Poseidon/Core/Profile/UserConfig.cpp
+++ b/engine/Poseidon/Core/Profile/UserConfig.cpp
@@ -113,9 +113,29 @@ void UserConfig::InitDifficulties()
 
 bool UserConfig::IsEnabled(DifficultyType type) const
 {
+    if (_serverDifficultyActive)
+        return _serverDifficulty[type];
+
     if (easyMode)
         return cadetDifficulty[type];
     else
         return veteranDifficulty[type];
+}
+
+void UserConfig::SetServerDifficulty(const bool* flags)
+{
+    if (!flags)
+    {
+        ClearServerDifficulty();
+        return;
+    }
+    for (int i = 0; i < DTN; i++)
+        _serverDifficulty[i] = flags[i];
+    _serverDifficultyActive = true;
+}
+
+void UserConfig::ClearServerDifficulty()
+{
+    _serverDifficultyActive = false;
 }
 } // namespace Poseidon

--- a/engine/Poseidon/Core/Profile/UserConfig.hpp
+++ b/engine/Poseidon/Core/Profile/UserConfig.hpp
@@ -24,8 +24,15 @@ class UserConfig
     void InitDefaults();
     void InitDifficulties();
 
-    /// Whether the toggle is enabled in the current difficulty mode (cadet/veteran).
+    /// Whether the toggle is enabled in the current difficulty mode. A server
+    /// override (set in multiplayer) takes precedence over the local profile.
     bool IsEnabled(DifficultyType type) const;
+
+    /// Adopt the server's per-flag difficulty so queries are server-authoritative.
+    void SetServerDifficulty(const bool* flags);
+    /// Drop the server override; queries fall back to the local profile.
+    void ClearServerDifficulty();
+    bool HasServerDifficulty() const { return _serverDifficultyActive; }
 
     // --- Difficulty Settings ---
     bool cadetDifficulty[DTN];   // Flags for cadet mode
@@ -42,5 +49,9 @@ class UserConfig
   private:
     void LoadFromParamFile(const ParamFile& cfg);
     void SaveToParamFile(ParamFile& cfg) const;
+
+    // Server difficulty pushed by the host in multiplayer (session-local, not persisted).
+    bool _serverDifficultyActive = false;
+    bool _serverDifficulty[DTN] = {};
 };
 } // namespace Poseidon

--- a/engine/Poseidon/Network/NetworkClient.cpp
+++ b/engine/Poseidon/Network/NetworkClient.cpp
@@ -223,6 +223,8 @@ NetworkClient::~NetworkClient()
     // Mute/ignore are per-session, client-local: drop them when the MP client
     // tears down so they don't leak into the next session.
     ClearMuteIgnore();
+    // Drop the server difficulty override so it doesn't leak into a later session.
+    USER_CONFIG.ClearServerDifficulty();
     Poseidon::DeleteDirectoryStructure("tmp", true);
 }
 

--- a/engine/Poseidon/Network/NetworkClientActions.cpp
+++ b/engine/Poseidon/Network/NetworkClientActions.cpp
@@ -1151,6 +1151,9 @@ void NetworkClient::Disconnect(RString message)
     _state = NGSNone;
     _serverState = NGSNone;
 
+    // Leaving the server: difficulty reverts to the local profile.
+    USER_CONFIG.ClearServerDifficulty();
+
     const PlayerIdentity* id = FindIdentity(_player);
     if (id)
     {

--- a/engine/Poseidon/Network/NetworkClientOnMessage.cpp
+++ b/engine/Poseidon/Network/NetworkClientOnMessage.cpp
@@ -612,6 +612,9 @@ void NetworkClient::OnMessage(int from, NetworkMessage* msg, NetworkMessageType 
             }
 
             USER_CONFIG.easyMode = _missionHeader.cadetMode;
+            // Difficulty is server-authoritative in multiplayer: adopt the host's settings so
+            // name tags, HUD and map markers match the server, not this client's local profile.
+            USER_CONFIG.SetServerDifficulty(_missionHeader.difficulty.Data());
             _playerRoles.Resize(0);
 
             // check if mission file is valid

--- a/tests/unit/engine/Poseidon/Core/test_user_config.cpp
+++ b/tests/unit/engine/Poseidon/Core/test_user_config.cpp
@@ -167,6 +167,88 @@ TEST_CASE("UserConfig IsEnabled logic", "[core][config][difficulty]")
     }
 }
 
+TEST_CASE("UserConfig server difficulty override in multiplayer", "[core][config][difficulty][multiplayer]")
+{
+    using namespace Poseidon;
+    UserConfig config;
+
+    // A joining client in veteran mode: friendly/enemy tags, HUD and map are off
+    // locally; the weapon cursor stays on (its veteran default).
+    config.easyMode = false;
+    config.veteranDifficulty[DTFriendlyTag] = false;
+    config.veteranDifficulty[DTEnemyTag] = false;
+    config.veteranDifficulty[DTHUD] = false;
+    config.veteranDifficulty[DTMap] = false;
+    config.veteranDifficulty[DTWeaponCursor] = true;
+
+    SECTION("Without an override the local profile is used")
+    {
+        REQUIRE(config.HasServerDifficulty() == false);
+        REQUIRE(config.IsEnabled(DTFriendlyTag) == false);
+        REQUIRE(config.IsEnabled(DTHUD) == false);
+    }
+
+    SECTION("Server override takes precedence over the local profile")
+    {
+        // The host enables the in-world callouts; this is the difficulty array a
+        // client receives from the server.
+        bool serverDifficulty[DTN] = {};
+        serverDifficulty[DTFriendlyTag] = true;
+        serverDifficulty[DTEnemyTag] = true;
+        serverDifficulty[DTHUD] = true;
+        serverDifficulty[DTMap] = true;
+        serverDifficulty[DTWeaponCursor] = true;
+
+        config.SetServerDifficulty(serverDifficulty);
+
+        REQUIRE(config.HasServerDifficulty() == true);
+        REQUIRE(config.IsEnabled(DTFriendlyTag) == true);
+        REQUIRE(config.IsEnabled(DTEnemyTag) == true);
+        REQUIRE(config.IsEnabled(DTHUD) == true);
+        REQUIRE(config.IsEnabled(DTMap) == true);
+        REQUIRE(config.IsEnabled(DTWeaponCursor) == true);
+
+        // The override wins regardless of cadet/veteran mode.
+        config.easyMode = true;
+        REQUIRE(config.IsEnabled(DTFriendlyTag) == true);
+    }
+
+    SECTION("Server override can also disable callouts the local profile would show")
+    {
+        config.easyMode = true;
+        config.cadetDifficulty[DTFriendlyTag] = true;
+
+        bool serverDifficulty[DTN] = {}; // strict server: everything off
+        config.SetServerDifficulty(serverDifficulty);
+
+        REQUIRE(config.IsEnabled(DTFriendlyTag) == false);
+    }
+
+    SECTION("Clearing the override restores the local profile")
+    {
+        bool serverDifficulty[DTN] = {};
+        serverDifficulty[DTFriendlyTag] = true;
+        config.SetServerDifficulty(serverDifficulty);
+        REQUIRE(config.IsEnabled(DTFriendlyTag) == true);
+
+        config.ClearServerDifficulty();
+        REQUIRE(config.HasServerDifficulty() == false);
+        REQUIRE(config.IsEnabled(DTFriendlyTag) == false);
+    }
+
+    SECTION("A null difficulty array clears the override")
+    {
+        bool serverDifficulty[DTN] = {};
+        serverDifficulty[DTHUD] = true;
+        config.SetServerDifficulty(serverDifficulty);
+        REQUIRE(config.HasServerDifficulty() == true);
+
+        config.SetServerDifficulty(nullptr);
+        REQUIRE(config.HasServerDifficulty() == false);
+        REQUIRE(config.IsEnabled(DTHUD) == false);
+    }
+}
+
 TEST_CASE("UserConfig InitDifficulties", "[core][config][difficulty]")
 {
     Poseidon::UserConfig config;


### PR DESCRIPTION
In multiplayer, a client that joins a server saw no name tags, HUD or map markers — only the weapon cursor still showed. The client read its difficulty toggles (friendly/enemy tags, HUD, map) from its own local profile instead of the server's settings, so anything the host enabled was ignored.

The host already sends its per-flag difficulty in the mission header, but nothing applied it on the client. Now the client adopts the server's difficulty while connected (`UserConfig::IsEnabled` honors it) and reverts to the local profile on disconnect.

Includes a unit test (`UserConfig server difficulty override in multiplayer`) that fails before this change and passes after.