### PR TITLE
Add step-by-step install/build guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ In short: the code is free software, the name is not, and the game data comes se
 
 ## Quick Start
 
+### Step-by-step Guides
+
+There are installation/build guides for [Linux](docs/build/linux.md) and
+[Windows](docs/build/windows.md).
+
 ### Development Builds
 
 The quickest way to get the game or server executables is to download the CI builds: <https://ofpisnotdead-com.github.io/CWR-CE-builds/>
@@ -33,8 +38,14 @@ The quickest way to get the game or server executables is to download the CI bui
 - [Ninja](https://ninja-build.org/)
 - [vcpkg](https://vcpkg.io/)
 
-On Windows, run `winget install Kitware.CMake LLVM.LLVM Ninja-build.Ninja`
-and follow the instructions for [setting up
+On Windows, run the following commands:
+
+```
+winget install Ccache.Ccache Kitware.CMake LLVM.LLVM Ninja-build.Ninja PolarGoose.ClangFormat
+winget install Microsoft.VisualStudio.BuildTools --custom '"--add Microsoft.VisualStudio.Workload.VCTools;includeRecommended"'
+```
+
+Then follow the instructions for [setting up
 vcpkg](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-powershell)
 to get the required software.
 
@@ -61,6 +72,7 @@ Copy game binaries from `dist/` into [Steam Demo folder](https://store.steampowe
 - [Master server tools](mserver/README.md) - Rust service and CLI crates
 - [Tests](tests/README.md) - test source trees; CI currently compiles them only
 - `cmake/` - presets, toolchains, vcpkg triplets, and overlay ports
+- `docs/` - auxiliary documentation
 - `docker/` - container support for service and runtime environments
 - `packages/` - ignored local game data staging area
 - `resources/` - application icon resources

--- a/docs/build/linux.md
+++ b/docs/build/linux.md
@@ -1,0 +1,113 @@
+# Installing on Linux
+
+You can install CWR-CE on GNU/Linux by [downloading the development builds](#development-builds) or by [building it yourself](#building-manually), then [moving the binaries into a directory with the game data](#install-binaries-alongside-game-data).
+
+## Development builds
+
+The quickest way to play the game is to download pre-built binaries. Changes to CWR-CE are automatically compiled and tested, and the resulting CI builds are published on the following webpage: <https://ofpisnotdead-com.github.io/CWR-CE-builds/#main>
+
+On this page, the download links for the latest build are sorted to the top of the list. Among the download options, you'll find:
+
+- `Linux-x64-rwdi-Game` - The full game. Intended to be run with the [Steam game data](https://store.steampowered.com/app/65790/Arma_Cold_War_Assault_Remastered/), but you may use it with the [Steam demo data](https://store.steampowered.com/app/4819000/Arma_Cold_War_Assault_Remastered_Demo/) to unlock usage of additional features (like the editor).
+- `Linux-x64-rwdi-GameDemo` - The game demo, with fewer features. Intended to be run with the [Steam demo data](https://store.steampowered.com/app/4819000/Arma_Cold_War_Assault_Remastered_Demo/).
+- `Linux-x64-rwdi-Server` - The multiplayer server.
+
+After downloading the binaries you are interested in, you must [install them](#install-binaries-alongside-game-data).
+
+## Building manually
+
+You may want to compile the code yourself, such as when testing changes made in local development or when you need binaries that aren't published elsewhere. In this case, [CMake](https://cmake.org/) presets can be used to quickly configure and build the project.
+
+### Installing the dependencies
+
+Before anything can be built, you must ensure that the dependencies are installed. See the section below for steps that correspond to your Linux distribution.
+
+#### Arch Linux
+
+Run the following command in a terminal (with elevated privildges, such as with `su` or `sudo`) to install the dependencies:
+
+```shell
+pacman -S autoconf-archive automake ccache clang git libtool libxcursor libxinerama libxkbcommon libxrandr libxtst make opengl-driver pkgconf python vcpkg wayland wayland-protocols
+```
+
+After this has completed successfully, you will need to follow the instructions in the post-install script to complete the setup for vcpkg:
+
+```shell
+# Set up the environment variables without needing to load a new environment
+source /etc/profile.d/vcpkg.sh
+# Install vcpkg recipes
+git clone https://github.com/microsoft/vcpkg $VCPKG_ROOT
+```
+
+#### Debian/Ubuntu
+
+Run the following command in a terminal to install most of the dependencies:
+
+```shell
+sudo apt-get install autoconf-archive automake ccache clang clang-format cmake curl git libtool libltdl-dev libgl1-mesa-dev libwayland-dev libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev libxtst-dev make ninja-build pkg-config python3 python3-venv tar unzip wayland-protocols zip
+```
+
+After this has completed successfully, you will need to run the following commands to setup vcpkg:
+
+```shell
+git clone https://github.com/microsoft/vcpkg ~/.local/share/vcpkg
+cd ~/.local/share/vcpkg; ./bootstrap-vcpkg.sh
+```
+
+Once vcpkg is set up, the environment variables need to be set:
+
+```
+echo "# Configure vcpkg\nexport VCPKG_ROOT=$HOME/.local/share/vcpkg\nexport PATH=$PATH:$VCPKG_ROOT" >> ~/.bash_profile
+source ~/.bash_profile
+```
+
+#### Fedora
+
+Run the following command in a terminal to install the dependencies:
+
+```shell
+sudo dnf install autoconf-archive ccache clang clang-tools-extra git libGL-devel libtool libtool-ltdl-devel libX11-devel libXcursor-devel libXext-devel libXi-devel libXinerama-devel libxkbcommon-devel libXrandr-devel libXtst-devel perl-FindBin perl-IPC-Cmd perl-Time-Piece pkgconf python3 vcpkg wayland-devel wayland-protocols-devel
+```
+
+After this has completed successfully, you will need to follow the instructions in the `README.fedora` file to complete the setup for vcpkg:
+
+```shell
+# Set up the environment variables without needing to load a new environment
+source /etc/profile.d/vcpkg.sh 
+# Install vcpkg recipes
+git clone https://github.com/microsoft/vcpkg $VCPKG_ROOT
+```
+
+### Downloading the repository
+
+The CWR-CE [source code repository](https://github.com/ofpisnotdead-com/CWR-CE) can be cloned with [Git](https://git-scm.com/) using the following command, run in a terminal:
+
+```shell
+cd ~; git clone https://github.com/ofpisnotdead-com/CWR-CE.git
+```
+
+Before moving on to the [compiling steps](#compiling), we should make sure we are working in the new directory with the CWR-CE source code:
+
+```shell
+cd CWR-CE
+```
+
+### Compiling
+
+The `linux-x64-clang-rwdi` preset provides a simpler path for building most of the executable targets with debug symbols. To use the preset, run the following commands in a terminal:
+
+```shell
+cmake --preset linux-x64-clang-rwdi
+cmake --build build/linux-x64-clang-rwdi
+```
+
+Note that these may take a while, especially the first time they are run. Afterwards, the binaries will be available in the `dist/linux-x64-clang-rwdi` directory. For example, `dist/linux-x64-clang-rwdi/PoseidonGame` is the full game binary.
+
+## Install binaries alongside game data
+
+The game expects to be run alongside remastered game data, including the [Steam game](https://store.steampowered.com/app/65790/Arma_Cold_War_Assault_Remastered/) and [Steam demo](https://store.steampowered.com/app/4819000/Arma_Cold_War_Assault_Remastered_Demo/). To install the binaries, you must:
+
+1. Install the [game](https://store.steampowered.com/app/65790/Arma_Cold_War_Assault_Remastered/) or [demo](https://store.steampowered.com/app/4819000/Arma_Cold_War_Assault_Remastered_Demo/) within Steam.
+2. Copy the binaries into the `Remastered` folder in the game's files, or the top level of the demo's downloaded files. If you aren't sure how to find these, follow the instructions in the [Steam Support article for finding bonus content](https://help.steampowered.com/en/faqs/view/720F-F7D3-0EB2-059F).
+
+After the binaries are in place, they may be run directly, or you may press play in Steam.

--- a/docs/build/win.md
+++ b/docs/build/win.md
@@ -1,0 +1,81 @@
+# Installing on Windows
+
+You can install CWR-CE on Windows by [downloading the development builds](#development-builds) or by [building it yourself](#building-manually), then [moving the binaries into a directory with the game data](#install-binaries-alongside-game-data).
+
+## Development builds
+
+The quickest way to play the game is to download pre-built binaries. Changes to CWR-CE are automatically compiled and tested, and the resulting CI builds are published on the following webpage: <https://ofpisnotdead-com.github.io/CWR-CE-builds/#main>
+
+On this page, the download links for the latest build are sorted to the top of the list. Among the download options, you'll find:
+
+- `Linux-x64-rwdi-Game` - The full game. Intended to be run with the [Steam game data](https://store.steampowered.com/app/65790/Arma_Cold_War_Assault_Remastered/), but you may use it with the [Steam demo data](https://store.steampowered.com/app/4819000/Arma_Cold_War_Assault_Remastered_Demo/) to unlock usage of additional features (like the editor).
+- `Windows-x64-rwdi-GameDemo` - The game demo, with fewer features. Intended to be run with the [Steam demo data](https://store.steampowered.com/app/4819000/Arma_Cold_War_Assault_Remastered_Demo/).
+- `Windows-x64-rwdi-Server` - The multiplayer server.
+
+After downloading the binaries you are interested in, you must [install them](#install-binaries-alongside-game-data).
+
+## Building manually
+
+You may want to compile the code yourself, such as when testing changes made in local development or when you need binaries that aren't published elsewhere. In this case, [CMake](https://cmake.org/) presets can be used to quickly configure and build the project.
+
+### Installing the dependencies
+
+Before anything can be built, you must ensure that the dependencies are installed.
+
+First, run the following commands in PowerShell to install most of the dependencies:
+
+```powershell
+winget install Ccache.Ccache Git.Git Kitware.CMake LLVM.LLVM Ninja-build.Ninja PolarGoose.ClangFormat
+winget install Microsoft.VisualStudio.BuildTools --custom '"--add Microsoft.VisualStudio.Workload.VCTools;includeRecommended"'
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+```
+
+After this has completed successfully, you will need to follow the instructions for [setting up vcpkg](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-powershell#1---set-up-vcpkg):
+
+```powershell
+git clone https://github.com/microsoft/vcpkg.git $env:USERPROFILE\vcpkg
+cd $env:USERPROFILE\vcpkg; .\bootstrap-vcpkg.bat
+```
+
+Once vcpkg is set up, the environment variables need to be set:
+
+```powershell
+$env:VCPKG_ROOT = "$env:USERPROFILE\vcpkg"
+$env:PATH = "$env:VCPKG_ROOT;$env:PATH"
+```
+
+Note that these commands will only set the vcpkg environment variables for the current session. For the environment variables to persist, they must be set in the Windows System Environment Variables panel.
+
+### Downloading the repository
+
+The CWR-CE [source code repository](https://github.com/ofpisnotdead-com/CWR-CE) can be cloned with [Git](https://git-scm.com/) using the following command, run in PowerShell:
+
+```powershell
+cd $env:USERPROFILE; git clone https://github.com/ofpisnotdead-com/CWR-CE.git
+```
+
+Before moving on to the [compiling steps](#compiling), we should make sure we are working in the new directory with the CWR-CE source code:
+
+```powershell
+cd CWR-CE
+```
+
+### Compiling
+
+The `win-x64-clang-rwdi` preset provides a simpler path for building most of the executable targets with debug symbols. To use the preset, run the following commands in PowerShell:
+
+```powershell
+cmake --preset win-x64-clang-rwdi
+cmake --build build/win-x64-clang-rwdi
+```
+
+Note that these may take a while, especially the first time they are run. Afterwards, the binaries will be available in the `dist\win-x64-clang-rwdi` directory. For example, `dist\win-x64-clang-rwdi\PoseidonGame.exe` is the full game binary.
+
+## Install binaries alongside game data
+
+The game expects to be run alongside remastered game data, including the [Steam game](https://store.steampowered.com/app/65790/Arma_Cold_War_Assault_Remastered/) and [Steam demo](https://store.steampowered.com/app/4819000/Arma_Cold_War_Assault_Remastered_Demo/). To install the binaries, you must:
+
+1. Install the [game](https://store.steampowered.com/app/65790/Arma_Cold_War_Assault_Remastered/) or [demo](https://store.steampowered.com/app/4819000/Arma_Cold_War_Assault_Remastered_Demo/) within Steam.
+2. Copy the binaries into the `Remastered` folder in the game's files, or the top level of the demo's downloaded files. If you aren't sure how to find these, follow the instructions in the [Steam Support article for finding bonus content](https://help.steampowered.com/en/faqs/view/720F-F7D3-0EB2-059F).
+
+After the binaries are in place, they may be run directly, or you may press play in Steam.


### PR DESCRIPTION
These guides are standalone Markdown files in `docs/builds`, and are available for both Windows and Linux. I was trying to aim for users who are somewhat familiar with computers (can run programs and copy and paste things) but may have zero experience with compiling/programming, and giving these users just enough to get started.

I did not test these instructions myself from scratch, and I don't have a Windows system (so that part should be reviewed with particular scrutiny), but I do believe them to be relatively correct.

This also updates a few parts of the README to correspond with the additions.

## Caveats

~~It might be worth adding a Debian/Ubuntu section for the dependencies on Linux, but I don't have a system readily available and didn't feel like figuring out the exact vcpkg steps (EDIT: seems like it is basically the same as on Windows).~~ Debian/Ubuntu instructions are now part of this PR.

~~vcpkg installation on Windows is a bit messy. It could be that this section, among others, benefit from a more opinionated set of instructions.~~ It is still a bit messy (this is inherent with vcpkg), but it is more opinionated now (doesn't require the user to make changes), and should probably just work when exactly following these steps.

There are likely edge cases where these commands fail and these instructions don't account for. I am not certain it is appropriate to try to address all of these.

## Rendered

For at least as long as this PR is open, the Markdown can be viewed as it is rendered on GitHub here:

- [Linux](https://github.com/her001/CWR-CE/blob/a68d83d09fef816fa227af3f257a52a82c4180b1/docs/build/linux.md)
- [Windows](https://github.com/her001/CWR-CE/blob/a68d83d09fef816fa227af3f257a52a82c4180b1/docs/build/win.md)
- [README](https://github.com/her001/CWR-CE/blob/a68d83d09fef816fa227af3f257a52a82c4180b1/README.md)