### PR TITLE
[Marker] Modify markersMap with an extra hash-map

### DIFF
--- a/engine/Poseidon/AI/AICenterImpl.cpp
+++ b/engine/Poseidon/AI/AICenterImpl.cpp
@@ -739,7 +739,7 @@ namespace Poseidon
 
 OLinkArray<EntityAI> vehiclesMap;
 OLinkArray<Vehicle> sensorsMap;
-GblMarkerArrayWithHash markersMap;
+GlobalMarkerArrayWithHash markersMap;
 AutoArray<SynchronizedItem> synchronized;
 
 void SynchronizedItem::Add(AIGroup* grp)

--- a/engine/Poseidon/AI/AICenterImpl.cpp
+++ b/engine/Poseidon/AI/AICenterImpl.cpp
@@ -739,7 +739,7 @@ namespace Poseidon
 
 OLinkArray<EntityAI> vehiclesMap;
 OLinkArray<Vehicle> sensorsMap;
-AutoArray<ArcadeMarkerInfo> markersMap;
+GblMarkerArrayWithHash markersMap;
 AutoArray<SynchronizedItem> synchronized;
 
 void SynchronizedItem::Add(AIGroup* grp)
@@ -843,7 +843,11 @@ LSError AIGlobalSerialize(ParamArchive& ar)
     PARAM_CHECK(ar.SerializeRefs("VehiclesMap", vehiclesMap, 1))
     PARAM_CHECK(ar.SerializeRefs("SensorsMap", sensorsMap, 1))
     PARAM_CHECK(ar.Serialize("Stats", GStats, 1))
-    PARAM_CHECK(ar.Serialize("Markers", markersMap, 1))
+
+    const int oldSize = markersMap.Size();
+    PARAM_CHECK(ar.Serialize("Markers", markersMap.ArrayForSerialize(), 1))
+    markersMap.OnSerialize(oldSize);
+
     return LSOK;
 }
 

--- a/engine/Poseidon/AI/AICore.hpp
+++ b/engine/Poseidon/AI/AICore.hpp
@@ -91,7 +91,144 @@ struct SynchronizedItem
 
 extern OLinkArray<EntityAI> vehiclesMap;
 extern OLinkArray<Vehicle> sensorsMap;
-extern AutoArray<ArcadeMarkerInfo> markersMap;
+class GblMarkerArrayWithHash
+{
+private:
+	struct RStrIHasher
+	{
+		unsigned int operator()(const RString& str) const
+		{
+			return CalculateStringHashValueCI(str);
+		}
+	};
+	struct RStrIEqual
+	{
+		bool operator()(const RString& lhs, const RString& rhs) const
+		{
+			return stricmp(lhs.Data(), rhs.Data()) == 0;
+		}
+	};
+	AutoArray<ArcadeMarkerInfo> m_markersArr;
+	std::unordered_map<RString, int, RStrIHasher, RStrIEqual> m_name2IdxMap;
+public:
+	// Transmit to AutoArray
+	int Add(const ArcadeMarkerInfo& src)
+	{
+		const int insertedIdx = m_markersArr.Add(src);
+		// It's acceptable in origin OFP that meets same name markers when reading mission.sqm
+		// thus src.name can exist in m_name2IdxMap on adding new marker
+		m_name2IdxMap.insert(std::make_pair(src.name, insertedIdx)); // can fail
+		return insertedIdx;
+	}
+	int Add() = delete; // not allow Add default object first and then rename it
+	int Size() const
+	{
+		return m_markersArr.Size();
+	}
+	void Clear()
+	{
+		m_markersArr.Clear();
+		m_name2IdxMap.clear();
+	}
+	void Delete(int index)
+	{
+		// Note: Markers are created in three distinct ways. User-created markers (via the map) are shared across the network, carry a "_user_defined" prefix, and possess a unique ID, thus they never duplicate. Script-created markers (via createMarker) are local and have a duplicate-name check. Markers defined in mission.sqm may have duplicate names.
+		// Since duplicates are possible, when deleting a marker by name, the deletion logic must advance its search index to the next marker with the same name if one exists.
+		// For markers with the "_user_defined" prefix, uniqueness can usually be assumed. However, this assumption breaks if script-created or mission.sqm markers also employ that prefix, although such practices are rarely encountered.
+
+		RString deletedMarkerName = m_markersArr[index].name;
+		const char* userDefined = "_user_defined";
+		const bool isUserDefMarker = strnicmp(deletedMarkerName, userDefined, strlen(userDefined)) == 0;
+		const int oldSize = m_markersArr.Size();
+		int newIdx = oldSize;
+
+		m_markersArr.Delete(index);
+
+		if (!isUserDefMarker)
+		{
+			// origin OFP will only delete first marker matches input name
+			// search whether there exists markers using same name and update index value
+			for (int i = index, n = m_markersArr.Size(); i < n; ++i)
+			{
+				if (stricmp(deletedMarkerName, m_markersArr[i].name) == 0)
+				{
+					newIdx = i;
+					break;
+				}
+			}
+		}
+		for (auto it = m_name2IdxMap.begin(); it != m_name2IdxMap.end(); )
+		{
+			if (it->second < index)
+			{
+				++it;
+			}
+			else if (it->second == index)
+			{
+				if (newIdx == oldSize)	// no another marker whose name is deletedMarkerName
+				{
+					it = m_name2IdxMap.erase(it);
+				}
+				else					// still have marker whose name is deletedMarkerName
+				{
+					it->second = newIdx;
+					++it;
+				}
+			}
+			else // it->second > index
+			{
+				--it->second;
+				++it;
+			}
+		}
+	}
+	ArcadeMarkerInfo& operator[](int i)
+	{
+		return m_markersArr[i];
+	}
+	const ArcadeMarkerInfo& operator[](int i) const
+	{
+		return m_markersArr[i];
+	}
+
+	// Search
+	static bool ValidIdx(int index) { return index >= 0; }
+	int FindIdx(const RString& name) const
+	{
+		auto it = m_name2IdxMap.find(name);
+		if (it != m_name2IdxMap.cend())
+			return it->second;
+		return -1;
+	}
+	ArcadeMarkerInfo* Find(const RString& name)
+	{
+		const int idx = FindIdx(name);
+		if (!ValidIdx(idx))
+			return nullptr;
+		return &m_markersArr[idx];
+	}
+	const ArcadeMarkerInfo* Find(const RString& name) const
+	{
+		const int idx = FindIdx(name);
+		if (!ValidIdx(idx))
+			return nullptr;
+		return &m_markersArr[idx];
+	}
+
+	// For serialize
+	AutoArray<ArcadeMarkerInfo>& ArrayForSerialize()
+	{
+		return m_markersArr;
+	}
+	void OnSerialize(const int oldSize)
+	{
+		for (int i = oldSize, c = m_markersArr.Size(); i < c; ++i)
+		{
+			m_name2IdxMap.insert(std::make_pair(m_markersArr[i].name, i)); // can fail
+		}
+	}
+};
+extern GblMarkerArrayWithHash markersMap;
 extern AutoArray<SynchronizedItem> synchronized;
 
 template <class Task, class ContextType>

