### PR TITLE
Fix HUD width limit setting affecting 3D FOV

### DIFF
--- a/engine/Poseidon/UI/Settings/AspectRatio.cpp
+++ b/engine/Poseidon/UI/Settings/AspectRatio.cpp
@@ -185,7 +185,7 @@ PolicyResult ResolvePolicy(const PolicyInput& input)
             result.effectiveRatio = clampRatio;
     }
 
-    result.settings = BuildSettingsForRatio(result.effectiveRatio);
+    result.settings = BuildSettingsForRatio(result.viewportRatio);
     if (result.viewportRatio > result.effectiveRatio)
     {
         ApplyCenteredUiBand(result.settings, result.effectiveRatio, input.viewportWidth, input.viewportHeight);

--- a/tests/unit/engine/Poseidon/UI/Settings/test_aspectRatio.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_aspectRatio.cpp
@@ -159,7 +159,7 @@ TEST_CASE("AspectRatio Modern clamps ultrawide gameplay framing", "[Settings][As
 
     CHECK(result.viewportRatio == Catch::Approx(32.0f / 9.0f));
     CHECK(result.effectiveRatio == Catch::Approx(21.0f / 9.0f));
-    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (21.0f / 9.0f)));
+    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (32.0f / 9.0f)));
     CHECK(result.settings.uiTopLeftX > 0.0f);
 }
 
@@ -169,14 +169,14 @@ TEST_CASE("AspectRatio Modern clamp uses the selected HUD width band", "[Setting
 
     AspectRatio::PolicyResult result = AspectRatio::ResolvePolicy(input);
     CHECK(result.effectiveRatio == Catch::Approx(21.0f / 9.0f));
-    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (21.0f / 9.0f)));
+    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (32.0f / 9.0f)));
     CHECK(result.settings.uiTopLeftX == Catch::Approx(0.171875f));
     CHECK(result.settings.uiBottomRightX == Catch::Approx(0.828125f));
 
     input.ultrawideClamp = AspectRatio::Clamp16x9;
     result = AspectRatio::ResolvePolicy(input);
     CHECK(result.effectiveRatio == Catch::Approx(16.0f / 9.0f));
-    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (16.0f / 9.0f)));
+    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (32.0f / 9.0f)));
     CHECK(result.settings.uiTopLeftX == Catch::Approx(0.25f));
     CHECK(result.settings.uiBottomRightX == Catch::Approx(0.75f));
 }

--- a/tests/unit/engine/Poseidon/UI/Settings/test_presentation.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_presentation.cpp
@@ -19,11 +19,13 @@ TEST_CASE("Presentation: 16:9 resolves full-width undistorted UI", "[Settings][P
     CHECK(s.worldRight == Catch::Approx(1.0f));
 }
 
-TEST_CASE("Presentation: 32:9 Adaptive 21:9 clamps world FOV and HUD width", "[Settings][Presentation]")
+TEST_CASE("Presentation: 32:9 Adaptive 21:9 keeps full-width world FOV, clamps HUD width", "[Settings][Presentation]")
 {
     Poseidon::Presentation::SetPolicy(Poseidon::AspectRatio::Modern, Poseidon::AspectRatio::Clamp21x9);
     const Poseidon::AspectRatio::Settings s = Poseidon::Presentation::Resolve(3840, 1080);
-    CHECK(s.leftFOV == Catch::Approx(0.75f * (21.0f / 9.0f))); // FOV capped at the clamp
+    CHECK(s.leftFOV == Catch::Approx(0.75f * (32.0f / 9.0f)));
+    CHECK(s.worldLeft == Catch::Approx(0.0f));
+    CHECK(s.worldRight == Catch::Approx(1.0f));
     const float uiW = (s.uiBottomRightX - s.uiTopLeftX) * 3840.0f;
     const float uiH = (s.uiBottomRightY - s.uiTopLeftY) * 1080.0f;
     CHECK(uiW / uiH == Catch::Approx(21.0f / 9.0f).epsilon(0.001f));
@@ -36,7 +38,7 @@ TEST_CASE("Presentation: 32:9 Adaptive 16:9 uses the narrower HUD width limit", 
     Poseidon::Presentation::SetPolicy(Poseidon::AspectRatio::Modern, Poseidon::AspectRatio::Clamp16x9);
     const Poseidon::AspectRatio::Settings s = Poseidon::Presentation::Resolve(3840, 1080);
 
-    CHECK(s.leftFOV == Catch::Approx(0.75f * (16.0f / 9.0f)));
+    CHECK(s.leftFOV == Catch::Approx(0.75f * (32.0f / 9.0f)));
     CHECK(s.uiTopLeftX == Catch::Approx(0.25f));
     CHECK(s.uiBottomRightX == Catch::Approx(0.75f));
 


### PR DESCRIPTION
The "HUD width limit" setting is presumably supposed to do just that: limit the HUD to a certain aspect ratio, which is a common setting in modern games (to enable comfortable use of ultrawide monitors). However likely due to oversight, in current `main` it actually affects the 3D FOV as well.

Before this PR, at roughly 32:9 aspect ratio:

Off
<img width="5120" height="1417" alt="PoseidonGame_j9XN2vGAtT" src="https://github.com/user-attachments/assets/ea87aff1-dd21-4003-8ea1-14e061ea075a" />
21:9
<img width="5120" height="1417" alt="PoseidonGame_4ehxRQRdjl" src="https://github.com/user-attachments/assets/cdc70cdf-3267-4be9-8306-2afb69608491" />
16:9
<img width="5120" height="1417" alt="PoseidonGame_5wNQSwTrup" src="https://github.com/user-attachments/assets/6517c1b3-2bbd-43a5-aaf3-c828de5a371e" />

After this PR:

16:9 (and all the other settings)
<img width="5120" height="1417" alt="PoseidonGame_iEZne7DpHw" src="https://github.com/user-attachments/assets/b6c435c4-5960-40ea-af09-bb2cfdd97f04" />

This also applies to the in-game camera, but the main menu laptop is an obvious indicator.

The issue was fixed by using the actual viewport ratio for the `BuildSettingsForRatio` call, which calculates the FOV. The configured aspect ratio is still used to override the UI size, so the feature should work as intended (though the UI still looks ugly and stretched at any settings other than Off and 16:9).