### PR TITLE
Show master server operator in browsers

### DIFF
--- a/engine/Poseidon/Core/resincl.hpp
+++ b/engine/Poseidon/Core/resincl.hpp
@@ -384,6 +384,7 @@ CMD_RADIO_CUSTOM_0
 #define IDC_MODS_FILTER				123
 #define IDC_MODS_FILTER_NAME			124
 #define IDC_MODS_NOTEBOOK			106
+#define IDC_MODS_MASTER_SERVER			7000
 
 // Mods download dialog (RscDisplayModDownload) — opened from Apply when the
 // ticked set includes not-yet-downloaded (Available) mods.

--- a/engine/Poseidon/Network/NetworkConfig.cpp
+++ b/engine/Poseidon/Network/NetworkConfig.cpp
@@ -1,6 +1,7 @@
 #include <Poseidon/Network/NetworkConfig.hpp>
 #include <Poseidon/Core/Config/EngineConfig.hpp>
 #include <Poseidon/Foundation/Strings/RString.hpp>
+#include <cstring>
 
 const int DefaultNetworkPort = 1985;
 const char* DefaultMasterServer = "https://papa-bear.cz";
@@ -71,6 +72,20 @@ RString GetNetworkMasterServer()
 void SetNetworkMasterServer(const RString& host)
 {
     NetworkMasterServer = host;
+}
+
+RString FormatNetworkMasterServerAttribution(const RString& host)
+{
+    if (host.GetLength() == 0)
+        return "Operated by disabled";
+
+    const char* stripped = host;
+    if (std::strncmp(stripped, "https://", 8) == 0)
+        stripped += 8;
+    else if (std::strncmp(stripped, "http://", 7) == 0)
+        stripped += 7;
+
+    return RString("Operated by ") + stripped;
 }
 
 bool GetNetworkPublicServer()

--- a/engine/Poseidon/Network/NetworkConfig.hpp
+++ b/engine/Poseidon/Network/NetworkConfig.hpp
@@ -18,6 +18,7 @@ RString GetNetworkPassword();
 void SetNetworkPassword(const RString& password);
 RString GetNetworkMasterServer();
 void SetNetworkMasterServer(const RString& host);
+RString FormatNetworkMasterServerAttribution(const RString& host);
 bool GetNetworkPublicServer();
 void SetNetworkPublicServer(bool value);
 RString GetNetworkProxy();

--- a/engine/Poseidon/UI/DisplayUI.hpp
+++ b/engine/Poseidon/UI/DisplayUI.hpp
@@ -143,15 +143,7 @@ class DisplayMods : public Display
     bool _sortAscending = true;
 
   public:
-    DisplayMods(ControlsContainer* parent) : Display(parent)
-    {
-        _enableSimulation = false;
-        _exitWhenClose = -1;
-        Load("RscDisplayMods");
-        // Match the MP browser: open with a default Name-ascending sort and its
-        // caret shown (out-of-line; CModsList + ModsSortColumn aren't visible here).
-        ApplyInitialSort();
-    }
+    DisplayMods(ControlsContainer* parent);
 
     // Builds the catalog list as a CModsList (5-column DrawItem) and seeds it.
     // Out-of-line in OptionsUIApp.cpp where CModsList is fully visible.

