### PR TITLE
build: Combined widescreen fixes #61 and #66

### DIFF
--- a/engine/Poseidon/Input/InputProcessingSdl.cpp
+++ b/engine/Poseidon/Input/InputProcessingSdl.cpp
@@ -240,8 +240,17 @@ void ProcessMouse_SDL(DWORD timeDelta)
         clampPtr = &clamp;
     }
 
-    bool markKeyboardTurn =
-        GInput.mouse.Update(GInput.cursor, GInput.gameFocusLost, GInput.lookAroundEnabled, Glob.uiTime, clampPtr);
+    // Default to the reference aspect ratio, override with the actual viewport aspect ratio if available
+    float viewportAspectRatio = MouseState::kBaseAspectRatio;
+    if (::Poseidon::GEngine)
+    {
+        const int viewH = ::Poseidon::GEngine->Height();
+        if (viewH > 0)
+            viewportAspectRatio = static_cast<float>(::Poseidon::GEngine->Width()) / static_cast<float>(viewH);
+    }
+
+    bool markKeyboardTurn = GInput.mouse.Update(GInput.cursor, GInput.gameFocusLost, GInput.lookAroundEnabled,
+                                                Glob.uiTime, clampPtr, viewportAspectRatio);
 
     if (markKeyboardTurn)
         GInput.keyboard.turnLastActive = Glob.uiTime;

--- a/engine/Poseidon/Input/InputProcessingSdl.cpp
+++ b/engine/Poseidon/Input/InputProcessingSdl.cpp
@@ -240,17 +240,26 @@ void ProcessMouse_SDL(DWORD timeDelta)
         clampPtr = &clamp;
     }
 
-    // Default to the reference aspect ratio, override with the actual viewport aspect ratio if available
-    float viewportAspectRatio = MouseState::kBaseAspectRatio;
+    // Aiming spans the full window, so it uses the window aspect ratio
+    // (Width/Height).  The cursor's coordinates are relative to the HUD region,
+    // so it uses that region's aspect ratio (Width2D/Height2D) — this keeps its
+    // speed consistent and unaffected by the HUD width limit.  Both fall back to
+    // the 4:3 reference when the engine size is unavailable.
+    float aimAspectRatio = MouseState::kBaseAspectRatio;
+    float cursorAspectRatio = MouseState::kBaseAspectRatio;
     if (::Poseidon::GEngine)
     {
-        const int viewH = ::Poseidon::GEngine->Height();
-        if (viewH > 0)
-            viewportAspectRatio = static_cast<float>(::Poseidon::GEngine->Width()) / static_cast<float>(viewH);
+        const int winH = ::Poseidon::GEngine->Height();
+        if (winH > 0)
+            aimAspectRatio = static_cast<float>(::Poseidon::GEngine->Width()) / static_cast<float>(winH);
+
+        const int uiH = ::Poseidon::GEngine->Height2D();
+        if (uiH > 0)
+            cursorAspectRatio = static_cast<float>(::Poseidon::GEngine->Width2D()) / static_cast<float>(uiH);
     }
 
     bool markKeyboardTurn = GInput.mouse.Update(GInput.cursor, GInput.gameFocusLost, GInput.lookAroundEnabled,
-                                                Glob.uiTime, clampPtr, viewportAspectRatio);
+                                                Glob.uiTime, clampPtr, cursorAspectRatio, aimAspectRatio);
 
     if (markKeyboardTurn)
         GInput.keyboard.turnLastActive = Glob.uiTime;

--- a/engine/Poseidon/Input/MouseState.cpp
+++ b/engine/Poseidon/Input/MouseState.cpp
@@ -34,7 +34,7 @@ void MouseState::DiscardBuffered()
 }
 
 bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundEnabled, UITime currentTime,
-                        const CursorClamp* clamp, float viewportAspectRatio)
+                        const CursorClamp* clamp, float cursorAspectRatio, float aimAspectRatio)
 {
     // Reset per-frame edge state
     leftToDo = false;
@@ -129,16 +129,22 @@ bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundE
     rightToDo = buttonsToDo[1];
     middleToDo = buttonsToDo[2];
 
-    // Cursor movement, with aspect ratio correction and clamping
-    float moveX = deltaX * (kCursorScaleY / viewportAspectRatio);
+    // Scale horizontal movement by aspect ratio so it feels consistent with
+    // vertical. Aim and the cursor use different aspect ratios because they
+    // measure width differently: aiming spans the full window, but the cursor's
+    // coordinates are relative to the HUD region (even though it can move past
+    // it), so it must use the HUD region's aspect ratio to stay uniform on both axes.
+    float aimMoveX = deltaX * (kCursorScaleY / aimAspectRatio);
+    float cursorMoveX = deltaX * (kCursorScaleY / cursorAspectRatio);
     float moveY = deltaY * kCursorScaleY;
 
-    saturate(moveX, -kCursorLimitX, +kCursorLimitX);
+    saturate(aimMoveX, -kCursorLimitX, +kCursorLimitX);
+    saturate(cursorMoveX, -kCursorLimitX, +kCursorLimitX);
     saturate(moveY, -kCursorLimitY, +kCursorLimitY);
 
     if (gameFocusLost <= 0)
     {
-        cursor.aimDeltaX += moveX;
+        cursor.aimDeltaX += aimMoveX;
         if (reverseY)
             cursor.aimDeltaY -= moveY;
         else
@@ -146,7 +152,7 @@ bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundE
     }
     // The menu cursor can be scaled independently of look (menuCursorScale 1.0
     // == classic: cursor and aim move together).
-    cursor.cursorX += moveX * tuning.menuCursorScale;
+    cursor.cursorX += cursorMoveX * tuning.menuCursorScale;
     cursor.cursorY += moveY * tuning.menuCursorScale;
 
     cursor.aimDeltaZ += kWheelToCursorScale * deltaZ;

--- a/engine/Poseidon/Input/MouseState.cpp
+++ b/engine/Poseidon/Input/MouseState.cpp
@@ -34,7 +34,7 @@ void MouseState::DiscardBuffered()
 }
 
 bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundEnabled, UITime currentTime,