--- a/engine/Poseidon/AI/AICore.hpp
+++ b/engine/Poseidon/AI/AICore.hpp
@@ -12,6 +12,7 @@
 #include <Poseidon/Game/TitEffects.hpp>
 
 #include <Poseidon/AI/Path/ArcadeWaypoint.hpp>
+#include <Poseidon/AI/MarkerArrayWithHash.hpp>
 
 #include <Poseidon/Core/FSM/Fsm.hpp>
 
@@ -91,144 +92,7 @@ struct SynchronizedItem
 
 extern OLinkArray<EntityAI> vehiclesMap;
 extern OLinkArray<Vehicle> sensorsMap;
-class GblMarkerArrayWithHash
-{
-private:
-	struct RStrIHasher
-	{
-		unsigned int operator()(const RString& str) const
-		{
-			return CalculateStringHashValueCI(str);
-		}
-	};
-	struct RStrIEqual
-	{
-		bool operator()(const RString& lhs, const RString& rhs) const
-		{
-			return stricmp(lhs.Data(), rhs.Data()) == 0;
-		}
-	};
-	AutoArray<ArcadeMarkerInfo> m_markersArr;
-	std::unordered_map<RString, int, RStrIHasher, RStrIEqual> m_name2IdxMap;
-public:
-	// Transmit to AutoArray
-	int Add(const ArcadeMarkerInfo& src)
-	{
-		const int insertedIdx = m_markersArr.Add(src);
-		// It's acceptable in origin OFP that meets same name markers when reading mission.sqm
-		// thus src.name can exist in m_name2IdxMap on adding new marker
-		m_name2IdxMap.insert(std::make_pair(src.name, insertedIdx)); // can fail
-		return insertedIdx;
-	}
-	int Add() = delete; // not allow Add default object first and then rename it
-	int Size() const
-	{
-		return m_markersArr.Size();
-	}
-	void Clear()
-	{
-		m_markersArr.Clear();
-		m_name2IdxMap.clear();
-	}
-	void Delete(int index)
-	{
-		// Note: Markers are created in three distinct ways. User-created markers (via the map) are shared across the network, carry a "_user_defined" prefix, and possess a unique ID, thus they never duplicate. Script-created markers (via createMarker) are local and have a duplicate-name check. Markers defined in mission.sqm may have duplicate names.
-		// Since duplicates are possible, when deleting a marker by name, the deletion logic must advance its search index to the next marker with the same name if one exists.
-		// For markers with the "_user_defined" prefix, uniqueness can usually be assumed. However, this assumption breaks if script-created or mission.sqm markers also employ that prefix, although such practices are rarely encountered.
-
-		RString deletedMarkerName = m_markersArr[index].name;
-		const char* userDefined = "_user_defined";
-		const bool isUserDefMarker = strnicmp(deletedMarkerName, userDefined, strlen(userDefined)) == 0;
-		const int oldSize = m_markersArr.Size();
-		int newIdx = oldSize;
-
-		m_markersArr.Delete(index);
-
-		if (!isUserDefMarker)
-		{
-			// origin OFP will only delete first marker matches input name
-			// search whether there exists markers using same name and update index value
-			for (int i = index, n = m_markersArr.Size(); i < n; ++i)
-			{
-				if (stricmp(deletedMarkerName, m_markersArr[i].name) == 0)
-				{
-					newIdx = i;
-					break;
-				}
-			}
-		}
-		for (auto it = m_name2IdxMap.begin(); it != m_name2IdxMap.end(); )
-		{
-			if (it->second < index)
-			{
-				++it;
-			}
-			else if (it->second == index)
-			{
-				if (newIdx == oldSize)	// no another marker whose name is deletedMarkerName
-				{
-					it = m_name2IdxMap.erase(it);
-				}
-				else					// still have marker whose name is deletedMarkerName
-				{
-					it->second = newIdx;
-					++it;
-				}
-			}
-			else // it->second > index
-			{
-				--it->second;
-				++it;
-			}
-		}
-	}
-	ArcadeMarkerInfo& operator[](int i)
-	{
-		return m_markersArr[i];
-	}
-	const ArcadeMarkerInfo& operator[](int i) const
-	{
-		return m_markersArr[i];
-	}
-
-	// Search
-	static bool ValidIdx(int index) { return index >= 0; }
-	int FindIdx(const RString& name) const
-	{
-		auto it = m_name2IdxMap.find(name);
-		if (it != m_name2IdxMap.cend())
-			return it->second;
-		return -1;
-	}
-	ArcadeMarkerInfo* Find(const RString& name)
-	{
-		const int idx = FindIdx(name);
-		if (!ValidIdx(idx))
-			return nullptr;
-		return &m_markersArr[idx];
-	}
-	const ArcadeMarkerInfo* Find(const RString& name) const
-	{
-		const int idx = FindIdx(name);
-		if (!ValidIdx(idx))
-			return nullptr;
-		return &m_markersArr[idx];
-	}
-
-	// For serialize
-	AutoArray<ArcadeMarkerInfo>& ArrayForSerialize()
-	{
-		return m_markersArr;
-	}
-	void OnSerialize(const int oldSize)
-	{
-		for (int i = oldSize, c = m_markersArr.Size(); i < c; ++i)
-		{
-			m_name2IdxMap.insert(std::make_pair(m_markersArr[i].name, i)); // can fail
-		}
-	}
-};
-extern GblMarkerArrayWithHash markersMap;
+extern GlobalMarkerArrayWithHash markersMap;
 extern AutoArray<SynchronizedItem> synchronized;
 
 template <class Task, class ContextType>

