### PR TITLE
QIFStreamB: try mod dirs when loose-file open fails on POSIX

### DIFF
--- a/engine/Poseidon/IO/Streams/QBStream.cpp
+++ b/engine/Poseidon/IO/Streams/QBStream.cpp
@@ -20,6 +20,7 @@
 #include <Poseidon/Foundation/platform.hpp>
 
 #include <Poseidon/Foundation/Common/Win.h>
+#include <Poseidon/Core/ModSystem.hpp>
 #include <Poseidon/IO/Filesystem/FileOps.hpp>
 #include <Poseidon/IO/Filesystem/DirScanner.hpp>
 #include <Poseidon/IO/Streams/FileAccessPolicy.hpp>
@@ -1342,6 +1343,108 @@ QFBank* QIFStreamB::AutoBank(const char* name)
 
 QIFStreamB::QIFStreamB() : _bank(nullptr) {}
 
+} // namespace Poseidon
+
+// Forward declaration (defined in Core/GameState.cpp). The mod-path store is a
+// process-wide global; each callback receives one absolute mod directory string.
+extern bool EnumModDirectories(Poseidon::ModDirectoryCallback callback, void* context);
+
+namespace Poseidon
+{
+
+namespace
+{
+// Loose-file mod fallback: on Windows the launcher makes each mod a subdirectory
+// of the game data folder, so `open("finmod\Sounds\...")` finds the file via cwd.
+// On POSIX the mod lives elsewhere (XDG Workshop/Local mods dirs) while cwd stays
+// at the data root, so the naive cwd-relative open fails for loose (non-PBO) mod
+// assets. Splice: if `name`'s first component matches a mounted mod's leaf
+// directory name (case-insensitively), rewrite to `<mod-abs-path>/<rest>` and
+// return the resolved absolute path. Ignores the trailing base-directory entry
+// (empty dir) that EnumModDirectories yields last.
+struct ResolveLooseModContext
+{
+    const char* firstComp;
+    size_t firstCompLen;
+    const char* rest; // starts with a separator, or empty at end of name
+    char* out;
+    size_t outLen;
+    bool resolved;
+};
+
+bool ResolveLooseModCallback(RStringB dir, void* ctx)
+{
+    auto* c = static_cast<ResolveLooseModContext*>(ctx);
+    if (dir.GetLength() == 0)
+    {
+        return false;
+    }
+    const char* dirStr = (const char*)dir;
+    // Basename of the mod directory: everything after the last '/' or '\'.
+    const char* base = dirStr;
+    for (const char* p = dirStr; *p; ++p)
+    {
+        if (*p == '/' || *p == '\\')
+        {
+            base = p + 1;
+        }
+    }
+    if (strlen(base) != c->firstCompLen)
+    {
+        return false;
+    }
+    if (strnicmp(base, c->firstComp, (int)c->firstCompLen) != 0)
+    {
+        return false;
+    }
+    // Splice: <mod-abs-path>/<rest-after-first-component>. `rest` still carries
+    // its leading separator; the resolver in OpenFileForRead / FilePathExists
+    // normalizes '\\' to '/'.
+    snprintf(c->out, c->outLen, "%s%s", dirStr, c->rest);
+    c->resolved = true;
+    return true; // stop enumeration
+}
+
+// Try to rewrite `name` into an absolute path under one of the mounted mod
+// directories. Returns true and fills `out` on hit; returns false otherwise
+// (out is left untouched).
+bool ResolveLooseModPath(const char* name, char* out, size_t outLen)
+{
+    if (!name || !*name)
+    {
+        return false;
+    }
+    // Skip any leading separators — configs sometimes carry a leading '\\'.
+    const char* p = name;
+    while (*p == '/' || *p == '\\')
+    {
+        ++p;
+    }
+    if (!*p)
+    {
+        return false;
+    }
+    const char* sep = p;
+    while (*sep && *sep != '/' && *sep != '\\')
+    {
+        ++sep;
+    }
+    if (!*sep)
+    {
+        return false; // no separator — not a mod-qualified path
+    }
+    ResolveLooseModContext ctx;
+    ctx.firstComp = p;
+    ctx.firstCompLen = (size_t)(sep - p);
+    ctx.rest = sep; // includes the separator
+    ctx.out = out;
+    ctx.outLen = outLen;
+    ctx.resolved = false;
+    ::EnumModDirectories(ResolveLooseModCallback, &ctx);
+    return ctx.resolved;
+}
+} // namespace
+
 void QIFStreamB::AutoOpen(const char* name, IQFBankContext* context)
 {
     const char* name0 = name;
@@ -1369,6 +1472,18 @@ void QIFStreamB::AutoOpen(const char* name, IQFBankContext* context)
         }
     }
     QIFStream::open(name0);
+    if (!fail())
+    {
+        return;
+    }
+    // Loose-file mod fallback: the plain cwd-relative open missed. If `name0`
+    // is a mod-qualified path (first component == a mounted mod's basename),
+    // retry against the mod's absolute path. See ResolveLooseModPath.
+    char resolved[MaxFileName];
+    if (ResolveLooseModPath(name0, resolved, sizeof(resolved)))
+    {
+        QIFStream::open(resolved);
+    }
 }
 
 bool QIFStreamB::IsFromBank(const QFBank* bank) const
@@ -1405,7 +1520,17 @@ bool QIFStreamB::FileExist(const char* name, IQFBankContext* context)
             }
         }
     }