-                        const CursorClamp* clamp)
+                        const CursorClamp* clamp, float viewportAspectRatio)
 {
     // Reset per-frame edge state
     leftToDo = false;
@@ -129,8 +129,8 @@ bool MouseState::Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundE
     rightToDo = buttonsToDo[1];
     middleToDo = buttonsToDo[2];
 
-    // Cursor movement (matches Windows logic)
-    float moveX = deltaX * kCursorScaleX;
+    // Cursor movement, with aspect ratio correction and clamping
+    float moveX = deltaX * (kCursorScaleY / viewportAspectRatio);
     float moveY = deltaY * kCursorScaleY;
 
     saturate(moveX, -kCursorLimitX, +kCursorLimitX);

--- a/engine/Poseidon/Input/MouseState.hpp
+++ b/engine/Poseidon/Input/MouseState.hpp
@@ -71,9 +71,14 @@ struct MouseState
     // Process buffered input into state. Writes cursor/aim to shared accumulator.
     // Returns true if mouse turn was active AND lookAround was enabled
     // (caller should mark keyboard turn active in that case — cross-device concern).
+    // cursorAspectRatio scales the 2D cursor (its coordinates are relative to
+    // the HUD region); aimAspectRatio scales the 3D aim (uses the full window).
+    // These aspect ratios differ only when the HUD width limit shrinks the UI on
+    // a wide screen.
     bool Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundEnabled,
                 Foundation::UITime currentTime, const CursorClamp* clamp,
-                float viewportAspectRatio = kBaseAspectRatio);
+                float cursorAspectRatio = kBaseAspectRatio,
+                float aimAspectRatio = kBaseAspectRatio);
 
     // Flush buffered input and reset per-frame deltas.
     void FlushAndReset();
@@ -107,7 +112,7 @@ struct MouseState
     static constexpr int kDoubleClickWindowMs = 400;
     // The original game assumes a 4:3 aspect ratio for mouse input, with default scales of X / 200 and Y / 150.
     // To maintain roughly the same speed while adjusting for the actual aspect ratio, we keep the Y scale fixed
-    // and derive the X scale from it and the viewport aspect ratio passed to Update().
+    // and derive the X scale from it and the aspect ratios passed to Update() (see Update for the cursor/aim split).
     static constexpr float kCursorScaleY = 1.0f / 150.0f;
     static constexpr float kCursorLimitX = 0.6f;
     static constexpr float kCursorLimitY = 0.4f;

--- a/engine/Poseidon/Input/MouseState.hpp
+++ b/engine/Poseidon/Input/MouseState.hpp
@@ -33,6 +33,9 @@ struct MouseState
     float sensitivityX = 1.0f;
     float sensitivityY = 1.0f;
 
+    // Reference aspect ratio (4:3) the cursor scales were tuned for
+    static constexpr float kBaseAspectRatio = 4.0f / 3.0f;
+
     // Config
     bool reverseY = false;
     bool buttonsReversed = false;
@@ -69,7 +72,8 @@ struct MouseState
     // Returns true if mouse turn was active AND lookAround was enabled
     // (caller should mark keyboard turn active in that case — cross-device concern).
     bool Update(CursorAccum& cursor, int gameFocusLost, bool lookAroundEnabled,
-                Foundation::UITime currentTime, const CursorClamp* clamp);
+                Foundation::UITime currentTime, const CursorClamp* clamp,
+                float viewportAspectRatio = kBaseAspectRatio);
 
     // Flush buffered input and reset per-frame deltas.
     void FlushAndReset();
@@ -101,7 +105,9 @@ struct MouseState
   private:
     static constexpr int kButtonBufferSize = 16;
     static constexpr int kDoubleClickWindowMs = 400;
-    static constexpr float kCursorScaleX = 1.0f / 200.0f;
+    // The original game assumes a 4:3 aspect ratio for mouse input, with default scales of X / 200 and Y / 150.
+    // To maintain roughly the same speed while adjusting for the actual aspect ratio, we keep the Y scale fixed
+    // and derive the X scale from it and the viewport aspect ratio passed to Update().
     static constexpr float kCursorScaleY = 1.0f / 150.0f;
     static constexpr float kCursorLimitX = 0.6f;
     static constexpr float kCursorLimitY = 0.4f;