--- a/engine/Poseidon/AI/MarkerArrayWithHash.cpp
+++ b/engine/Poseidon/AI/MarkerArrayWithHash.cpp
@@ -1,0 +1,28 @@
+#include <Poseidon/AI/MarkerArrayWithHash.hpp>
+
+
+namespace Poseidon
+{
+
+void GlobalMarkerArrayWithHash::Delete(int index)
+{
+    // Note: Markers are created in three distinct ways. User-created markers (via the map) are shared across the network, carry a "_user_defined" prefix, and possess a unique ID, thus they never duplicate. Script-created markers (via createMarker) are local and have a duplicate-name check. Markers defined in mission.sqm may have duplicate names.
+    // Since duplicates are possible, when deleting a marker by name, the deletion logic must advance its search index to the next marker with the same name if one exists.
+    // For markers with the "_user_defined" prefix, uniqueness can usually be assumed. However, this assumption breaks if script-created or mission.sqm markers also employ that prefix, although such practices are rarely encountered.
+
+    RString deletedMarkerName = KeyExtractor()(m_array[index]);
+    const char* userDefined = "_user_defined";
+    const bool isUserDefMarker = strnicmp(deletedMarkerName, userDefined, strlen(userDefined)) == 0;
+
+    m_array.Delete(index);
+
+    int nextSameElementIndex = -1;
+    const bool mayHaveDuplicates = !isUserDefMarker;
+    if (mayHaveDuplicates)
+    {
+        checkNextSameElementIndex(index, nextSameElementIndex, deletedMarkerName);
+    }
+    adjustIndexAfterDelete(index, nextSameElementIndex);
+}
+
+}  // namespace Poseidon

--- a/engine/Poseidon/AI/MarkerArrayWithHash.hpp
+++ b/engine/Poseidon/AI/MarkerArrayWithHash.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+
+#include <unordered_map>
+
+#include <Poseidon/Foundation/Containers/ArrayWithHash.hpp>
+#include <Poseidon/Foundation/Strings/RString.hpp>
+#include <Poseidon/AI/Path/ArcadeWaypoint.hpp>
+
+namespace Poseidon
+{
+
+struct RStrIHasher
+{
+	unsigned int operator()(const RString& str) const
+	{
+		return CalculateStringHashValueCI(str);
+	}
+};
+struct RStrIEqual
+{
+	bool operator()(const RString& lhs, const RString& rhs) const
+	{
+		return stricmp(lhs.Data(), rhs.Data()) == 0;
+	}
+};
+
+struct MarkerNameExtractor
+{
+	const RString& operator()(const ArcadeMarkerInfo& marker) const
+	{
+		return marker.name;
+	}
+};
+
+class GlobalMarkerArrayWithHash : public Foundation::ArrayWithHashDuplicate<ArcadeMarkerInfo, RString, MarkerNameExtractor, RStrIHasher, RStrIEqual>
+{
+public:
+	// Custom Delete method to handle duplicate marker names properly.
+	void Delete(int index);
+};
+
+}  // namespace Poseidon