-    return QIFStream::FileExists(name);
+    if (QIFStream::FileExists(name))
+    {
+        return true;
+    }
+    // Loose-file mod fallback, symmetric with AutoOpen.
+    char resolved[MaxFileName];
+    if (ResolveLooseModPath(name, resolved, sizeof(resolved)))
+    {
+        return QIFStream::FileExists(resolved);
+    }
+    return false;
 }
 
 struct EncryptorInformation


### PR DESCRIPTION
## Summary

On POSIX ports (the FreeBSD port and any Linux port with an XDG layout) mods live under `~/.local/share/Cold War Assault/Workshop/<mod>/` while the process `cwd` stays at the data root (`~/.local/share/CWR/base/`).
Loose (non-PBO) mod assets referenced by config with the mod-qualified name — e.g. `\finmod\Sounds\Vehicles\tank_gear.wss`, are unreachable through the cwd-relative fallback in `QIFStreamB::AutoOpen`, so vehicle and weapon sounds go silent whenever a mod ships loose files.

Log symptom (FreeBSD, `finmod` pack downloaded from the Mods option of the UI):

```
[WARN] [CORE] FileCache: file 'finmod\sounds\vehicles\tank_gear.wss' not found
[WARN] [CORE] FileCache: file 'finmod\sounds\vehicles\car_treads.wss' not found
[WARN] [CORE] FileCache: file 'finmod\sounds\vehicles\turret_mechanic.wss' not found
[WARN] [CORE] FileCache: file 'finmod\sounds\guns\rpg_fire.wss' not found
```

The files verifiably exist under the mod directory; `procstat -f` confirms `cwd` is the data root, not the mods parent.

## Where the miss happens

`FileServer.cpp:105-112` — `FileCache::Load` on a miss constructs a `FileInCache(name)` which calls `QIFStreamB::AutoOpen`. If the resulting stream fails, the "FileCache: file ... not found" WARN is emitted. So this is NOT a cache-key mismatc,  it's the underlying `AutoOpen` failing. `QIFStreamB::AutoOpen(name)` in `IO/Streams/QBStream.cpp:1345`:

1. Try `AutoBank(name)` → find a mounted `.pbo` whose prefix matches
   `name`. If found, open from the PBO. **Path used for finmod's
   PBO-bundled assets** (world PBOs, mission PBOs, etc.).
2. Fallback: `QIFStream::open(name0)` → plain filesystem open of the
   verbatim name relative to `cwd`.

The fallback is where loose mod files should be resolved, but there was no mod-directory search in this path. `open("finmod/sounds/vehicles/tank_gear.wss")` looks for `~/.local/share/CWR/base/finmod/sounds/vehicles/tank_gear.wss` and returns `ENOENT`.

Meanwhile the codebase already has a mod-dir enumerator that other call sites use: `EnumModDirectories(callback, ctx)` in
`Core/GameState.cpp:129`. `LoadBanks` (PBO discovery) and mission-PBO lookup (`OptionsUI.cpp:932`, `Network.cpp:337`) both use it, the `AutoOpen` fallback did not.

## Why it only bites POSIX

On Windows the CWR launcher makes each mod a subdirectory of the game data folder , `<data>\finmod\`. `cwd = <data>` at runtime, so `open("finmod\Sounds\Vehicles\tank_gear.wss")` resolves relative to `cwd` and hits the loose file. The FreeBSD port (should be the same for Linux?) ships the mod under XDG `~/.local/share/Cold War Assault/Workshop/<mod>/`, separate from `~/.local/share/CWR/base/` , same layout the vanilla Linux port picked up years ago, and the same reason the mount-path CLI `--mod <fullpath>` exists. But the file-open fallback still assumed `cwd`-relative resolution.

The path-normalization stack (`platformPath` / `unixPath` / `ci_resolve_path`) is a red herring, it correctly turns
`finmod\sounds\...` into `finmod/sounds/...` before `open()`. The open still failed because that relative path didn't exist under `cwd`.

## Fix

Extend `QIFStreamB::AutoOpen` , and symmetrically `QIFStreamB::FileExist` , to retry the loose-file open against each
mounted mod's absolute path when the `cwd`-relative open fails. Take the first path component of `name0` (e.g. `finmod` from `finmod\sounds\...`), match it case-insensitively against each mod's basename via `::EnumModDirectories`, rewrite to `<mod-abs-path>/<rest>` on hit, and retry `QIFStream::open`. This mirrors the Windows convention (mod = subdirectory of the data folder), same fallback semantics, just made explicit instead of piggybacking on `cwd`.

Rejected an alternative "blind prefix scan of every mod dir" , costs an `open()` per mod per miss with no upside, since the current mod convention always mod-qualifies loose paths.

PBO-served files are unaffected: the new code runs only after `AutoBank` fails to find a match (or the bank open itself misses). Case-insensitive comparison uses Poseidon's portable `strnicmp`, not `strncasecmp`, so Windows builds continue to compile.

## Verification

Prior to the fix the disk-side workaround was a symlink from `<data>/finmod` to `<Workshop>/finmod` , which unblocked play but proved the resolver was the missing piece. With this engine fix installed and the workaround symlink removed, vehicle audio (engine, gears, treads, turret servo) works unaided across mission load and multiple vehicle types. No new warnings; the `FileCache: file ... not found` lines for the mod's loose `.wss` assets are gone.