--- a/engine/Poseidon/UI/DisplayUIMultiplayer.cpp
+++ b/engine/Poseidon/UI/DisplayUIMultiplayer.cpp
@@ -788,7 +788,7 @@ DisplayMultiplayer::DisplayMultiplayer(ControlsContainer* parent) : Display(pare
     C3DActiveText* dplayButton = dynamic_cast<C3DActiveText*>(GetCtrl(IDC_MULTI_DPLAY));
     if (dplayButton)
     {
-        dplayButton->SetText(LocalizeString(IDS_DISP_MULTI_SOCKETS));
+        dplayButton->SetText(FormatNetworkMasterServerAttribution(GetNetworkMasterServer()));
     }
 
     SetSource(source);
@@ -1757,7 +1757,7 @@ void DisplayMultiplayer::RefreshLanguage()
 {
     if (auto* dplayButton = dynamic_cast<C3DActiveText*>(GetCtrl(IDC_MULTI_DPLAY)))
     {
-        dplayButton->SetText(LocalizeString(IDS_DISP_MULTI_SOCKETS));
+        dplayButton->SetText(FormatNetworkMasterServerAttribution(GetNetworkMasterServer()));
     }
 
     SetSource(_source);

--- a/engine/Poseidon/UI/OptionsUIApp.cpp
+++ b/engine/Poseidon/UI/OptionsUIApp.cpp
@@ -1306,6 +1306,45 @@ Control* DisplayMods::OnCreateCtrl(int type, int idc, const ParamEntry& cls)
     return Display::OnCreateCtrl(type, idc, cls);
 }
 
+DisplayMods::DisplayMods(ControlsContainer* parent) : Display(parent)
+{
+    _enableSimulation = false;
+    _exitWhenClose = -1;
+    Load("RscDisplayMods");
+
+    if (ControlObjectContainer* notebook = dynamic_cast<ControlObjectContainer*>(GetCtrl(IDC_MODS_NOTEBOOK)))
+    {
+        ParamEntry* sourceCls = Res.FindEntry("RscDisplayMods")
+                                    ? (Res >> "RscDisplayMods" >> "Notebook").FindEntry("ButtonSource")
+                                    : nullptr;
+        if (sourceCls != nullptr && sourceCls->IsClass())
+        {
+            static ParamFile s_masterServerLabelCfg;
+            s_masterServerLabelCfg.Clear();
+            ParamClass* cls = s_masterServerLabelCfg.AddClass("ModsMasterServerAttribution");
+            cls->Add("type", CT_3DSTATIC);
+            cls->Add("idc", IDC_MODS_MASTER_SERVER);
+            cls->Add("style", ST_LEFT);
+            cls->Add("text", RString(""));
+            cls->Add("x", 0.025f);
+            cls->Add("y", 0.925f);
+            cls->Add("w", 0.95f);
+            cls->Add("h", 0.045f);
+            cls->Add("selection", RString("display"));
+            cls->Add("angle", 0.0f);
+            cls->SetBase(sourceCls->GetClassInterface());
+
+            Control* ctrl = notebook->LoadControl(*cls);
+            if (C3DStatic* text = dynamic_cast<C3DStatic*>(ctrl))
+            {
+                text->SetText(FormatNetworkMasterServerAttribution(GetNetworkMasterServer()));
+            }
+        }
+    }
+
+    ApplyInitialSort();
+}
+
 void DisplayMods::SeedTestMods(int count)
 {
     CModsList* list = dynamic_cast<CModsList*>(GetCtrl(IDC_MODS_LIST));

--- a/tests/integration/ui/main_menu/mods_catalog.test.sqf
+++ b/tests/integration/ui/main_menu/mods_catalog.test.sqf
@@ -8,6 +8,7 @@ triAssertIncludes [(triVisibleTexts), "MODS"]
 triClick 119
 triAssertEq [(triDisplay), 72]
 triAssertEq [(triControlText 101), "MODS"]
+triAssertIncludes [(triVisibleTexts), "Operated by master.example"]
 triScreenshot "00_mods_screen"
 
 // Reset sort to Name before seeding: sort column persists across test runs in

--- a/tests/integration/ui/main_menu/mods_catalog.test.toml
+++ b/tests/integration/ui/main_menu/mods_catalog.test.toml
@@ -1,1 +1,2 @@
 tags = ["headful"]
+extra_args = ["--master-server", "https://master.example"]

--- a/tests/integration/ui/main_menu/mp_browser.test.sqf
+++ b/tests/integration/ui/main_menu/mp_browser.test.sqf
@@ -15,14 +15,14 @@ triAssertIncludes [(triVisibleTexts), "Ping"]
 triAssertIncludes [(triVisibleTexts), "Cancel"]
 triAssertIncludes [(triVisibleTexts), "Join"]
 triAssertIncludes [(triVisibleTexts), "New"]
-triAssertEq [(triControlText 109), "Implementation: Sockets"]
+triAssertEq [(triControlText 109), "Operated by master.example"]
 triAssertEq [(triControlText 122), "Address: LAN"]
 triAssertEq [(triControlText 107), "Password: No password"]
 triScreenshot "01_mp_server_browser"
 
 // Language switch updates localized status controls.
 triSetLanguage "Czech"
-triAssertEq [(triControlText 109), "Implementace: Sockety"]
+triAssertEq [(triControlText 109), "Operated by master.example"]
 triAssertEq [(triControlText 122), "Adresa: LAN"]
 triAssertEq [(triControlText 107), "Heslo: Bez hesla"]
 triSetLanguage "English"

--- a/tests/integration/ui/main_menu/mp_browser.test.toml
+++ b/tests/integration/ui/main_menu/mp_browser.test.toml
@@ -1,1 +1,2 @@
 tags = ["headful"]
+extra_args = ["--master-server", "https://master.example"]

--- a/tests/unit/engine/Poseidon/Network/test_master_server.cpp
+++ b/tests/unit/engine/Poseidon/Network/test_master_server.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include <Poseidon/Network/NetworkConfig.hpp>
 #include <Poseidon/Network/MasterServerServiceClient.hpp>
 
 using namespace Poseidon;
@@ -101,4 +102,13 @@ TEST_CASE("master service requests carry structured user-agent", "[network][mast
     REQUIRE(request.userAgent.find("CWR-CE/301") == 0);
     REQUIRE(request.userAgent.find("tag=") != std::string::npos);
     REQUIRE(request.userAgent.find("role=client") != std::string::npos);
+}
+
+TEST_CASE("master server attribution label includes the configured endpoint", "[network][master][ui]")
+{
+    REQUIRE(std::string(FormatNetworkMasterServerAttribution("https://master.example")) ==
+            "Operated by master.example");
+    REQUIRE(std::string(FormatNetworkMasterServerAttribution("http://master.example")) == "Operated by master.example");
+    REQUIRE(std::string(FormatNetworkMasterServerAttribution("master.example")) == "Operated by master.example");
+    REQUIRE(std::string(FormatNetworkMasterServerAttribution("")) == "Operated by disabled");
 }


### PR DESCRIPTION
- show the active master-server operator on the Mods and Multiplayer browser screens
- strip http:// and https:// from the displayed endpoint
- reuse the Multiplayer implementation label slot and keep the Mods attribution in the lower-left notebook area

<img width="1298" height="1036" alt="image" src="https://github.com/user-attachments/assets/77927f27-f3e8-486d-af1f-b1939c616cc2" />

<img width="1298" height="1036" alt="image" src="https://github.com/user-attachments/assets/3ab7bb96-d447-45b9-ba3a-f7995a444c82" />
