### PR TITLE
Reject unsafe mission transfer filenames

### DIFF
--- a/engine/Poseidon/Network/NetworkClientOnMessage.cpp
+++ b/engine/Poseidon/Network/NetworkClientOnMessage.cpp
@@ -15,6 +15,7 @@ using namespace Poseidon;
 // #include "strIncl.hpp"
 #include <Poseidon/UI/Locale/StringtableExt.hpp>
 #include <Poseidon/Foundation/Platform/GamePaths.hpp>
+#include <Poseidon/Network/NetworkMissionTransfer.hpp>
 
 #include <Poseidon/AI/ArcadeTemplate.hpp>
 #include <Poseidon/AI/AI.hpp>
@@ -633,16 +634,18 @@ void NetworkClient::OnMessage(int from, NetworkMessage* msg, NetworkMessageType 
             _playerRoles.Resize(0);
 
             // check if mission file is valid
-            RString fullname = _missionHeader.fileDir + _missionHeader.fileName;
-            _missionFileValid = CheckMissionFile(fullname, _missionHeader);
+            const RString missionCacheBasePath =
+                Poseidon::BuildNetworkMissionTransferCacheBasePath(_missionHeader.fileName);
+            RString fullname =
+                missionCacheBasePath.GetLength() > 0 ? _missionHeader.fileDir + _missionHeader.fileName : RString();
+            _missionFileValid = fullname.GetLength() > 0 && CheckMissionFile(fullname, _missionHeader);
             LOG_DEBUG(Network, "[MissionHeader] file='{}' valid={}", (const char*)fullname, _missionFileValid);
 
             if (!_missionFileValid)
             {
                 // check cache
-                RString fullname = RString(GamePaths::Instance().CacheDir().c_str()) +
-                                   RString(GameDirs::MPMissionsCachePath().c_str()) + _missionHeader.fileName;
-                _missionFileValid = CheckMissionFile(fullname, _missionHeader);
+                RString fullname = missionCacheBasePath;
+                _missionFileValid = fullname.GetLength() > 0 && CheckMissionFile(fullname, _missionHeader);
                 LOG_DEBUG(Network, "[MissionHeader] cache='{}' valid={}", (const char*)fullname, _missionFileValid);
             }
 
@@ -724,9 +727,13 @@ void NetworkClient::OnMessage(int from, NetworkMessage* msg, NetworkMessageType 
 
             // Rewrite transfer path to use client's own cache dir
             // (server embeds its absolute CacheDir which differs per-instance)
-            transfer.path = RString(GamePaths::Instance().CacheDir().c_str()) +
-                            RString(GameDirs::MPMissionsCachePath().c_str()) + _missionHeader.fileName +
-                            RString(".pbo");
+            transfer.path = Poseidon::BuildNetworkMissionTransferCachePboPath(_missionHeader.fileName);
+            if (transfer.path.GetLength() == 0)
+            {
+                LOG_WARN(Network, "[NMTTransferMissionFile] rejected unsafe mission file name '{}'",
+                         (const char*)_missionHeader.fileName);
+                break;
+            }
 
             const std::string prefix = GameDirs::MPCurrentPrefix();
             RemoveBank(prefix.c_str());

--- a/engine/Poseidon/Network/NetworkMissionTransfer.cpp
+++ b/engine/Poseidon/Network/NetworkMissionTransfer.cpp
@@ -1,6 +1,7 @@
 #include <Poseidon/Network/NetworkMissionTransfer.hpp>
 
 #include <Poseidon/Foundation/Platform/GamePaths.hpp>
+#include <Poseidon/Foundation/Common/Filenames.hpp>
 #include <Poseidon/Network/Network.hpp>
 #include <Poseidon/IO/Streams/QBStream.hpp>
 #include <Poseidon/Foundation/Algorithms/Crc.hpp>
@@ -37,15 +38,27 @@ bool ValidateNetworkMissionFileOnDisk(const RString& missionPath, int expectedFi
                                              expectedFileCrc);
 }
 
+bool IsSafeNetworkMissionFileName(const char* missionFileName)
+{
+    return missionFileName != nullptr && missionFileName[0] != 0 && IsRelativePath(missionFileName) &&
+           strchr(missionFileName, '/') == nullptr && strchr(missionFileName, '\\') == nullptr;
+}
+
 RString BuildNetworkMissionTransferCacheBasePath(const char* missionFileName)
 {
+    if (!IsSafeNetworkMissionFileName(missionFileName))
+    {
+        return RString();
+    }
+
     return RString(GamePaths::Instance().CacheDir().c_str()) + RString(GameDirs::MPMissionsCachePath().c_str()) +
-           RString(missionFileName != nullptr ? missionFileName : "");
+           RString(missionFileName);
 }
 
 RString BuildNetworkMissionTransferCachePboPath(const char* missionFileName)
 {
-    return BuildNetworkMissionTransferCacheBasePath(missionFileName) + RString(".pbo");
+    const RString basePath = BuildNetworkMissionTransferCacheBasePath(missionFileName);
+    return basePath.GetLength() > 0 ? basePath + RString(".pbo") : RString();
 }
 
 RString BuildNetworkMissionTransferBankPath(const char* transferPath)

--- a/tests/unit/engine/Poseidon/Network/test_network_predicate_parity.cpp
+++ b/tests/unit/engine/Poseidon/Network/test_network_predicate_parity.cpp
@@ -3,6 +3,7 @@
 
 #include <Poseidon/Foundation/platform.hpp>
 #include <Poseidon/Network/NetworkCustomAssets.hpp>
+#include <Poseidon/Network/NetworkMissionTransfer.hpp>
 #include <Poseidon/Network/NetworkPlayerRoleAssignment.hpp>
 #include <Poseidon/Network/NetworkServerAuth.hpp>
 
@@ -261,6 +262,18 @@ TEST_CASE("Transferred custom asset paths are confined to expected temp namespac
     REQUIRE_FALSE(Poseidon::IsSafeNetworkTransferredAssetPath(RString("tmp/players/Al/ice/face.jpg")));
     REQUIRE_FALSE(Poseidon::IsSafeNetworkTransferredAssetPath(RString("tmp/mpmissions/__CUR_MP.pbo")));
     REQUIRE_FALSE(Poseidon::IsSafeNetworkTransferredAssetPath(RString("../outside.bin")));
+}
+
+TEST_CASE("Mission transfer cache paths reject traversal in server-provided mission names",
+          "[network][mission][transfer][security]")
+{
+    REQUIRE(Poseidon::BuildNetworkMissionTransferCachePboPath("co06_clean_sweep.Intro").GetLength() > 0);
+
+    REQUIRE(Poseidon::BuildNetworkMissionTransferCachePboPath("../escape").GetLength() == 0);
+    REQUIRE(Poseidon::BuildNetworkMissionTransferCachePboPath("nested/escape").GetLength() == 0);
+    REQUIRE(Poseidon::BuildNetworkMissionTransferCachePboPath("/tmp/escape").GetLength() == 0);
+    REQUIRE(Poseidon::BuildNetworkMissionTransferCachePboPath("C:/Windows/System32/escape").GetLength() == 0);
+    REQUIRE(Poseidon::BuildNetworkMissionTransferCachePboPath("C:\\Windows\\System32\\escape").GetLength() == 0);
 }
 
 TEST_CASE("Transferred custom asset probe maps semantic asset names to temp paths", "[network][assets]")


### PR DESCRIPTION
Validate server-provided mission filenames before building client cache paths. Mission header validation and mission file transfer receive now skip names that contain traversal, separators, absolute paths, or drive qualifiers instead of passing them to file probes or ReceiveFileSegment.

Regression: PoseidonCoreTests - Mission transfer cache paths reject traversal in server-provided mission names. Without the fix, BuildNetworkMissionTransferCachePboPath("../escape").GetLength() expands to 29 == 0.