--- a/engine/Poseidon/Foundation/Containers/ArrayWithHash.hpp
+++ b/engine/Poseidon/Foundation/Containers/ArrayWithHash.hpp
@@ -1,0 +1,147 @@
+#pragma once
+
+
+#include <unordered_map>
+
+#include <Poseidon/Foundation/Containers/Array.hpp>
+namespace Poseidon::Foundation
+{
+
+// ArrayWithHashDuplicate is a container that pairs an array with a hash map,
+// mapping keys to array indices for fast lookup by key.
+// Elements are stored in insertion order. Duplicate keys are allowed:
+// when inserting a key that already exists, the element is still appended to the array,
+// but the hash map retains the index of the **first** occurrence.
+// Lookup by key always returns the index of the first matching element.
+template <typename ElementType, typename KeyType, typename Element2Key, typename hasher = std::hash<KeyType>, typename keyEq = std::equal_to<KeyType>>
+class ArrayWithHashDuplicate
+{
+protected:
+    AutoArray<ElementType> m_array;
+    std::unordered_map<KeyType, int, hasher, keyEq> m_key2IdxMap;
+    using KeyExtractor = Element2Key;
+public:
+    // Transmit to AutoArray
+    int Add(const ElementType& src)
+    {
+        const int insertedIdx = m_array.Add(src);
+        insertKeyToMap(Element2Key()(src), insertedIdx);
+        return insertedIdx;
+    }
+    int Add() = delete; // not allow Add default object first and then rename it
+    int Size() const
+    {
+        return m_array.Size();
+    }
+    void Clear()
+    {
+        m_array.Clear();
+        m_key2IdxMap.clear();
+    }
+    void Delete(int index) = delete; // Derived class should implement its own Delete method to handle duplicate keys properly.
+    ElementType& operator[](int i)
+    {
+        return m_array[i];
+    }
+    const ElementType& operator[](int i) const
+    {
+        return m_array[i];
+    }
+
+    // Search
+    static bool ValidIdx(int index) { return index >= 0; }
+    int FindIdx(const KeyType& name) const
+    {
+        auto it = m_key2IdxMap.find(name);
+        if (it != m_key2IdxMap.cend())
+            return it->second;
+        return -1;
+    }
+    ElementType* Find(const KeyType& name)
+    {
+        const int idx = FindIdx(name);
+        if (!ValidIdx(idx))
+            return nullptr;
+        return &m_array[idx];
+    }
+    const ElementType* Find(const KeyType& name) const
+    {
+        const int idx = FindIdx(name);
+        if (!ValidIdx(idx))
+            return nullptr;
+        return &m_array[idx];
+    }
+
+    // For serialize
+    AutoArray<ElementType>& ArrayForSerialize()
+    {
+        return m_array;
+    }
+    void OnSerialize(const int oldSize)
+    {
+        for (int i = oldSize, c = m_array.Size(); i < c; ++i)
+        {
+            insertKeyToMap(Element2Key()(m_array[i]), i);
+        }
+    }
+protected:
+    void defaultDelete(int index)
+    {
+        KeyType keyOfDeletedElement = Element2Key()(m_array[index]);
+
+        m_array.Delete(index);
+
+        int nextSameElementIndex = -1;
+        constexpr bool mayHaveDuplicates = true; // We don't know if there are duplicates, so we must check.
+        if (mayHaveDuplicates)
+        {
+            checkNextSameElementIndex(index, nextSameElementIndex, keyOfDeletedElement);
+        }
+        adjustIndexAfterDelete(index, nextSameElementIndex);
+    }
+    void checkNextSameElementIndex(int deletedIndex, int& nextSameElementIndex, const KeyType& keyOfDeletedElement) const
+    {
+        for (int i = deletedIndex, n = m_array.Size(); i < n; ++i)
+        {
+            if (keyEq()(keyOfDeletedElement, Element2Key()(m_array[i])))
+            {
+                nextSameElementIndex = i;
+                break;
+            }
+        }
+    }
+    void adjustIndexAfterDelete(int deletedIndex, int nextSameElementIndex)
+    {
+        for (auto it = m_key2IdxMap.begin(); it != m_key2IdxMap.end(); )
+        {
+            if (it->second < deletedIndex)
+            {
+                ++it;
+            }
+            else if (it->second == deletedIndex)
+            {
+                if (ValidIdx(nextSameElementIndex))    // still exists duplicated element. Update the index to the next duplicated element's index
+                {
+                    it->second = nextSameElementIndex;
+                    ++it;
+                }
+                else                                   // no duplicated element exists, remove the key from the map
+                {
+                    it = m_key2IdxMap.erase(it);
+                }
+            }
+            else // it->second > deletedIndex
+            {
+                --it->second;
+                ++it;
+            }
+        }
+    }
+private:
+    void insertKeyToMap(const KeyType& name, int index)
+    {
+        m_key2IdxMap.insert(std::make_pair(name, index)); // can fail if name already exists
+    }
+};
+
+} // namespace Poseidon::Foundation

