### PR TITLE
Update README to mention the full game assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ On GNU/Linux, use the matching `linux-x64-clang-rwdi` preset.
 
 ### Testing
 
-Copy game binaries from `dist/` into [Steam Demo folder](https://store.steampowered.com/app/4819000/Arma_Cold_War_Assault_Remastered_Demo/) and start.
+Copy game binaries from `dist/` into the [Steam game's Remastered folder](https://store.steampowered.com/app/65790/Arma_Cold_War_Assault_Remastered/)
+or the [Steam demo folder](https://store.steampowered.com/app/4819000/Arma_Cold_War_Assault_Remastered_Demo/) and start.
 
 > [!WARNING]
 > Compiled binaries are not drop-in compatible with original game folder. See https://github.com/ofpisnotdead-com/CWR-CE/issues/8#issuecomment-4772323490 and https://github.com/ofpisnotdead-com/CWR-CE/issues/29#issuecomment-4803747960 for more info.
@@ -100,10 +101,11 @@ by Bohemia Interactive under the **Arma Public License Share Alike (APL-SA)**:
 
 ### Getting game data to run what you build
 
-The compiled binaries need game data to run. You can obtain the **free Demo game
-data** on Steam:
+The compiled binaries need game data to run. You can obtain the **free demo game
+data** or the paid full game on Steam:
 
-- *Arma: Cold War Assault Remastered* Demo on Steam: <https://store.steampowered.com/app/4819000>
+- *Arma: Cold War Assault Remastered* demo on Steam: <https://store.steampowered.com/app/4819000>
+- *Arma: Cold War Assault Remastered* full game on Steam: <https://store.steampowered.com/app/65790>
 
 The full game data ships with the retail game. Whatever you do with assets is
 governed by the APL-SA linked above; whatever you do with this source is governed by


### PR DESCRIPTION
The remastered data needed to run the full game is now available on Steam. This links to it and provides basic instructions to get started.

It may be that we want to adjust wording or present this differently. I was trying to make the smallest changes to where we were already mentioning the demo.