### PR TITLE
Fix mouse input scaling on non-4:3 monitors

### DIFF
--- a/engine/Poseidon/Input/InputProcessingSdl.cpp
+++ b/engine/Poseidon/Input/InputProcessingSdl.cpp
@@ -240,8 +240,17 @@ void ProcessMouse_SDL(DWORD timeDelta)
         clampPtr = &clamp;
     }
 
-    bool markKeyboardTurn =
-        GInput.mouse.Update(GInput.cursor, GInput.gameFocusLost, GInput.lookAroundEnabled, Glob.uiTime, clampPtr);
+    // Default to the reference aspect ratio, override with the actual viewport aspect ratio if available
+    float viewportAspectRatio = MouseState::kBaseAspectRatio;
+    if (::Poseidon::GEngine)
+    {
+        const int viewH = ::Poseidon::GEngine->Height();
+        if (viewH > 0)
+            viewportAspectRatio = static_cast<float>(::Poseidon::GEngine->Width()) / static_cast<float>(viewH);
+    }
+
+    bool markKeyboardTurn = GInput.mouse.Update(GInput.cursor, GInput.gameFocusLost, GInput.lookAroundEnabled,
+                                                Glob.uiTime, clampPtr, viewportAspectRatio);
 
     if (markKeyboardTurn)
         GInput.keyboard.turnLastActive = Glob.uiTime;

--- a/engine/Poseidon/Input/InputProcessingSdl.cpp
+++ b/engine/Poseidon/Input/InputProcessingSdl.cpp
@@ -240,17 +240,26 @@ void ProcessMouse_SDL(DWORD timeDelta)
         clampPtr = &clamp;
     }
 
-    // Default to the reference aspect ratio, override with the actual viewport aspect ratio if available
-    float viewportAspectRatio = MouseState::kBaseAspectRatio;
+    // Aiming spans the full window, so it uses the window aspect ratio
+    // (Width/Height).  The cursor's coordinates are relative to the HUD region,
+    // so it uses that region's aspect ratio (Width2D/Height2D) — this keeps its
+    // speed consistent and unaffected by the HUD width limit.  Both fall back to
+    // the 4:3 reference when the engine size is unavailable.
+    float aimAspectRatio = MouseState::kBaseAspectRatio;
+    float cursorAspectRatio = MouseState::kBaseAspectRatio;
     if (::Poseidon::GEngine)
     {
-        const int viewH = ::Poseidon::GEngine->Height();
-        if (viewH > 0)
-            viewportAspectRatio = static_cast<float>(::Poseidon::GEngine->Width()) / static_cast<float>(viewH);
+        const int winH = ::Poseidon::GEngine->Height();
+        if (winH > 0)
+            aimAspectRatio = static_cast<float>(::Poseidon::GEngine->Width()) / static_cast<float>(winH);
+
+        const int uiH = ::Poseidon::GEngine->Height2D();
+        if (uiH > 0)
+            cursorAspectRatio = static_cast<float>(::Poseidon::GEngine->Width2D()) / static_cast<float>(uiH);
     }
 
     bool markKeyboardTurn = GInput.mouse.Update(GInput.cursor, GInput.gameFocusLost, GInput.lookAroundEnabled,
-                                                Glob.uiTime, clampPtr, viewportAspectRatio);
+                                                Glob.uiTime, clampPtr, cursorAspectRatio, aimAspectRatio);
 
     if (markKeyboardTurn)
         GInput.keyboard.turnLastActive = Glob.uiTime;

--- a/engine/Poseidon/Input/MouseState.cpp
+++ b/engine/Poseidon/Input/MouseState.cpp
@@ -34,7 +34,7 @@ void MouseState::DiscardBuffered()
 }
 
 bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundEnabled, UITime currentTime,