--- a/engine/Poseidon/UI/Settings/AspectRatio.cpp
+++ b/engine/Poseidon/UI/Settings/AspectRatio.cpp
@@ -185,7 +185,7 @@ PolicyResult ResolvePolicy(const PolicyInput& input)
             result.effectiveRatio = clampRatio;
     }
 
-    result.settings = BuildSettingsForRatio(result.effectiveRatio);
+    result.settings = BuildSettingsForRatio(result.viewportRatio);
     if (result.viewportRatio > result.effectiveRatio)
     {
         ApplyCenteredUiBand(result.settings, result.effectiveRatio, input.viewportWidth, input.viewportHeight);

--- a/tests/unit/engine/Poseidon/UI/Settings/test_aspectRatio.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_aspectRatio.cpp
@@ -159,7 +159,7 @@ TEST_CASE("AspectRatio Modern clamps ultrawide gameplay framing", "[Settings][As
 
     CHECK(result.viewportRatio == Catch::Approx(32.0f / 9.0f));
     CHECK(result.effectiveRatio == Catch::Approx(21.0f / 9.0f));
-    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (21.0f / 9.0f)));
+    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (32.0f / 9.0f)));
     CHECK(result.settings.uiTopLeftX > 0.0f);
 }
 
@@ -169,14 +169,14 @@ TEST_CASE("AspectRatio Modern clamp uses the selected HUD width band", "[Setting
 
     AspectRatio::PolicyResult result = AspectRatio::ResolvePolicy(input);
     CHECK(result.effectiveRatio == Catch::Approx(21.0f / 9.0f));
-    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (21.0f / 9.0f)));
+    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (32.0f / 9.0f)));
     CHECK(result.settings.uiTopLeftX == Catch::Approx(0.171875f));
     CHECK(result.settings.uiBottomRightX == Catch::Approx(0.828125f));
 
     input.ultrawideClamp = AspectRatio::Clamp16x9;
     result = AspectRatio::ResolvePolicy(input);
     CHECK(result.effectiveRatio == Catch::Approx(16.0f / 9.0f));
-    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (16.0f / 9.0f)));
+    CHECK(result.settings.leftFOV == Catch::Approx(0.75f * (32.0f / 9.0f)));
     CHECK(result.settings.uiTopLeftX == Catch::Approx(0.25f));
     CHECK(result.settings.uiBottomRightX == Catch::Approx(0.75f));
 }

--- a/tests/unit/engine/Poseidon/UI/Settings/test_presentation.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_presentation.cpp
@@ -19,11 +19,13 @@ TEST_CASE("Presentation: 16:9 resolves full-width undistorted UI", "[Settings][P
     CHECK(s.worldRight == Catch::Approx(1.0f));
 }
 
-TEST_CASE("Presentation: 32:9 Adaptive 21:9 clamps world FOV and HUD width", "[Settings][Presentation]")
+TEST_CASE("Presentation: 32:9 Adaptive 21:9 keeps full-width world FOV, clamps HUD width", "[Settings][Presentation]")
 {
     Poseidon::Presentation::SetPolicy(Poseidon::AspectRatio::Modern, Poseidon::AspectRatio::Clamp21x9);
     const Poseidon::AspectRatio::Settings s = Poseidon::Presentation::Resolve(3840, 1080);
-    CHECK(s.leftFOV == Catch::Approx(0.75f * (21.0f / 9.0f))); // FOV capped at the clamp
+    CHECK(s.leftFOV == Catch::Approx(0.75f * (32.0f / 9.0f)));
+    CHECK(s.worldLeft == Catch::Approx(0.0f));
+    CHECK(s.worldRight == Catch::Approx(1.0f));
     const float uiW = (s.uiBottomRightX - s.uiTopLeftX) * 3840.0f;
     const float uiH = (s.uiBottomRightY - s.uiTopLeftY) * 1080.0f;
     CHECK(uiW / uiH == Catch::Approx(21.0f / 9.0f).epsilon(0.001f));
@@ -36,7 +38,7 @@ TEST_CASE("Presentation: 32:9 Adaptive 16:9 uses the narrower HUD width limit", 
     Poseidon::Presentation::SetPolicy(Poseidon::AspectRatio::Modern, Poseidon::AspectRatio::Clamp16x9);
     const Poseidon::AspectRatio::Settings s = Poseidon::Presentation::Resolve(3840, 1080);
 
-    CHECK(s.leftFOV == Catch::Approx(0.75f * (16.0f / 9.0f)));
+    CHECK(s.leftFOV == Catch::Approx(0.75f * (32.0f / 9.0f)));
     CHECK(s.uiTopLeftX == Catch::Approx(0.25f));
     CHECK(s.uiBottomRightX == Catch::Approx(0.75f));
 


### PR DESCRIPTION
- fix: fix HUD width limit affecting FOV, including 3D UI elements
- fix: scale cursor movement by the actual aspect ratio instead of assuming 4:3