--- a/engine/Poseidon/Game/Commands/GameStateExtWorld.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtWorld.cpp
@@ -437,15 +437,11 @@ GameValue MarkerGetPos(const GameState* state, GameValuePar oper1)
     array[1] = 0.0f;
     array[2] = 0.0f;
 
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        ArcadeMarkerInfo& mInfo = markersMap[i];
-        if (stricmp(mInfo.name, name) == 0)
-        {
-            array[0] = mInfo.position.X();
-            array[1] = mInfo.position.Z();
-            break;
-        }
+        array[0] = pInfo->position.X();
+        array[1] = pInfo->position.Z();
     }
     return value;
 }
@@ -460,14 +456,10 @@ GameValue MarkerSetPos(const GameState* state, GameValuePar oper1, GameValuePar 
         return NOTHING;
     }
 
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        ArcadeMarkerInfo& mInfo = markersMap[i];
-        if (stricmp(mInfo.name, name) == 0)
-        {
-            mInfo.position = pos;
-            break;
-        }
+        pInfo->position = pos;
     }
     return NOTHING;
 }
@@ -476,13 +468,10 @@ GameValue MarkerGetType(const GameState* state, GameValuePar oper1)
 {
     GameStringType name = oper1;
 
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        ArcadeMarkerInfo& mInfo = markersMap[i];
-        if (stricmp(mInfo.name, name) == 0)
-        {
-            return mInfo.type;
-        }
+        return pInfo->type;
     }
     return GameStringType("");
 }
@@ -492,15 +481,11 @@ GameValue MarkerSetType(const GameState* state, GameValuePar oper1, GameValuePar
     GameStringType name = oper1;
     GameStringType type = oper2;
 
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        ArcadeMarkerInfo& mInfo = markersMap[i];
-        if (stricmp(mInfo.name, name) == 0)
-        {
-            mInfo.type = type;
-            mInfo.OnTypeChanged();
-            break;
-        }
+        pInfo->type = type;
+        pInfo->OnTypeChanged();
     }
     return NOTHING;
 }
@@ -515,14 +500,11 @@ GameValue MarkerGetSize(const GameState* state, GameValuePar oper1)
     array[0] = 0.0f;
     array[1] = 0.0f;
 
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        ArcadeMarkerInfo& mInfo = markersMap[i];
-        if (stricmp(mInfo.name, name) == 0)
-        {
-            array[0] = mInfo.a;
-            array[1] = mInfo.b;
-        }
+        array[0] = pInfo->a;
+        array[1] = pInfo->b;
     }
     return value;
 }
@@ -538,15 +520,11 @@ GameValue MarkerSetSize(const GameState* state, GameValuePar oper1, GameValuePar
         return NOTHING;
     }
 
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        ArcadeMarkerInfo& mInfo = markersMap[i];
-        if (stricmp(mInfo.name, name) == 0)
-        {
-            mInfo.a = size[0];
-            mInfo.b = size[1];
-            break;
-        }
+        pInfo->a = size[0];
+        pInfo->b = size[1];
     }
     return NOTHING;
 }
@@ -555,13 +533,10 @@ GameValue MarkerGetColor(const GameState* state, GameValuePar oper1)
 {
     GameStringType name = oper1;
 
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        ArcadeMarkerInfo& mInfo = markersMap[i];
-        if (stricmp(mInfo.name, name) == 0)
-        {
-            return mInfo.colorName;
-        }
+        return pInfo->colorName;
     }
     return GameStringType("");
 }
@@ -571,15 +546,11 @@ GameValue MarkerSetColor(const GameState* state, GameValuePar oper1, GameValuePa
     GameStringType name = oper1;
     GameStringType color = oper2;
 
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        ArcadeMarkerInfo& mInfo = markersMap[i];
-        if (stricmp(mInfo.name, name) == 0)
-        {
-            mInfo.colorName = color;
-            mInfo.OnColorChanged();
-            break;
-        }
+        pInfo->colorName = color;
+        pInfo->OnColorChanged();
     }
     return NOTHING;
 }

--- a/engine/Poseidon/Game/Commands/GameStateExtWorldConfig.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtWorldConfig.cpp
@@ -740,18 +740,17 @@ GameValue MarkerCreate(const GameState* state, GameValuePar oper1)
         return RString();
     }
 
-    for (int i = 0; i < markersMap.Size(); i++)
+    // Important: The same-name validation applies only to MarkerCreate, not to markers from mission.sqm.
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        if (stricmp(markersMap[i].name, name) == 0)
-        {
-            return RString();
-        }
+        return RString();
     }
 