-                        const CursorClamp* clamp, float viewportAspectRatio)
+                        const CursorClamp* clamp, float cursorAspectRatio, float aimAspectRatio)
 {
     // Reset per-frame edge state
     leftToDo = false;
@@ -129,16 +129,22 @@ bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundE
     rightToDo = buttonsToDo[1];
     middleToDo = buttonsToDo[2];
 
-    // Cursor movement, with aspect ratio correction and clamping
-    float moveX = deltaX * (kCursorScaleY / viewportAspectRatio);
+    // Scale horizontal movement by aspect ratio so it feels consistent with
+    // vertical. Aim and the cursor use different aspect ratios because they
+    // measure width differently: aiming spans the full window, but the cursor's
+    // coordinates are relative to the HUD region (even though it can move past
+    // it), so it must use the HUD region's aspect ratio to stay uniform on both axes.
+    float aimMoveX = deltaX * (kCursorScaleY / aimAspectRatio);
+    float cursorMoveX = deltaX * (kCursorScaleY / cursorAspectRatio);
     float moveY = deltaY * kCursorScaleY;
 
-    saturate(moveX, -kCursorLimitX, +kCursorLimitX);
+    saturate(aimMoveX, -kCursorLimitX, +kCursorLimitX);
+    saturate(cursorMoveX, -kCursorLimitX, +kCursorLimitX);
     saturate(moveY, -kCursorLimitY, +kCursorLimitY);
 
     if (gameFocusLost <= 0)
     {
-        cursor.aimDeltaX += moveX;
+        cursor.aimDeltaX += aimMoveX;
         if (reverseY)
             cursor.aimDeltaY -= moveY;
         else
@@ -146,7 +152,7 @@ bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundE
     }
     // The menu cursor can be scaled independently of look (menuCursorScale 1.0
     // == classic: cursor and aim move together).
-    cursor.cursorX += moveX * tuning.menuCursorScale;
+    cursor.cursorX += cursorMoveX * tuning.menuCursorScale;
     cursor.cursorY += moveY * tuning.menuCursorScale;
 
     cursor.aimDeltaZ += kWheelToCursorScale * deltaZ;

--- a/engine/Poseidon/Input/MouseState.cpp
+++ b/engine/Poseidon/Input/MouseState.cpp
@@ -34,7 +34,7 @@ void MouseState::DiscardBuffered()
 }
 
 bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundEnabled, UITime currentTime,
-                        const CursorClamp* clamp)
+                        const CursorClamp* clamp, float viewportAspectRatio)
 {
     // Reset per-frame edge state
     leftToDo = false;
@@ -129,8 +129,8 @@ bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundE
     rightToDo = buttonsToDo[1];
     middleToDo = buttonsToDo[2];
 
-    // Cursor movement (matches Windows logic)
-    float moveX = deltaX * kCursorScaleX;
+    // Cursor movement, with aspect ratio correction and clamping
+    float moveX = deltaX * (kCursorScaleY / viewportAspectRatio);
     float moveY = deltaY * kCursorScaleY;
 
     saturate(moveX, -kCursorLimitX, +kCursorLimitX);

--- a/engine/Poseidon/Input/MouseState.hpp
+++ b/engine/Poseidon/Input/MouseState.hpp
@@ -71,9 +71,14 @@ struct MouseState
     // Process buffered input into state. Writes cursor/aim to shared accumulator.
     // Returns true if mouse turn was active AND lookAround was enabled
     // (caller should mark keyboard turn active in that case — cross-device concern).
+    // cursorAspectRatio scales the 2D cursor (its coordinates are relative to
+    // the HUD region); aimAspectRatio scales the 3D aim (uses the full window).
+    // These aspect ratios differ only when the HUD width limit shrinks the UI on
+    // a wide screen.
     bool Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundEnabled,
                 Foundation::UITime currentTime, const CursorClamp* clamp,
-                float viewportAspectRatio = kBaseAspectRatio);
+                float cursorAspectRatio = kBaseAspectRatio,
+                float aimAspectRatio = kBaseAspectRatio);
 
     // Flush buffered input and reset per-frame deltas.
     void FlushAndReset();
@@ -107,7 +112,7 @@ struct MouseState
     static constexpr int kDoubleClickWindowMs = 400;
     // The original game assumes a 4:3 aspect ratio for mouse input, with default scales of X / 200 and Y / 150.
     // To maintain roughly the same speed while adjusting for the actual aspect ratio, we keep the Y scale fixed
-    // and derive the X scale from it and the viewport aspect ratio passed to Update().
+    // and derive the X scale from it and the aspect ratios passed to Update() (see Update for the cursor/aim split).
     static constexpr float kCursorScaleY = 1.0f / 150.0f;
     static constexpr float kCursorLimitX = 0.6f;
     static constexpr float kCursorLimitY = 0.4f;

