### PR TITLE
Landscape::ExplosionDammageEffects: guard null preloaded CraterShell

### DIFF
--- a/engine/Poseidon/World/Simulation/Collisions.cpp
+++ b/engine/Poseidon/World/Simulation/Collisions.cpp
@@ -972,6 +972,15 @@ void Landscape::ExplosionDammageEffects(EntityAI* owner, Shot* shot, Object* dir
         else
         {
             LODShapeWithShadow* shape = GLOB_SCENE->Preloaded(CraterShell);
+            // Preload contract (ScenePreloader.cpp:59-69): shape may be null
+            // under --no-strict when CfgScenePreload.CraterShell.model is
+            // missing or fails to load (broken base data or a mod that
+            // overrides the slot with an invalid path). Skip the crater FX
+            // rather than crash on the first explosion.
+            if (!shape)
+            {
+                return;
+            }
             float azimut = GRandGen.RandomValue() * H_PI * 2;
 
             Matrix4 transform(MIdentity);
@@ -1010,48 +1019,52 @@ void Landscape::ExplosionDammageEffects(EntityAI* owner, Shot* shot, Object* dir
                 transform.SetOrientation(Matrix3(MRotationY, azimut));
                 transform.SetScale(scale * 0.5);
                 LODShapeWithShadow* shape = GLOB_SCENE->Preloaded(CraterShell);
-                // small/big explosion
+                // See preload-contract note above (CraterShell branch, ~line 976).
+                // Skip crater FX (no visible crater, no ground debris) but still let
+                // the outer function fall through to the Disclose() call below.
+                if (shape)
+                {
+                    Vector3 offset = transform.Rotate(shape->BoundingCenter());
+                    transform.SetPosition(Vector3(pos[0], surfY, pos[2]) + offset);
 
-                Vector3 offset = transform.Rotate(shape->BoundingCenter());
-                transform.SetPosition(Vector3(pos[0], surfY, pos[2]) + offset);
+                    float timeToLive = scale * 60;
+                    timeToLive *= craterTimeCoef;
+                    saturateMin(timeToLive, 120);
 
-                float timeToLive = scale * 60;
-                timeToLive *= craterTimeCoef;
-                saturateMin(timeToLive, 120);
-
-                // create vehicle
-                Crater* crater =
-                    new Crater(shape, VehicleTypes.New("crater"), timeToLive, scale * 0.5, true, false, water);
-                crater->SetTransform(transform);
-                crater->SetAlpha(alpha);
-                GLOB_WORLD->AddAnimal(crater);
+                    // create vehicle
+                    Crater* crater =
+                        new Crater(shape, VehicleTypes.New("crater"), timeToLive, scale * 0.5, true, false, water);
+                    crater->SetTransform(transform);
+                    crater->SetAlpha(alpha);
+                    GLOB_WORLD->AddAnimal(crater);
 
 #if 1
-                float distance2ToCamera = GScene->GetCamera()->Position().Distance2(transform.Position());
-                if (distance2ToCamera < Square(500))
-                {
-                    int count = toIntFloor(landAlpha * 10);
-                    while (--count >= 0)
+                    float distance2ToCamera = GScene->GetCamera()->Position().Distance2(transform.Position());
+                    if (distance2ToCamera < Square(500))
                     {
-                        // some ground effects flying out
-                        Vector3 vel((GRandGen.RandomValue() * 15 - 7.5) * landAlpha,
-                                    (GRandGen.RandomValue() * 10) * landAlpha,
-                                    (GRandGen.RandomValue() * 15 - 7.5) * landAlpha);
-                        Vector3 posOffset((GRandGen.RandomValue() * 2 - 1) * scale,
-                                          (GRandGen.RandomValue() * 1) * scale,
-                                          (GRandGen.RandomValue() * 2 - 1) * scale);
-                        Matrix4 fxTrans = transform;
-                        // random orientation
-                        fxTrans.SetOrientation(Matrix3(MRotationX, GRandGen.RandomValue() * (2 * H_PI)) *
-                                               Matrix3(MRotationY, GRandGen.RandomValue() * (2 * H_PI)));
-                        fxTrans.SetPosition(transform.Position() + posOffset);
+                        int count = toIntFloor(landAlpha * 10);
+                        while (--count >= 0)
+                        {
+                            // some ground effects flying out
+                            Vector3 vel((GRandGen.RandomValue() * 15 - 7.5) * landAlpha,
+                                        (GRandGen.RandomValue() * 10) * landAlpha,
+                                        (GRandGen.RandomValue() * 15 - 7.5) * landAlpha);
+                            Vector3 posOffset((GRandGen.RandomValue() * 2 - 1) * scale,
+                                              (GRandGen.RandomValue() * 1) * scale,
+                                              (GRandGen.RandomValue() * 2 - 1) * scale);
+                            Matrix4 fxTrans = transform;
+                            // random orientation
+                            fxTrans.SetOrientation(Matrix3(MRotationX, GRandGen.RandomValue() * (2 * H_PI)) *
+                                                   Matrix3(MRotationY, GRandGen.RandomValue() * (2 * H_PI)));
+                            fxTrans.SetPosition(transform.Position() + posOffset);
 
-                        ThingEffectKind kind = dyn_cast<Transport>(directHit) ? TEArmor : TEGround;
-                        Entity* fx = CreateThingEffect(kind, fxTrans, vel);
-                        (void)fx;
+                            ThingEffectKind kind = dyn_cast<Transport>(directHit) ? TEArmor : TEGround;
+                            Entity* fx = CreateThingEffect(kind, fxTrans, vel);
+                            (void)fx;
+                        }
                     }
-                }
 #endif
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

`engine/Poseidon/World/Scene/ScenePreloader.cpp:59-69` documents an explicit `--no-strict` fallback: when `CfgScenePreload.<slot>.model` fails to load, `LoadShape` logs the error and returns null so the engine can still boot. The comment ("`--no-strict` (the build players run): a missing preload model is logged but not fatal — return a null shape and let the engine boot rather than `exit(1)`") is explicit about the invariant.

`Landscape::ExplosionDammageEffects` in `engine/Poseidon/World/Simulation/Collisions.cpp` didn't honor that
contract. Both `CraterShell` branches call `GLOB_SCENE->Preloaded(CraterShell)` and immediately dereference the
result — `shape->BoundingCenter()` at line 1015, and the shape pointer is handed to `new Crater(...)` unchecked at both 984 and 1024.

When the preload comes back null, the first explosion crashes:

```
SIGSEGV in Vector3P::operator[](this=0x0000000000000168, i=0)
  Math3DP.hpp:137
  ← Matrix4P::Rotate(op=0x0000000000000168)  Math3DP.hpp:466
  ← Landscape::ExplosionDammageEffects        Collisions.cpp:1015
  ← Landscape::ExplosionDammage               Collisions.cpp:1176
  ← SmokeSourceVehicle::SimulateExplosion     Smokes.cpp:300
  ← Tank::Simulate                            Tank.cpp:1494
```

`op=0x168` is the field offset of `Vector3 _boundingCenter` inside a null `LODShapeWithShadow*`. `BoundingCenter()` returns `Vector3Val`, which is `const Vector3K&` (a reference), so a null `shape` produces a null-reference-return that crashes on the first component access inside `Matrix4P::Rotate`.

## Fix

Add null-shape guards at both `CraterShell` use sites:

- Line 976 branch (no `directHit`, above-ground splash crater): early
  `return` — nothing more to do in this branch when the shape is
  missing.
- Line 1021 branch (flat-ground crater case): wrap the crater
  creation and its child ground-debris FX block in `if (shape) { ...
  }`. The outer function still falls through to the `if (ownerCenter)
  Disclose(...)` call, which must always run.

Both sites include a comment pointing at the `ScenePreloader.cpp:59-69` contract so the guard's purpose is discoverable from the crash site.

## Reproduction

Encountered after activating the `finmod` mod through the in-game Mods menu. The mod-triggered restart brought the game up with the CraterShell preload slot null (root cause of the null still under investigation — `bin/remaster.cpp` declares
`CraterShell.model = "data3d\krater.p3d"`, and `Data3D.pbo` in the base pack does contain `krater.p3d`, so the load-failure is in the resolver path after mod activation, not a missing asset).

Independent of what causes the null, the game crashed on first explosion. With this guard, a missing `CraterShell` degrades to "no crater visible" — cosmetic, playable — instead of taking the world down on first tank hit.

## Verification

Activated the mod via the in-game Mods menu (the re-mount path that previously crashed on first explosion within
seconds) and played a combat mission with multiple fuel explosions — no crash, no assert.