-    int index = markersMap.Add();
-    ArcadeMarkerInfo& marker = markersMap[index];
+    ArcadeMarkerInfo marker{};
     marker.name = name;
     marker.position = pos;
+    markersMap.Add(marker);
 
     return array[0];
 }
@@ -759,13 +758,10 @@ GameValue MarkerCreate(const GameState* state, GameValuePar oper1)
 GameValue MarkerDelete(const GameState* state, GameValuePar oper1)
 {
     GameStringType name = oper1;
-    for (int i = 0; i < markersMap.Size(); i++)
+    const int i = markersMap.FindIdx(name);
+    if (markersMap.ValidIdx(i))
     {
-        if (stricmp(markersMap[i].name, name) == 0)
-        {
-            markersMap.Delete(i);
-            break;
-        }
+        markersMap.Delete(i);
     }
     return NOTHING;
 }
@@ -773,13 +769,10 @@ GameValue MarkerDelete(const GameState* state, GameValuePar oper1)
 GameValue MarkerSetText(const GameState* state, GameValuePar oper1, GameValuePar oper2)
 {
     GameStringType name = oper1;
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        if (stricmp(markersMap[i].name, name) == 0)
-        {
-            markersMap[i].text = oper2;
-            break;
-        }
+        pInfo->text = oper2;
     }
     return NOTHING;
 }
@@ -787,14 +780,11 @@ GameValue MarkerSetText(const GameState* state, GameValuePar oper1, GameValuePar
 GameValue MarkerSetShape(const GameState* state, GameValuePar oper1, GameValuePar oper2)
 {
     GameStringType name = oper1;
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        if (stricmp(markersMap[i].name, name) == 0)
-        {
-            GameStringType type = oper2;
-            markersMap[i].markerType = GetEnumValue<MarkerType>((const char*)type);
-            break;
-        }
+        GameStringType type = oper2;
+        pInfo->markerType = GetEnumValue<MarkerType>((const char *)type);
     }
     return NOTHING;
 }
@@ -802,14 +792,11 @@ GameValue MarkerSetShape(const GameState* state, GameValuePar oper1, GameValuePa
 GameValue MarkerSetBrush(const GameState* state, GameValuePar oper1, GameValuePar oper2)
 {
     GameStringType name = oper1;
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        if (stricmp(markersMap[i].name, name) == 0)
-        {
-            markersMap[i].fillName = oper2;
-            markersMap[i].OnFillChanged();
-            break;
-        }
+        pInfo->fillName = oper2;
+        pInfo->OnFillChanged();
     }
     return NOTHING;
 }
@@ -817,12 +804,10 @@ GameValue MarkerSetBrush(const GameState* state, GameValuePar oper1, GameValuePa
 GameValue MarkerGetDir(const GameState* state, GameValuePar oper1)
 {
     GameStringType name = oper1;
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        if (stricmp(markersMap[i].name, name) == 0)
-        {
-            return markersMap[i].angle;
-        }
+        return pInfo->angle;
     }
     return 0.0f;
 }
@@ -830,13 +815,10 @@ GameValue MarkerGetDir(const GameState* state, GameValuePar oper1)
 GameValue MarkerSetDir(const GameState* state, GameValuePar oper1, GameValuePar oper2)
 {
     GameStringType name = oper1;
-    for (int i = 0; i < markersMap.Size(); i++)
+    ArcadeMarkerInfo* pInfo = markersMap.Find(name);
+    if (pInfo)
     {
-        if (stricmp(markersMap[i].name, name) == 0)
-        {
-            markersMap[i].angle = oper2;
-            break;
-        }
+        pInfo->angle = oper2;
     }
     return NOTHING;
 }

--- a/engine/Poseidon/Network/NetworkClientOnMessage.cpp
+++ b/engine/Poseidon/Network/NetworkClientOnMessage.cpp
@@ -1217,34 +1217,27 @@ void NetworkClient::OnMessage(int from, NetworkMessage* msg, NetworkMessageType 
                 break;
             }
             RString name = marker.marker.name;
-            int index = -1;
-            for (int i = 0; i < markersMap.Size(); i++)
+            int index = markersMap.FindIdx(name);
+            if (!markersMap.ValidIdx(index))
             {
-                if (stricmp(markersMap[i].name, name) == 0)
-                {
-                    index = i;
-                    break;
-                }
+                // insert if inexist
+                markersMap.Add(marker.marker);
             }
-            if (index < 0)
+            else
             {
-                index = markersMap.Add();
+                // update. marker's name won't change
+                markersMap[index] = marker.marker;
             }
-            markersMap[index] = marker.marker;
         }
         break;
         case NMTMarkerDelete:
         {
             MarkerDeleteMessage info;
             info.TransferMsg(ctx);
-            for (int i = 0; i < markersMap.Size(); i++)
+            int index = markersMap.FindIdx(info.name);
+            if (markersMap.ValidIdx(index))
             {
-                ArcadeMarkerInfo& marker = markersMap[i];
-                if (marker.name == info.name)
-                {
-                    markersMap.Delete(i);
-                    break;
-                }
+                markersMap.Delete(index);
             }
         }
         break;

