### PR TITLE
AIGroupImpl: skip msgCmd->GetFrom() == this check on shared center radio

### DIFF
--- a/engine/Poseidon/AI/AIGroupImpl.cpp
+++ b/engine/Poseidon/AI/AIGroupImpl.cpp
@@ -88,7 +88,10 @@ bool AIGroup::CommandSent(bool channelCenter)
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        CheckMsgCmdFrom(this, msgCmd, "CommandSent(bool)/FindPrevMessage");
+        if (!channelCenter)
+        {
+            CheckMsgCmdFrom(this, msgCmd, "CommandSent(bool)/FindPrevMessage");
+        }
         if (msgCmd->IsToMainSubgroup())
         {
             return true;
@@ -102,7 +105,10 @@ bool AIGroup::CommandSent(bool channelCenter)
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        CheckMsgCmdFrom(this, msgCmd, "CommandSent(bool)/GetActualMessage");
+        if (!channelCenter)
+        {
+            CheckMsgCmdFrom(this, msgCmd, "CommandSent(bool)/GetActualMessage");
+        }
         if (msgCmd->IsToMainSubgroup())
         {
             return true;
@@ -155,7 +161,10 @@ bool AIGroup::CommandSent(Command::Message message, bool channelCenter)
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        CheckMsgCmdFrom(this, msgCmd, "CommandSent(msg,bool)/FindPrevMessage");
+        if (!channelCenter)
+        {
+            CheckMsgCmdFrom(this, msgCmd, "CommandSent(msg,bool)/FindPrevMessage");
+        }
         if (msgCmd->GetCmdMessage() == message)
         {
             return true;
@@ -168,7 +177,10 @@ bool AIGroup::CommandSent(Command::Message message, bool channelCenter)
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        CheckMsgCmdFrom(this, msgCmd, "CommandSent(msg,bool)/GetActualMessage");
+        if (!channelCenter)
+        {
+            CheckMsgCmdFrom(this, msgCmd, "CommandSent(msg,bool)/GetActualMessage");
+        }
         if (msgCmd->GetCmdMessage() == message)
         {
             return true;
@@ -216,7 +228,10 @@ bool AIGroup::CommandSent(AIUnit* to, Command::Message message, bool channelCent
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        CheckMsgCmdFrom(this, msgCmd, "CommandSent(to,msg,bool)/FindPrevMessage");
+        if (!channelCenter)
+        {
+            CheckMsgCmdFrom(this, msgCmd, "CommandSent(to,msg,bool)/FindPrevMessage");
+        }
         if (msgCmd->IsTo(to) && msgCmd->GetCmdMessage() == message)
         {
             return true;
@@ -229,7 +244,10 @@ bool AIGroup::CommandSent(AIUnit* to, Command::Message message, bool channelCent
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        CheckMsgCmdFrom(this, msgCmd, "CommandSent(to,msg,bool)/GetActualMessage");
+        if (!channelCenter)
+        {
+            CheckMsgCmdFrom(this, msgCmd, "CommandSent(to,msg,bool)/GetActualMessage");
+        }
         if (msgCmd->IsTo(to) && msgCmd->GetCmdMessage() == message)
         {
             return true;

--- a/engine/Poseidon/AI/AIGroupImpl.cpp
+++ b/engine/Poseidon/AI/AIGroupImpl.cpp
@@ -41,6 +41,22 @@ namespace Poseidon
 {
 using namespace Foundation;
 
+// Diagnostic for msgCmd->GetFrom() == this invariant violations in the radio
+// queue scans below. Returns the result of the check so call sites can be
+// written as `if (!CheckMsgCmdFrom(...)) continue;` in future patches.
+static bool CheckMsgCmdFrom(const AIGroup* self, RadioMessageCommand* msgCmd, const char* callSite)
+{
+    if (msgCmd->GetFrom() == self)
+    {
+        return true;
+    }
+    LOG_ERROR(AI, "AIGroup radio queue holds foreign command at {}: this={} ({}), from={} ({}), msgType={}", callSite,
+              self ? (const char*)self->GetDebugName() : "null", (const void*)self,
+              msgCmd->GetFrom() ? (const char*)msgCmd->GetFrom()->GetDebugName() : "null",
+              (const void*)msgCmd->GetFrom(), msgCmd->GetType());
+    return false;
+}
+
 // Parameters
 
 bool AIGroup::CommandSent(bool channelCenter)
@@ -72,7 +88,7 @@ bool AIGroup::CommandSent(bool channelCenter)
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        AI_ERROR(msgCmd->GetFrom() == this);
+        CheckMsgCmdFrom(this, msgCmd, "CommandSent(bool)/FindPrevMessage");
         if (msgCmd->IsToMainSubgroup())
         {
             return true;
@@ -86,7 +102,7 @@ bool AIGroup::CommandSent(bool channelCenter)
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        AI_ERROR(msgCmd->GetFrom() == this);
+        CheckMsgCmdFrom(this, msgCmd, "CommandSent(bool)/GetActualMessage");
         if (msgCmd->IsToMainSubgroup())
         {
             return true;
@@ -139,7 +155,7 @@ bool AIGroup::CommandSent(Command::Message message, bool channelCenter)
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        AI_ERROR(msgCmd->GetFrom() == this);
+        CheckMsgCmdFrom(this, msgCmd, "CommandSent(msg,bool)/FindPrevMessage");
         if (msgCmd->GetCmdMessage() == message)
         {
             return true;
@@ -152,7 +168,7 @@ bool AIGroup::CommandSent(Command::Message message, bool channelCenter)
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        AI_ERROR(msgCmd->GetFrom() == this);
+        CheckMsgCmdFrom(this, msgCmd, "CommandSent(msg,bool)/GetActualMessage");
         if (msgCmd->GetCmdMessage() == message)
         {
             return true;
@@ -200,7 +216,7 @@ bool AIGroup::CommandSent(AIUnit* to, Command::Message message, bool channelCent
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        AI_ERROR(msgCmd->GetFrom() == this);
+        CheckMsgCmdFrom(this, msgCmd, "CommandSent(to,msg,bool)/FindPrevMessage");
         if (msgCmd->IsTo(to) && msgCmd->GetCmdMessage() == message)
         {
             return true;
@@ -213,7 +229,7 @@ bool AIGroup::CommandSent(AIUnit* to, Command::Message message, bool channelCent
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        AI_ERROR(msgCmd->GetFrom() == this);
+        CheckMsgCmdFrom(this, msgCmd, "CommandSent(to,msg,bool)/GetActualMessage");
         if (msgCmd->IsTo(to) && msgCmd->GetCmdMessage() == message)
         {
             return true;
@@ -237,7 +253,7 @@ void AIGroup::ClearGetInCommands(AIUnit* to)
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        AI_ERROR(msgCmd->GetFrom() == this);
+        CheckMsgCmdFrom(this, msgCmd, "ClearGetInCommands/FindPrevMessage");
         if (msgCmd->IsTo(to) && msgCmd->GetCmdMessage() == Command::GetIn &&
             (msgCmd->GetContext() == Command::CtxAuto || msgCmd->GetContext() == Command::CtxAutoSilent))
         {
@@ -252,8 +268,7 @@ void AIGroup::ClearGetInCommands(AIUnit* to)
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        AI_ERROR(msgCmd->GetFrom() == this);
-        AI_ERROR(msgCmd->GetFrom() == this);
+        CheckMsgCmdFrom(this, msgCmd, "ClearGetInCommands/GetActualMessage");
         if (msgCmd->IsTo(to) && msgCmd->GetCmdMessage() == Command::GetIn &&
             (msgCmd->GetContext() == Command::CtxAuto || msgCmd->GetContext() == Command::CtxAutoSilent))
         {


### PR DESCRIPTION
 ## Problem

  `AIGroupImpl::CommandSent(..., bool channelCenter)` picks its radio channel from `channelCenter`:

  ```cpp
  RadioChannel& radio = channelCenter ? GetCenter()->GetRadio() : GetRadio();
  
  ```

  - channelCenter == false → the group's own radio → msgCmd->GetFrom() == this is a valid invariant.
  - channelCenter == true  → the per-side AICenter radio, shared by every group on that side → foreign commands
  are the normal case, and the following AI_ERROR(msgCmd->GetFrom() == this) fires once per foreign message per
  scan pass.

  The msgCmd->IsTo(to) && msgCmd->GetCmdMessage() == message check that follows already filters foreign messages
  semantically, so the AI logic is fine — only the assertion is wrong.

  Six sites are affected (all three CommandSent overloads × the FindPrevMessage loop + the GetActualMessage
  check). The two remaining msgCmd->GetFrom() == this sites in ClearGetInCommands use _radio directly and are
  unaffected.

### Evidence

 Instrumented build (10-minute session, campaign C02 "Battlefields", trace logging):

  - 2908 firings of msgCmd->GetFrom() != this.
  - Only the six channelCenter-parameterised sites fire; the two ClearGetInCommands sites never do.
  - All hits carry msgType == RMTCommand.
  - 5 distinct sender groups, 20 distinct scanner groups, all same-side per hit — consistent with
  AICenter::GetRadio() being one channel per side.

  After this PR the same session produces 0 firings.

 ###  What this PR does

  1. Adds a small file-local CheckMsgCmdFrom helper that replaces the bare AI_ERROR(msgCmd->GetFrom() == this) at
   all 8 sites and logs both group identities on violation — useful diagnostic for any future real invariant leak
   on the per-group path.
  2. Gates the check with if (!channelCenter) at the 6 center-channel sites so it only runs where the invariant
  actually holds.

  Commit split:
  - b9803f3 — instrumentation only (behaviour-equivalent to the previous AI_ERROR, but names both groups on
  violation).
  - 6583c4e — the actual fix (if (!channelCenter) guard at the 6 sites).


  ### Environment where this was reproduced

  FreeBSD 16.0-CURRENT, clang 21.1.8, gl33 backend on AMD Radeon 680M / Mesa 26.0.6. GOG retail campaign data.
  The bug is not FreeBSD-specific: it's a pure logic issue in the shared code path, but the FreeBSD trace log
  with `--log-categories AI,Core,World,Mission,Config` is what made it visible.