--- a/engine/Poseidon/Input/MouseState.hpp
+++ b/engine/Poseidon/Input/MouseState.hpp
@@ -33,6 +33,9 @@ struct MouseState
     float sensitivityX = 1.0f;
     float sensitivityY = 1.0f;
 
+    // Reference aspect ratio (4:3) the cursor scales were tuned for
+    static constexpr float kBaseAspectRatio = 4.0f / 3.0f;
+
     // Config
     bool reverseY = false;
     bool buttonsReversed = false;
@@ -69,7 +72,8 @@ struct MouseState
     // Returns true if mouse turn was active AND lookAround was enabled
     // (caller should mark keyboard turn active in that case — cross-device concern).
     bool Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundEnabled,
-                Foundation::UITime currentTime, const CursorClamp* clamp);
+                Foundation::UITime currentTime, const CursorClamp* clamp,
+                float viewportAspectRatio = kBaseAspectRatio);
 
     // Flush buffered input and reset per-frame deltas.
     void FlushAndReset();
@@ -101,7 +105,9 @@ struct MouseState
   private:
     static constexpr int kButtonBufferSize = 16;
     static constexpr int kDoubleClickWindowMs = 400;
-    static constexpr float kCursorScaleX = 1.0f / 200.0f;
+    // The original game assumes a 4:3 aspect ratio for mouse input, with default scales of X / 200 and Y / 150.
+    // To maintain roughly the same speed while adjusting for the actual aspect ratio, we keep the Y scale fixed
+    // and derive the X scale from it and the viewport aspect ratio passed to Update().
     static constexpr float kCursorScaleY = 1.0f / 150.0f;
     static constexpr float kCursorLimitX = 0.6f;
     static constexpr float kCursorLimitY = 0.4f;


### PR DESCRIPTION
In base OFP, mouse movement is scaled by fixed `kCursorScaleX` and `kCursorScaleY` values, 200 and 150 respectively. The game uses normalized coordinates for the viewport, where coordinates range from -1 to 1 in both axis. So this multiplication scales the movements down to suit the scale, but they also compensate for the aspect ratio, so that mouse movements are even in both directions, even though viewport width and height are not the same. The constants were picked so that they compensate for 4:3 aspect ratio monitors; 200/150 = 4/3 = 1.333...

For other aspect ratios, this code is simply wrong. While movement in the Y direction is unchanged, for widescreen monitors it causes horizontal movement to get faster and faster with wider screens. Here's a table:

| Display | Aspect | Error factor (H vs V) | Horizontal too fast by |
|---------|--------|-----------------------|------------------------|
| 4:3     | 1.333  | 1.000                 | 0% (correct)           |
| 16:9    | 1.778  | 1.333                 | +33%                   |
| 21:9    | 2.333  | 1.750                 | +75%                   |
| 32:9    | 3.556  | 2.667                 | +167%                  |

This PR fixes the issue by computing the actual aspect ratio during input processing, and uses it to compute the correct X scale value. Y scale is kept at the previous value of 150.

---

Edit 2026-07-06: More fixes.

There was a further problem with the original fix. While it did fix mouse input consistency for aiming, there was a further issue affecting 2D cursors. The problem was that I had assumed 2D cursors use coordinates ranging between -1 and +1, but it's actually more complex than that. The HUD width limit changes the meaning of those values; -1 is the left edge of the aspect ratio limited HUD, +1 is the right edge and importantly, coordinates can actually go beyond that. The cursor clamping code would have revealed this to me earlier.

| HUD width limit (band on a 32:9 window) | uiTopLeftX | clamp.minX | clamp.maxX |
| --- | --- | --- | --- |
| Off | 0.0000 | −1.000 | +1.000 |
| 21:9 | 0.1719 | −1.524 | +1.524 |
| 16:9 | 0.2500 | −2.000 | +2.000 |
| 4:3 | 0.3125 | −2.667 | +2.667 |

So all in all: we have to normalize aim / camera movement input with the actual aspect ratio, and the cursor input with HUD width limit's aspect ratio.