--- a/engine/Poseidon/UI/Map/UIMapDisplayBriefing.cpp
+++ b/engine/Poseidon/UI/Map/UIMapDisplayBriefing.cpp
@@ -983,10 +983,10 @@ void DisplayMap::OnHTMLLink(int idc, RString link)
     if (strnicmp(ptr, name, n) == 0)
     {
         ptr += n;
-        for (int i = 0; i < markersMap.Size(); i++)
+        const int i = markersMap.FindIdx(ptr);
+        if (markersMap.ValidIdx(i))
         {
             ArcadeMarkerInfo& mInfo = markersMap[i];
-            if (stricmp(ptr, mInfo.name) == 0)
             {
                 float invSizeLand = 1.0 / (LandGrid * LandRange);
                 Vector3 curPos = _map->GetCenter();
@@ -1800,12 +1800,16 @@ void DisplayMap::OnChildDestroyed(int idd, int exit)
         DisplayInsertMarker* display = dynamic_cast<DisplayInsertMarker*>((ControlsContainer*)_child);
         PoseidonAssert(display);
 
-        int index = markersMap.Add();
+        const int size = markersMap.Size();
+        ArcadeMarkerInfo tempMarker{};
+        char buffer[256];
+        sprintf(buffer, "_USER_DEFINED #%d/%d", GetNetworkManager().GetPlayer(), size);
+        tempMarker.name = buffer;
+        const int index = markersMap.Add(tempMarker);
+        PoseidonAssert(index == size);
+
         ArcadeMarkerInfo& marker = markersMap[index];
         marker.position = _map->ScreenToWorld(DrawCoord(display->_x, display->_y));
-        char buffer[256];
-        snprintf(buffer, sizeof(buffer), "_USER_DEFINED #%d/%d", GetNetworkManager().GetPlayer(), index);
-        marker.name = buffer;
         marker.text = display->_text;
         marker.markerType = MTIcon;
         const ParamEntry& markers = Pars >> "CfgMarkers";

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldMove.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldMove.cpp
@@ -718,6 +718,7 @@ void Man::ResetMovement(float speed, int action)
 static ArcadeMarkerInfo* FindMarker(RString name)
 {
     AUTO_STATIC_ARRAY(int, indices, 16);
+    // Note: Marker lookup remains linear (not hash-based) to maintain legacy behavior, as mission.sqm allows duplicate marker names.
     int len = name.GetLength();
     for (int i = 0; i < markersMap.Size(); i++)
     {

--- a/tests/integration/missions/marker_script_command.Demo/mission.sqm
+++ b/tests/integration/missions/marker_script_command.Demo/mission.sqm
@@ -29,7 +29,7 @@ class Mission
 	};
 	class Markers
 	{
-		items=3;
+		items=9;
 		class Item0
 		{
 			position[]={5978.265137,354.269257,6467.002930};
@@ -50,6 +50,36 @@ class Mission
 			name="conflictName";
 			type="End";
 			colorName="ColorGreen";
+		};
+		class Item3
+		{
+			position[]={0,0,0};
+			name="a";
+		};
+		class Item4
+		{
+			position[]={1,1,1};
+			name="b";
+		};
+		class Item5
+		{
+			position[]={100,100,100};
+			name="a";
+		};
+		class Item6
+		{
+			position[]={2,2,2};
+			name="c";
+		};
+		class Item7
+		{
+			position[]={200,200,200};
+			name="a";
+		};
+		class Item8
+		{
+			position[]={3,3,3};
+			name="d";
 		};
 	};
 };

--- a/tests/integration/missions/marker_script_command.Demo/mission.sqm
+++ b/tests/integration/missions/marker_script_command.Demo/mission.sqm
@@ -1,0 +1,76 @@
+version=11;
+class Mission
+{
+	randomSeed=5997571;
+	class Intel
+	{
+	};
+	class Groups
+	{
+		items=1;
+		class Item0
+		{
+			side="WEST";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={6119.489746,347.468842,6425.809570};
+					id=0;
+					side="WEST";
+					vehicle="SoldierWB";
+					player="PLAYER COMMANDER";
+					leader=1;
+					skill=0.600000;
+				};
+			};
+		};
+	};
+	class Markers
+	{
+		items=3;
+		class Item0
+		{
+			position[]={5978.265137,354.269257,6467.002930};
+			name="conflictName";
+			type="Destroy";
+			colorName="ColorRed";
+		};
+		class Item1
+		{
+			position[]={5972.918945,361.594604,6371.414551};
+			name="conflictName";
+			type="Join";
+			colorName="ColorBlue";
+		};
+		class Item2
+		{
+			position[]={5974.918945,361.594604,6311.414551};
+			name="conflictName";
+			type="End";
+			colorName="ColorGreen";
+		};
+	};
+};
+class Intro
+{
+	randomSeed=11956739;
+	class Intel
+	{
+	};
+};
+class OutroWin
+{
+	randomSeed=2546179;
+	class Intel
+	{
+	};
+};
+class OutroLoose
+{
+	randomSeed=1239555;
+	class Intel
+	{
+	};
+};

--- a/tests/integration/scripting/marker_with_hash.test.sqf
+++ b/tests/integration/scripting/marker_with_hash.test.sqf
@@ -7,17 +7,60 @@ _existedMarker = "conflictName";
 createMarker [_existedMarker, [0, 0, 0]]; // checked in the end
 
 // verify first marker
-if (getMarkerColor _existedMarker != "ColorRed") exitWith { "FAIL: first marker is red" };
+TriAssertEq [getMarkerColor _existedMarker, "ColorRed"]
 
 // verify second marker
 deleteMarker _existedMarker;
-if (getMarkerColor _existedMarker != "ColorBlue") exitWith { "FAIL: second marker is blue" };
+TriAssertEq [getMarkerColor _existedMarker, "ColorBlue"]
 
 // verify third marker
 deleteMarker _existedMarker;
-if (getMarkerColor _existedMarker != "ColorGreen") exitWith { "FAIL: third marker is green" };
+TriAssertEq [getMarkerColor _existedMarker, "ColorGreen"]
 
 // check no marker left
-if (getMarkerColor _existedMarker != "") exitWith { "FAIL: expected no more marker left after having remoted existed 3 markers defined by mission.sqm" };
+deleteMarker _existedMarker;
+TriAssertEq [getMarkerColor _existedMarker, ""]
+
+
+// check delete dubpicate markers
+// existing markers defined by mission.sqm: a, b, a, c, a, d
+
+// verify b/c/d
+TriAssertEq [(getMarkerPos "b") select 0, 1];
+TriAssertEq [(getMarkerPos "c") select 0, 2];
+TriAssertEq [(getMarkerPos "d") select 0, 3];
+
+// remove first "a" marker
+deleteMarker "a";
+// markers now are b, a, c, a, d. Index of a is now 1 and 3. Index of b is 0, c is 2, d is 4
+
+// verify second "a"
+TriAssertEq [(getMarkerPos "a") select 0, 100];
+
+// verify b/c/d
+TriAssertEq [(getMarkerPos "b") select 0, 1];
+TriAssertEq [(getMarkerPos "c") select 0, 2];
+TriAssertEq [(getMarkerPos "d") select 0, 3];
+
+// remove second "a" marker
+deleteMarker "a";
+// markers now are b, c, a, d. Index of a is now 2. Index of b is 0, c is 1, d is 3
+
+// verify third "a"
+TriAssertEq [(getMarkerPos "a") select 0, 200];
+
+// verify b/c/d
+TriAssertEq [(getMarkerPos "b") select 0, 1];
+TriAssertEq [(getMarkerPos "c") select 0, 2];
+TriAssertEq [(getMarkerPos "d") select 0, 3];
+
+// remove third "a" marker
+deleteMarker "a";
+// markers now are b, c, d. Index of b is 0, c is 1, d is 2
+
+// verify b/c/d
+TriAssertEq [(getMarkerPos "b") select 0, 1];
+TriAssertEq [(getMarkerPos "c") select 0, 2];
+TriAssertEq [(getMarkerPos "d") select 0, 3];
 
 triEndTest

--- a/tests/integration/scripting/marker_with_hash.test.sqf
+++ b/tests/integration/scripting/marker_with_hash.test.sqf
@@ -1,0 +1,23 @@
+// test enableAi and checkAIFeature
+
+triSimUntil { time >= 1 }
+
+// create exist marker will fail
+_existedMarker = "conflictName";
+createMarker [_existedMarker, [0, 0, 0]]; // checked in the end
+
+// verify first marker
+if (getMarkerColor _existedMarker != "ColorRed") exitWith { "FAIL: first marker is red" };
+
+// verify second marker
+deleteMarker _existedMarker;
+if (getMarkerColor _existedMarker != "ColorBlue") exitWith { "FAIL: second marker is blue" };
+
+// verify third marker
+deleteMarker _existedMarker;
+if (getMarkerColor _existedMarker != "ColorGreen") exitWith { "FAIL: third marker is green" };
+
+// check no marker left
+if (getMarkerColor _existedMarker != "") exitWith { "FAIL: expected no more marker left after having remoted existed 3 markers defined by mission.sqm" };
+
+triEndTest

--- a/tests/integration/scripting/marker_with_hash.test.toml
+++ b/tests/integration/scripting/marker_with_hash.test.toml
@@ -1,0 +1,4 @@
+tags = ["scripting", "headless"]
+binary = "PoseidonGame"
+mission = "tests/integration/missions/marker_script_command.Demo"
+timeout = 60


### PR DESCRIPTION
The existing code processes markers using linear traversal. For CTI‑like missions with thousands of markers and millions of computations, a hash table should be adopted to handle them efficiently.

Tested and widely used in TZK 2.03 for 1 year

Integration test cases prepared and passed.