### PR TITLE
Clear freelook deltas on release

### DIFF
--- a/engine/Poseidon/Input/InputSubsystem.cpp
+++ b/engine/Poseidon/Input/InputSubsystem.cpp
@@ -548,7 +548,11 @@ void InputSubsystem::ComputeMovementState()
             lookAroundEnabled_ = lookAroundToggled_;
 
         if (oldLookAround != lookAroundEnabled_)
+        {
             freelookChanged_ = true;
+            if (oldLookAround && !lookAroundEnabled_)
+                GInput.cursor.aimDeltaX = GInput.cursor.aimDeltaY = GInput.cursor.aimDeltaZ = 0;
+        }
 
         moveUp_ += GetAction(UAMoveUp, true);
         moveDown_ += GetAction(UAMoveDown, true);

--- a/tests/unit/engine/Poseidon/Input/test_input_integration.cpp
+++ b/tests/unit/engine/Poseidon/Input/test_input_integration.cpp
@@ -423,6 +423,50 @@ TEST_CASE("InputSubsystem lookAround defaults to off", "[input][integration]")
     REQUIRE_FALSE(sub.IsLookAroundToggled());
 }
 
+TEST_CASE("InputSubsystem clears pending look delta when held freelook is released", "[input][integration]")
+{
+    auto& sub = InputSubsystem::Instance();
+    ProfileSnapshot infantrySnap(sub, InputContext::Infantry);
+    InputContext savedContext = sub.GetContext();
+    float savedAlt = GInput.keyboard.keys[SDL_SCANCODE_LALT];
+    float savedAimX = GInput.cursor.aimDeltaX;
+    float savedAimY = GInput.cursor.aimDeltaY;
+    float savedAimZ = GInput.cursor.aimDeltaZ;
+
+    auto& infantry = sub.GetProfile(InputContext::Infantry);
+    infantry.ClearBindings(UALookAround);
+    infantry.Bind(UALookAround, InputCode::Key(SDL_SCANCODE_LALT));
+    sub.SetContext(InputContext::Infantry);
+    sub.ResetLookAroundToggle();
+
+    GInput.keyboard.keys[SDL_SCANCODE_LALT] = 0.0f;
+    sub.Update();
+    REQUIRE_FALSE(sub.IsLookAroundEnabled());
+
+    GInput.keyboard.keys[SDL_SCANCODE_LALT] = 1.0f;
+    sub.Update();
+    REQUIRE(sub.IsLookAroundEnabled());
+
+    GInput.cursor.aimDeltaX = 0.25f;
+    GInput.cursor.aimDeltaY = -0.125f;
+    GInput.cursor.aimDeltaZ = 0.5f;
+
+    GInput.keyboard.keys[SDL_SCANCODE_LALT] = 0.0f;
+    sub.Update();
+
+    REQUIRE_FALSE(sub.IsLookAroundEnabled());
+    REQUIRE(sub.FreelookChanged());
+    CHECK(sub.ConsumeCursorDeltaX() == 0.0f);
+    CHECK(sub.ConsumeCursorDeltaY() == 0.0f);
+    CHECK(sub.ConsumeCursorScroll() == 0.0f);
+
+    GInput.keyboard.keys[SDL_SCANCODE_LALT] = savedAlt;
+    GInput.cursor.aimDeltaX = savedAimX;
+    GInput.cursor.aimDeltaY = savedAimY;
+    GInput.cursor.aimDeltaZ = savedAimZ;
+    sub.SetContext(savedContext);
+}
+
 // --- Joystick/activity/focus/fire/cursor tests (Phase 2H API) ---
 
 TEST_CASE("InputSubsystem joystick axes return zero on zeroed GInput", "[input][integration]")


### PR DESCRIPTION
Original OFP recenters the UI cursor from World::FreelookChange when freelook turns off, and consumes cursorMovedX/Y by zeroing them in World::Simulate.

CWR's SDL path can keep aimDeltaX/Y/Z queued until a consumer drains them, so release-frame freelook motion can survive into the next non-freelook frame. Clear those deltas on the active-to-inactive transition.