### PR TITLE
Prime streamed speech playback immediately

### DIFF
--- a/engine/PoseidonOpenAL/WaveOAL.cpp
+++ b/engine/PoseidonOpenAL/WaveOAL.cpp
@@ -421,6 +421,11 @@ void WaveOAL::OpenStreaming()
 
 bool WaveOAL::PumpDrainUpload()
 {
+    return PumpDrainUpload(true);
+}
+
+bool WaveOAL::PumpDrainUpload(bool kickDecode)
+{
     // pump-thread jobs (1)(2). CALLER HOLDS _sys->_audioMutex (the
     // StreamPumpLoop). Touches only _streaming bookkeeping + the AL buffer queue
     // (never play-state). Returns true (and latches decodeInFlight) when the
@@ -487,6 +492,10 @@ bool WaveOAL::PumpDrainUpload()
     // (3) decision: decode another chunk if there's room and content left. Latch
     // decodeInFlight here (under the lock) so the dtor's wait sees it before we
     // release the lock and the caller decodes.
+    if (!kickDecode)
+    {
+        return false;
+    }
     const bool needMore = !_streaming.eofReached.load(std::memory_order_acquire) &&
                           static_cast<int>(_streaming.queue.Size()) + _streaming.buffersInFlight <
                               ::Poseidon::Audio::StreamingBuffers::kNumBuffers;
@@ -905,7 +914,7 @@ void WaveOAL::Queue(IWave* predecessorBase, int /*repeat*/)
 // Actual playback — called from SoundSystemOAL::Commit()
 void WaveOAL::DoPlay()
 {
-    std::lock_guard<std::recursive_mutex> lk(_sys->_audioMutex);
+    std::unique_lock<std::recursive_mutex> lk(_sys->_audioMutex);
     if (_state.terminated)
         return;
     if (_playing)
@@ -960,6 +969,16 @@ void WaveOAL::DoPlay()
             }
             _loaded = true; // streamed waves "load" by opening AL state
             _loadState.store(static_cast<int>(LoadState::Resident), std::memory_order_release);
+            if (_kind == WaveSpeech && _streaming.buffersInFlight == 0 && _streaming.queue.Size() == 0 &&
+                !_streaming.decodeInFlight.load(std::memory_order_acquire))
+            {
+                _streaming.decodeInFlight.store(true, std::memory_order_release);
+                lk.unlock();
+                DecodeOneChunk();
+                lk.lock();
+                _streaming.decodeInFlight.store(false, std::memory_order_release);
+                PumpDrainUpload(false);
+            }
             UpdateStreamingPlayback(); // kick first chunk immediately
             // Source needs to be playing for AL to consume queued
             // buffers; start it now (will silently play silence

--- a/engine/PoseidonOpenAL/WaveOAL.hpp
+++ b/engine/PoseidonOpenAL/WaveOAL.hpp
@@ -183,6 +183,7 @@ class WaveOAL : public IWave
     // alSourcePause so DoPlay can restore the offset via AL_BYTE_OFFSET on the
     // next Commit — same pattern as Wave8::Play -> SetCurrentPosition(_curPosition).
     void StoreCurrentOffset();
+    bool PumpDrainUpload(bool kickDecode);
 
   public:
     // Diagnostic: live playback offset in seconds.  Reads AL_SEC_OFFSET when

--- a/tests/unit/engine/Poseidon/Audio/test_oal_loopback.cpp
+++ b/tests/unit/engine/Poseidon/Audio/test_oal_loopback.cpp
@@ -7,6 +7,9 @@
 #include <AL/alext.h>
 #include <Poseidon/Audio/Streaming/WaveStream.hpp>
 #include <Poseidon/Audio/Streaming/WaveLoaders.hpp>
+#include <Poseidon/Audio/IAudioSystem.hpp>
+#include <PoseidonOpenAL/SoundSystemOAL.hpp>
+#include <PoseidonOpenAL/WaveOAL.hpp>
 #include "test_fixtures.hpp"
 #include <cmath>
 #include <vector>
@@ -156,6 +159,42 @@ TEST_CASE("OpenAL loopback: device init", "[Audio][integration]")
     std::vector<int16_t> buf;
     dev.Render(buf, 1024);
     CHECK(IsSilence(buf));
+}
+
+TEST_CASE("OpenAL streamed speech primes audio on first commit", "[Audio][integration][streaming][speech]")
+{
+    auto* sys = dynamic_cast<SoundSystemOAL*>(CreateSoundSystemOAL());
+    if (!sys)
+    {
+        SUCCEED("default OpenAL output device unavailable");
+        return;
+    }
+
+    const std::string ogg = GET_FIXTURE("mission_smoke/alpha_scenario.cain/sound/line01.ogg");
+    auto* wave = static_cast<WaveOAL*>(sys->CreateWave(ogg.c_str(), false, true));
+    if (!wave)
+    {
+        delete sys;
+        SKIP("cannot create wave from fixture OGG");
+    }
+    if (!wave->IsStreamed())
+    {
+        wave->Release();
+        delete sys;
+        SKIP("fixture OGG not routed through the streaming path");
+    }
+
+    wave->SetKind(WaveSpeech);
+    wave->Repeat(1);
+    wave->Play();
+    sys->Commit();
+
+    INFO("state=" << static_cast<int>(wave->State()) << " buffersInFlight=" << wave->StreamingState().buffersInFlight);
+    CHECK(wave->StreamingState().buffersInFlight > 0);
+    CHECK(wave->State() == WaveState::Playing);
+
+    wave->Release();
+    delete sys;
 }
 
 TEST_CASE("OpenAL loopback: play WAV fixture produces signal", "[Audio][integration]")


### PR DESCRIPTION
Streamed OGG speech now decodes and uploads its first chunk during the first play commit, so campaign voice lines have queued audio before the asynchronous pump catches up. Long streamed audio keeps the normal pump path.

Regression: OpenAL streamed speech primes audio on first commit. Without the fix, the first commit leaves buffersInFlight=0 and the wave in WaitingDeferred; with the fix, buffersInFlight>0 and the wave is Playing. Verified with PoseidonTests [streaming].