### PR TITLE
add selectPlayer scripting command

### DIFF
--- a/engine/Poseidon/Game/Commands/GameStateExt.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExt.cpp
@@ -597,6 +597,7 @@ GameValue PublicVariable(const GameState* state, GameValuePar oper1);
 GameValue RequiredVersion(const GameState* state, GameValuePar oper1);
 GameValue SaveVar(const GameState* state, GameValuePar oper1);
 GameValue ScriptGoto(const GameState* state, GameValuePar oper1);
+GameValue SelectPlayer(const GameState* state, GameValuePar oper1);
 GameValue SetAcceleratedTime(const GameState* state, GameValuePar oper1);
 GameValue SetDate(const GameState* state, GameValuePar oper1);
 GameValue SetTerrainGrid(const GameState* state, GameValuePar oper1);
@@ -1207,6 +1208,8 @@ static const GameFunction* GetExtUnary(int& count)
         GameFunction(GameArray, "magazinesArray", ObjMagazinesArray, GameObject),
         GameFunction(GameArray, "GetHitpointsNames", ObjGetHitpointsNames, GameObject),
         GameFunction(GameNothing, "showDebug", DebugShow, GameArray),
+
+        GameFunction(GameNothing, "selectPlayer", SelectPlayer, GameObject),
     };
     count = sizeof(ExtUnary) / sizeof(*ExtUnary);
     return ExtUnary;

--- a/engine/Poseidon/Game/Commands/GameStateExtGrp.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtGrp.cpp
@@ -1942,3 +1942,26 @@ GameValue ObjGetSpeed(const GameState* state, GameValuePar oper1)
 
     return 3.6f * veh->ModelSpeed().Z();
 }
+
+GameValue SelectPlayer(const GameState* state, GameValuePar oper1)
+{
+    Object* obj = GetObject(oper1);
+    EntityAI* ai = dyn_cast<EntityAI>(obj);
+    if (!ai)
+    {
+        return NOTHING;
+    }
+
+    AIUnit* unit = ai->CommanderUnit();
+    if (!unit)
+    {
+        return NOTHING;
+    }
+
+    GWorld->SwitchCameraTo(unit->GetVehicle(), CamInternal);
+    GWorld->SetPlayerManual(true);
+    GWorld->SwitchPlayerTo(unit->GetPerson());
+    GWorld->SetRealPlayer(unit->GetPerson());
+
+    return NOTHING;
+}


### PR DESCRIPTION
Adds a new `selectPlayer` command that lets the player change between units. Fixes #47.