### PR TITLE
[UserActions] Use "_this" for statement to obtain user actions' caller

### DIFF
--- a/engine/Poseidon/AI/VehicleAIPilot.cpp
+++ b/engine/Poseidon/AI/VehicleAIPilot.cpp
@@ -1078,8 +1078,15 @@ void EntityAI::PerformAction(const UIAction& action, AIUnit* unit)
             {
                 const UserTypeAction& act = GetType()->_userTypeActions[action.param];
                 GameState* gstate = GWorld->GetGameState();
+                // Declaring "GameVarSpace local" here to execute statement locally. This is learnt from
+                // "CreateUnit" script command. Since CreateUnit works normally, maybe userActions can 
+                // have similar design and can thus uses "_this" to indicate the action caller
+                GameVarSpace local;
+                gstate->BeginContext(&local);
                 gstate->VarSet("this", GameValueExt(this), true);
+                gstate->VarSetLocal("_this", GameValueExt(unit->GetPerson()), true);
                 gstate->Execute(act.statement);
+                gstate->EndContext();
             }
             return;
     }


### PR DESCRIPTION
For actions add by "addAction", parameters to the activated executable statement is ["_target", "_caller", "_actionId"]. However in UserAction scripters can only use "this" as "_target" and noway to obtain "_caller". This PR makes "_this" available in UserAction to indicate the "_caller".