### PR TITLE
Make map edge scrolling frame rate independent

### DIFF
--- a/engine/Poseidon/UI/DisplayUIMultiplayerWizard.cpp
+++ b/engine/Poseidon/UI/DisplayUIMultiplayerWizard.cpp
@@ -935,33 +935,7 @@ void DisplayWizardMap::OnSimulate(EntityAI* vehicle)
         float mouseY = 0.5 + InputSubsystem::Instance().GetCursorY() * 0.5;
 
         // automatic map movement on edges
-        float dif = 0.02 - mouseX;
-        if (dif > 0)
-        {
-            _map->ScrollX(0.003 * exp(dif * 100.0f));
-        }
-        else
-        {
-            dif = mouseX - 0.98;
-            if (dif > 0)
-            {
-                _map->ScrollX(-0.003 * exp(dif * 100.0f));
-            }
-        }
-
-        dif = 0.02 - mouseY;
-        if (dif > 0)
-        {
-            _map->ScrollY(0.003 * exp(dif * 100.0f));
-        }
-        else
-        {
-            dif = mouseY - 0.98;
-            if (dif > 0)
-            {
-                _map->ScrollY(-0.003 * exp(dif * 100.0f));
-            }
-        }
+        _map->ScrollOnEdges(mouseX, mouseY);
 
         IControl* ctrl = GetCtrl(mouseX, mouseY);
         if (ctrl && ctrl == _map)

--- a/engine/Poseidon/UI/Map/UIMap.cpp
+++ b/engine/Poseidon/UI/Map/UIMap.cpp
@@ -371,6 +371,7 @@ CStaticMap::CStaticMap(ControlsContainer* parent, int idc, const ParamEntry& cls
 
     _moveKey = 0;
     _mouseKey = 0;
+    _edgeScrollLast = Glob.uiTime;
 
     _scaleMin = scaleMin;
     _scaleMax = scaleMax;
@@ -2457,6 +2458,51 @@ void CStaticMap::ScrollY(float dif)
 {
     _mapY += dif;
     SaturateY(_mapY);
+}
+
+void CStaticMap::ScrollOnEdges(float mouseX, float mouseY)
+{
+    // The edge scroll step used to be applied once per OnSimulate, so it scaled
+    // directly with the framerate.
+    // We'll assume a target frame rate of 60 FPS, and scale the step accordingly.
+    const float refFrameTime = 1.0f / 60.0f;
+    float dt = Glob.uiTime - _edgeScrollLast;
+    _edgeScrollLast = Glob.uiTime;
+    // Limit scroll speed to avoid excessive movement during lag spikes, alt-tab, etc.
+    saturate(dt, 0.0f, 0.1f);
+    float scale = dt / refFrameTime;
+
+    saturate(mouseX, 0, 1);
+    saturate(mouseY, 0, 1);
+
+    // Extracted from DisplayWizardMap::OnSimulate and DisplayMap::OnSimulate
+    float dif = 0.02f - mouseX;
+    if (dif > 0)
+    {
+        ScrollX(scale * 0.003f * exp(dif * 100.0f));
+    }
+    else
+    {
+        dif = mouseX - 0.98f;
+        if (dif > 0)
+        {
+            ScrollX(-scale * 0.003f * exp(dif * 100.0f));
+        }
+    }
+
+    dif = 0.02f - mouseY;
+    if (dif > 0)
+    {
+        ScrollY(scale * 0.003f * exp(dif * 100.0f));
+    }
+    else
+    {
+        dif = mouseY - 0.98f;
+        if (dif > 0)
+        {
+            ScrollY(-scale * 0.003f * exp(dif * 100.0f));
+        }
+    }
 }
 
 void CStaticMap::SetVisibleRect(float x, float y, float w, float h)

--- a/engine/Poseidon/UI/Map/UIMapBase.hpp
+++ b/engine/Poseidon/UI/Map/UIMapBase.hpp
@@ -162,6 +162,7 @@ public:
 
 	Poseidon::Foundation::UITime _moveStart;
 	Poseidon::Foundation::UITime _moveLast;
+	Poseidon::Foundation::UITime _edgeScrollLast;
 	unsigned _moveKey;
 	unsigned _mouseKey;
 
@@ -295,6 +296,7 @@ public:
 
 	void ScrollX(float dif);
 	void ScrollY(float dif);
+	void ScrollOnEdges(float mouseX, float mouseY);
 
 	bool IsShowingIds() const {return _showIds;}
 	void ShowIds(bool show = true) {_showIds = show;}

--- a/engine/Poseidon/UI/Map/UIMapDisplayBriefing.cpp
+++ b/engine/Poseidon/UI/Map/UIMapDisplayBriefing.cpp
@@ -1611,33 +1611,7 @@ void DisplayMap::OnSimulate(EntityAI* vehicle)
         saturate(mouseY, 0, 1);
 
         // automatic map movement on edges
-        float dif = 0.02 - mouseX;
-        if (dif > 0)
-        {
-            _map->ScrollX(0.003 * exp(dif * 100.0f));
-        }
-        else
-        {
-            dif = mouseX - 0.98;
-            if (dif > 0)
-            {
-                _map->ScrollX(-0.003 * exp(dif * 100.0f));
-            }
-        }
-
-        dif = 0.02 - mouseY;
-        if (dif > 0)
-        {
-            _map->ScrollY(0.003 * exp(dif * 100.0f));
-        }
-        else
-        {
-            dif = mouseY - 0.98;
-            if (dif > 0)
-            {
-                _map->ScrollY(-0.003 * exp(dif * 100.0f));
-            }
-        }
+        _map->ScrollOnEdges(mouseX, mouseY);
 
         IControl* ctrl = GetCtrl(mouseX, mouseY);
         if (ctrl && ctrl == _map)


### PR DESCRIPTION
Map views scroll when the player hovers over their edges. This worked fine in 2001 when everyone had a Pentium or something, but modern computers can run OFP at a very good framerate (at least in empty maps with the draw distance turned down 😄). The map scrolling logic is called in `OnSimulate`, which runs at the full frame rate, causing the map to scroll way too fast on fast PCs.

This introduces a delta time to the scrolling logic, which is used to scale the movement to make it work consistently independent of frame rate. It also unifies the copy-pasted code across `DisplayMap` and `DisplayWizardMap`.
