### PR TITLE
Options: Replace controls reset with presets page

### DIFF
--- a/engine/Poseidon/Input/InputSubsystem.cpp
+++ b/engine/Poseidon/Input/InputSubsystem.cpp
@@ -1142,9 +1142,8 @@ UserAction InputSubsystem::FindBindingConflict(int packedCode, UserAction exclud
     return UAN;
 }
 
-void InputSubsystem::ResetCategoryDefaults(ControlsCategory cat)
+void InputSubsystem::ResetCategory(ControlsCategory cat, UserActionDesc* descs)
 {
-    UserActionDesc* descs = GetUserActionDesc();
     const UserAction* list = GetControlsCategoryActions(cat);
     ContextList contexts = ContextsForCategory(cat);
     for (int i = 0; list[i] != UAN; i++)
@@ -1169,6 +1168,11 @@ void InputSubsystem::ResetCategoryDefaults(ControlsCategory cat)
                 profile.Bind(static_cast<UserAction>(idx), binding);
         }
     }
+}
+
+void InputSubsystem::ResetCategoryDefaults(ControlsCategory cat)
+{
+    ResetCategory(cat, GetUserActionDesc());
 }
 
 UserActionDesc* InputSubsystem::GetUserActionDesc()
@@ -1233,6 +1237,92 @@ UserActionDesc* InputSubsystem::GetUserActionDesc()
         UserActionDesc("SelectAll", IDS_USRACT_SELECT_ALL, SDL_SCANCODE_GRAVE, -1),
         UserActionDesc("Turbo", IDS_USRACT_TURBO, SDL_SCANCODE_LSHIFT, SDL_SCANCODE_RSHIFT, -1),
         UserActionDesc("Walk", IDS_USRACT_WALK, SDL_SCANCODE_F, -1),
+        UserActionDesc(true, "AxisTurn", IDS_USRACT_TURN, INPUT_DEVICE_STICK_AXIS + 0, -1),
+        UserActionDesc(true, "AxisDive", IDS_USRACT_ACCELERATE, INPUT_DEVICE_STICK_AXIS + 1, -1),
+        UserActionDesc(true, "AxisRudder", IDS_USRACT_RUDDER, INPUT_DEVICE_STICK_AXIS + 5, -1),
+        UserActionDesc(true, "AxisThrust", IDS_USRACT_THRUST, INPUT_DEVICE_STICK_AXIS + 2, INPUT_DEVICE_STICK_AXIS + 6,
+                       -1),
+        UserActionDesc("AimUp", IDS_USRACT_AIM_UP, -1),
+        UserActionDesc("AimDown", IDS_USRACT_AIM_DOWN, -1),
+        UserActionDesc("AimLeft", IDS_USRACT_AIM_LEFT, -1),
+        UserActionDesc("AimRight", IDS_USRACT_AIM_RIGHT, -1),
+#if _ENABLE_CHEATS
+        UserActionDesc("Cheat1", IDS_USRACT_CHEAT_1, SDL_SCANCODE_RGUI, -1),
+        UserActionDesc("Cheat2", IDS_USRACT_CHEAT_2, SDL_SCANCODE_RALT, -1),
+#endif
+    };
+    return userActionDesc;
+}
+
+void InputSubsystem::ResetCategoryA3Legacy(ControlsCategory cat)
+{
+    ResetCategory(cat, GetUserActionDescA3Legacy());
+}
+
+UserActionDesc* InputSubsystem::GetUserActionDescA3Legacy()
+{
+    static UserActionDesc userActionDesc[] = {
+        UserActionDesc("MoveForward", IDS_USRACT_MOVE_FORWARD, SDL_SCANCODE_W, SDL_SCANCODE_UP, -1),
+        UserActionDesc("MoveBack", IDS_USRACT_MOVE_BACK, SDL_SCANCODE_S, SDL_SCANCODE_DOWN, -1),
+        UserActionDesc("TurnLeft", IDS_USRACT_TURN_LEFT, SDL_SCANCODE_A, SDL_SCANCODE_LEFT, -1),
+        UserActionDesc("TurnRight", IDS_USRACT_TURN_RIGHT, SDL_SCANCODE_D, SDL_SCANCODE_RIGHT, -1),
+        UserActionDesc("MoveUp", IDS_USRACT_MOVE_UP, SDL_SCANCODE_Q, SDL_SCANCODE_PAGEUP,
+                       -1), // Leave as Q because it should be shift when flying but x on foot
+        UserActionDesc("MoveDown", IDS_USRACT_MOVE_DOWN, SDL_SCANCODE_Z, SDL_SCANCODE_PAGEDOWN, -1),
+        UserActionDesc("MoveFastForward", IDS_USRACT_FAST_FORWARD, -1),
+        UserActionDesc("MoveSlowForward", IDS_USRACT_SLOW_FORWARD, SDL_SCANCODE_Q, -1),
+        UserActionDesc("MoveLeft", IDS_USRACT_MOVE_LEFT, SDL_SCANCODE_X, SDL_SCANCODE_DELETE, -1),
+        UserActionDesc("MoveRight", IDS_USRACT_MOVE_RIGHT, SDL_SCANCODE_C, SDL_SCANCODE_END, -1),
+        UserActionDesc("ToggleWeapons", IDS_USRACT_TOGGLE_WEAPONS, SDL_SCANCODE_F, SDL_SCANCODE_RCTRL,
+                       INPUT_DEVICE_STICK + 3, -1),
+        UserActionDesc("Fire", IDS_USRACT_FIRE, INPUT_DEVICE_STICK + 7, -1),
+        UserActionDesc("ReloadMagazine", IDS_USRACT_RELOAD_MAGAZINE, SDL_SCANCODE_R, SDL_SCANCODE_HOME,
+                       INPUT_DEVICE_STICK + 2, -1),
+        UserActionDesc("LockTargets", IDS_USRACT_LOCK_TARGETS, SDL_SCANCODE_R, INPUT_DEVICE_STICK + 1, -1),
+        UserActionDesc("LockTarget", IDS_USRACT_LOCK_OR_ZOOM, INPUT_DEVICE_MOUSE + 1, -1),
+        UserActionDesc("RevealTarget", IDS_USRACT_REVEAL_TARGET, SDL_SCANCODE_T, -1),
+        UserActionDesc("PrevAction", IDS_USRACT_PREV_ACTION, SDL_SCANCODE_LEFTBRACKET, INPUT_DEVICE_STICK + 4,
+                       INPUT_DEVICE_STICK_POV + 0, -1),
+        UserActionDesc("NextAction", IDS_USRACT_NEXT_ACTION, SDL_SCANCODE_RIGHTBRACKET, INPUT_DEVICE_STICK + 5,
+                       INPUT_DEVICE_STICK_POV + 4, -1),
+        UserActionDesc("Action", IDS_USRACT_ACTION, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN, INPUT_DEVICE_MOUSE + 2,
+                       INPUT_DEVICE_STICK + 0, -1),
+        UserActionDesc("Headlights", IDS_USRACT_HEADLIGHTS, SDL_SCANCODE_L, -1),
+        UserActionDesc("NightVision", IDS_USRACT_NIGHT_VISION, SDL_SCANCODE_N, -1),
+        UserActionDesc("Binocular", IDS_USRACT_BINOCULAR, SDL_SCANCODE_B, -1),
+        UserActionDesc("Handgun", IDS_USRACT_HANDGUN, SDL_SCANCODE_SEMICOLON, -1),
+        UserActionDesc("Compass", IDS_USRACT_COMPASS, SDL_SCANCODE_K, INPUT_DEVICE_STICK_POV + 6, -1),
+        UserActionDesc("Watch", IDS_USRACT_WATCH, SDL_SCANCODE_O, INPUT_DEVICE_STICK_POV + 2, -1),
+        UserActionDesc("Map", IDS_USRACT_MAP, SDL_SCANCODE_M, INPUT_DEVICE_STICK + 8, -1),
+        UserActionDesc("Help", IDS_USRACT_HELP, SDL_SCANCODE_H, INPUT_DEVICE_STICK + 9, -1),
+        UserActionDesc("TimeInc", IDS_USRACT_TIME_INC, SDL_SCANCODE_EQUALS, -1),
+        UserActionDesc("TimeDec", IDS_USRACT_TIME_DEC, SDL_SCANCODE_MINUS, -1),
+        UserActionDesc("Optics", IDS_USRACT_OPTICS, SDL_SCANCODE_V, SDL_SCANCODE_KP_0,
+                       -1), // This is a big departure from A3, should be tap right click
+        UserActionDesc("PersonView", IDS_USRACT_PERSON_VIEW, SDL_SCANCODE_KP_ENTER, -1),
+        UserActionDesc("TacticalView", IDS_USRACT_TACTICAL_VIEW, SDL_SCANCODE_KP_PERIOD, -1),
+        UserActionDesc("ZoomIn", IDS_USRACT_ZOOM_IN, SDL_SCANCODE_KP_PLUS, -1),
+        UserActionDesc("ZoomOut", IDS_USRACT_ZOOM_OUT, SDL_SCANCODE_KP_MINUS, -1),
+        UserActionDesc("LookAround", IDS_USRACT_LOOK_ARROUND, SDL_SCANCODE_LALT, INPUT_DEVICE_STICK + 6, -1),
+        UserActionDesc("LookAroundToggle", IDS_USRACT_LOOK_ARROUND_TOGGLE, SDL_SCANCODE_KP_MULTIPLY, -1),
+        UserActionDesc("LookLeftDown", IDS_USRACT_LOOK_LEFT_DOWN, SDL_SCANCODE_KP_1, -1),
+        UserActionDesc("LookDown", IDS_USRACT_LOOK_DOWN, SDL_SCANCODE_KP_2, -1),
+        UserActionDesc("LookRightDown", IDS_USRACT_LOOK_RIGHT_DOWN, SDL_SCANCODE_KP_3, -1),
+        UserActionDesc("LookLeft", IDS_USRACT_LOOK_LEFT, SDL_SCANCODE_KP_4, -1),
+        UserActionDesc("LookCenter", IDS_USRACT_LOOK_CENTER, SDL_SCANCODE_KP_5, INPUT_DEVICE_STICK + 11, -1),
+        UserActionDesc("LookRight", IDS_USRACT_LOOK_RIGHT, SDL_SCANCODE_KP_6, -1),
+        UserActionDesc("LookLeftUp", IDS_USRACT_LOOK_LEFT_UP, SDL_SCANCODE_KP_7, -1),
+        UserActionDesc("LookUp", IDS_USRACT_LOOK_UP, SDL_SCANCODE_KP_8, -1),
+        UserActionDesc("LookRightUp", IDS_USRACT_LOOK_RIGHT_UP, SDL_SCANCODE_KP_9, -1),
+        UserActionDesc("PrevChannel", IDS_USRACT_PREV_CHANNEL, SDL_SCANCODE_COMMA, -1),
+        UserActionDesc("NextChannel", IDS_USRACT_NEXT_CHANNEL, SDL_SCANCODE_PERIOD, -1),
+        UserActionDesc("Chat", IDS_USRACT_CHAT, SDL_SCANCODE_SLASH, -1),
+        UserActionDesc("VoiceOverNet", IDS_USRACT_VOICE_OVER_NET, SDL_SCANCODE_CAPSLOCK, -1),
+        UserActionDesc("NetworkStats", IDS_USRACT_NETWORK_STATS, SDL_SCANCODE_P, -1),
+        UserActionDesc("NetworkPlayers", IDS_USRACT_NETWORK_PLAYERS, SDL_SCANCODE_I, -1), // This would be shift+p
+        UserActionDesc("SelectAll", IDS_USRACT_SELECT_ALL, SDL_SCANCODE_GRAVE, -1),
+        UserActionDesc("Turbo", IDS_USRACT_TURBO, SDL_SCANCODE_LSHIFT, SDL_SCANCODE_RSHIFT, -1),
+        UserActionDesc("Walk", IDS_USRACT_WALK, -1), // Walk would be a w+s toggle
         UserActionDesc(true, "AxisTurn", IDS_USRACT_TURN, INPUT_DEVICE_STICK_AXIS + 0, -1),
         UserActionDesc(true, "AxisDive", IDS_USRACT_ACCELERATE, INPUT_DEVICE_STICK_AXIS + 1, -1),
         UserActionDesc(true, "AxisRudder", IDS_USRACT_RUDDER, INPUT_DEVICE_STICK_AXIS + 5, -1),

--- a/engine/Poseidon/Input/InputSubsystem.hpp
+++ b/engine/Poseidon/Input/InputSubsystem.hpp
@@ -163,6 +163,7 @@ class InputSubsystem
 
     // Action descriptions
     static UserActionDesc* GetUserActionDesc();
+    static UserActionDesc* GetUserActionDescA3Legacy();
 
     // Config settings
     bool IsReverseMouse() const;
@@ -202,15 +203,14 @@ class InputSubsystem
     // both code AND modifier match, so "Ctrl+W" doesn't conflict with bare
     // "W".  Returns UAN if no conflict.  Pass excludeSlot = -1 to scan
     // every slot of excludeAction too.  modifier = -1 means "no modifier".
-    UserAction FindBindingConflict(int packedCode,
-                                   UserAction excludeAction = UAN,
-                                   int excludeSlot = -1,
+    UserAction FindBindingConflict(int packedCode, UserAction excludeAction = UAN, int excludeSlot = -1,
                                    int modifier = -1) const;
 
     // Restore the engine defaults (UserActionDesc[i].keys) for every
     // action in the given Controls UI category.  Other categories'
     // bindings are left untouched.  Caller persists via SaveKeys().
     void ResetCategoryDefaults(ControlsCategory cat);
+    void ResetCategoryA3Legacy(ControlsCategory cat);
 
     // Binding detection — hardware polling for rebind UI
     bool GetMouseButtonToDo(int i) const;
@@ -239,6 +239,7 @@ class InputSubsystem
     InputSubsystem(const InputSubsystem&) = delete;
     InputSubsystem& operator=(const InputSubsystem&) = delete;
 
+    void ResetCategory(ControlsCategory cat, UserActionDesc* descs);
     void ComputeMovementState();
     void SyncToGInput();
 
@@ -265,4 +266,3 @@ class InputSubsystem
     float syntheticLeftStickY_ = 0.0f;
 };
 } // namespace Poseidon
-

--- a/engine/Poseidon/UI/Options/ControlsPage.cpp
+++ b/engine/Poseidon/UI/Options/ControlsPage.cpp
@@ -1,11 +1,11 @@
 #include <Poseidon/UI/Options/ControlsPage.hpp>
 
-#include <Poseidon/UI/Options/ConfirmPage.hpp>
 #include <Poseidon/UI/Options/GamepadPage.hpp>
 #include <Poseidon/UI/Options/GamepadTuningPage.hpp>
 #include <Poseidon/UI/Options/KbmPage.hpp>
 #include <Poseidon/UI/Options/MousePage.hpp>
 #include <Poseidon/UI/Options/OptionsShell.hpp>
+#include <Poseidon/UI/Options/PresetsPage.hpp>
 
 #include <Poseidon/Input/InputSubsystem.hpp>
 
@@ -44,22 +44,9 @@ bool ControlsPage::OnNav(OptionsShell& shell, int idc)
             shell.PushPage(std::make_unique<GamepadTuningPage>());
             return true;
 
-        case 1403: // Reset all to defaults — confirm first
-        {
-            auto onYes = []()
-            {
-                auto& sub = InputSubsystem::Instance();
-                for (int c = 0; c < ControlsCategoryCount; ++c)
-                    sub.ResetCategoryDefaults((ControlsCategory)c);
-                sub.SaveKeys();
-            };
-            shell.PushPage(std::make_unique<ConfirmPage>(
-                std::string((const char*)LocalizeString("STR_DISP_OPT_CONFIRM_RESET_TITLE")),
-                std::string((const char*)LocalizeString("STR_DISP_OPT_CONFIRM_RESET_BODY")), std::move(onYes),
-                std::string((const char*)LocalizeString("STR_DISP_OPT_CTL_RESET_ALL")),
-                std::string((const char*)LocalizeString("STR_DISP_OPT_CAP_CANCEL"))));
+        case 1403: // Presets
+            shell.PushPage(std::make_unique<PresetsPage>());
             return true;
-        }
     }
     return false;
 }

--- a/engine/Poseidon/UI/Options/ControlsPage.hpp
+++ b/engine/Poseidon/UI/Options/ControlsPage.hpp
@@ -4,12 +4,11 @@
 //
 // Rows: Keyboard & Mouse (binding rebinder), Mouse (sensitivity /
 // Y-invert / button swap), Gamepad (binding rebinder), Gamepad Tuning
-// (deadzones / sensitivity), Reset all to defaults, Close.  Mirrors
+// (deadzones / sensitivity), Reset all to presets, Close.  Mirrors
 // IndexPage's FlatMenuPage shape — see optionsShell.hpp's
 // "RscOptionsPageControls" for the resource bundle.
 
 #include <Poseidon/UI/Options/FlatMenuPage.hpp>
-
 
 namespace Poseidon
 {
@@ -18,7 +17,7 @@ class ControlsPage : public FlatMenuPage
   public:
     ControlsPage() : FlatMenuPage(kCycle, kCycleSize) {}
 
-    const char* TitleText() const override; // STR_DISP_OPT_CONTROLS
+    const char* TitleText() const override;               // STR_DISP_OPT_CONTROLS
     int DefaultFocusIdc() const override { return 1401; } // Keyboard & Mouse — top row
     const char* ResourceClassName() const override { return "RscOptionsPageControls"; }
 
@@ -28,8 +27,8 @@ class ControlsPage : public FlatMenuPage
   private:
     // Cycle order matches the visible row layout in RscOptionsPageControls.
     // 1401 KB&M · 1402 Mouse · 1405 Gamepad · 1406 Gamepad Tuning ·
-    // 1403 Reset all · 1404 Close.  Stay in sync with the resource bundle
-    // when adding rows.
+    // 1403 Reset all to presets · 1404 Close.  Stay in sync with the
+    // resource bundle when adding rows.
     static constexpr int kCycle[] = {1401, 1402, 1405, 1406, 1403, 1404};
     static constexpr int kCycleSize = sizeof(kCycle) / sizeof(kCycle[0]);
 };

--- a/engine/Poseidon/UI/Options/PresetsPage.cpp
+++ b/engine/Poseidon/UI/Options/PresetsPage.cpp
@@ -1,0 +1,164 @@
+#include <Poseidon/UI/Options/ConfirmPage.hpp>
+#include <Poseidon/UI/Options/OptionsShell.hpp>
+#include <Poseidon/UI/Options/PresetsPage.hpp>
+
+#include <Poseidon/Input/InputSubsystem.hpp>
+
+#include <Poseidon/UI/Locale/Stringtable/Stringtable.hpp>
+
+using namespace Poseidon;
+namespace Poseidon
+{
+extern Input GInput;
+}
+
+const char* PresetsPage::TitleText() const
+{
+    return LocalizeStringWithFallback("STR_DISP_OPT_CTL_PRESETS", "Reset All");
+}
+
+const char* PresetsPage::CloseLabel()
+{
+    return LocalizeString("STR_DISP_CLOSE");
+}
+
+const char* PresetsPage::CloseDescription()
+{
+    return LocalizeString("STR_DISP_MAIN_OPT_CLOSE_DESC");
+}
+
+void PresetsPage::OnReshown(OptionsShell& shell)
+{
+    m_provider.SetCloseTexts(CloseLabel(), CloseDescription());
+    ScrollListPage::OnReshown(shell);
+}
+
+const char* PresetsPage::PresetsProvider::RowLabel(int row) const
+{
+    switch (row)
+    {
+        case kRowPreset:
+            return LocalizeStringWithFallback("STR_DISP_OPT_CTL_PRESETS_PRESET", "Preset");
+        case kRowApplyPreset:
+            return LocalizeStringWithFallback("STR_DISP_OPT_CTL_PRESETS_APPLY", "Reset all to preset");
+        default:
+            return "";
+    }
+}
+
+const char* PresetsPage::PresetsProvider::RowDescription(int row) const
+{
+    switch (row)
+    {
+        case kRowPreset:
+            return LocalizeStringWithFallback("STR_DISP_OPT_CTL_PRESETS_PRESET_DESC",
+                                              "Choose which preset to reset controls to.");
+        case kRowApplyPreset:
+            return LocalizeStringWithFallback("STR_DISP_OPT_CTL_PRESETS_APPLY_DESC",
+                                              "Apply the selected preset to all controls.");
+        default:
+            return "";
+    }
+}
+
+OptionsScrollList::RowDef PresetsPage::PresetsProvider::RowFor(int row) const
+{
+    RefreshStepperTexts();
+    switch (row)
+    {
+        case kRowPreset:
+            return {702, m_stepperOptions.data(), (int)m_stepperOptions.size()};
+        default:
+            return {-1, nullptr, 0};
+    }
+}
+
+OptionsScrollList::Kind PresetsPage::PresetsProvider::RowKind(int row) const
+{
+    switch (row)
+    {
+        case kRowPreset:
+            return OptionsScrollList::KindStepper;
+        case kRowApplyPreset:
+            return OptionsScrollList::KindAction;
+        default:
+            return OptionsScrollList::Provider::RowKind(row);
+    }
+}
+
+void PresetsPage::PresetsProvider::RefreshStepperTexts() const
+{
+    m_stepperText[0] = LocalizeString("STR_DISP_DEFAULT");
+    m_stepperText[1] = LocalizeStringWithFallback("STR_DISP_OPT_CTL_PRESETS_A3_LEGACY", "A3 Legacy");
+    m_stepperOptions[0] = m_stepperText[0].c_str();
+    m_stepperOptions[1] = m_stepperText[1].c_str();
+}
+
+int PresetsPage::PresetsProvider::RowValue(int row) const
+{
+    switch (row)
+    {
+        case kRowPreset:
+            return m_preset;
+        default:
+            return 0;
+    }
+}
+
+void PresetsPage::PresetsProvider::SetRowValue(int row, int value)
+{
+    switch (row)
+    {
+        case kRowPreset:
+            if (value < 0 || value >= 2)
+                return;
+            m_preset = value;
+            return;
+        default:
+            return;
+    }
+}
+
+void PresetsPage::PresetsProvider::OnRowAction(int row, Display& host)
+{
+    if (row != kRowApplyPreset)
+        return;
+    if (m_preset < 0 || m_preset > 1)
+        return;
+
+    auto* shell = dynamic_cast<OptionsShell*>(&host);
+    if (!shell)
+        return;
+
+    // New variable is needed to capture in onYes
+    int preset = m_preset;
+
+    char title[160];
+    snprintf(
+        title, sizeof(title),
+        (const char*)LocalizeStringWithFallback("STR_DISP_OPT_CTL_RESET_PRESET", "Reset all to controls to \"%s\"?"),
+        m_stepperOptions[preset]);
+    char confirm[160];
+    snprintf(confirm, sizeof(confirm),
+             (const char*)LocalizeStringWithFallback("STR_DISP_OPT_CTL_CONFIRM_PRESET", "Reset all to \"%s\"?"),
+             m_stepperOptions[preset]);
+
+    auto onYes = [shell, preset]()
+    {
+        auto& sub = InputSubsystem::Instance();
+        for (int c = 0; c < ControlsCategoryCount; ++c)
+            switch (preset)
+            {
+                case 0:
+                    sub.ResetCategoryDefaults((ControlsCategory)c);
+                case 1:
+                    sub.ResetCategoryA3Legacy((ControlsCategory)c);
+            }
+        sub.SaveKeys();
+
+        shell->PopPage();
+    };
+    shell->PushPage(std::make_unique<ConfirmPage>(
+        title, std::string((const char*)LocalizeString("STR_DISP_OPT_CONFIRM_RESET_BODY")), std::move(onYes), confirm,
+        std::string((const char*)LocalizeString("STR_DISP_OPT_CAP_CANCEL"))));
+}

--- a/engine/Poseidon/UI/Options/PresetsPage.hpp
+++ b/engine/Poseidon/UI/Options/PresetsPage.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+// Presets page for resetting all controls to presets. Gives a choice
+// between presets and presents a confirm dialog before applying the
+// change. This replaces the previous "Reset all to defaults" flow.
+
+#include <Poseidon/UI/Options/ScrollListPage.hpp>
+
+#include <array>
+#include <string>
+
+namespace Poseidon
+{
+
+class PresetsPage : public ScrollListPage
+{
+  public:
+    const char* TitleText() const override;
+
+    void OnReshown(OptionsShell& shell) override;
+
+  protected:
+    OptionsScrollList::Provider& ProviderRef() override { return m_provider; }
+
+  private:
+    static const char* CloseLabel();
+    static const char* CloseDescription();
+
+    class PresetsProvider : public OptionsScrollList::Provider
+    {
+      public:
+        enum : int
+        {
+            kRowPreset = 0,
+            kRowApplyPreset = 1,
+            kRowCount = 2,
+        };
+
+        int RowCount() const override { return kRowCount; }
+        const char* RowLabel(int row) const override;
+        const char* RowDescription(int row) const override;
+        OptionsScrollList::RowDef RowFor(int row) const override;
+        int RowValue(int row) const override;
+        void SetRowValue(int row, int value) override;
+        OptionsScrollList::Kind RowKind(int row) const override;
+        void OnRowAction(int row, Display& host) override;
+
+      private:
+        void RefreshStepperTexts() const;
+
+        mutable int m_preset = 0;
+        mutable std::array<std::string, 2> m_stepperText;
+        mutable std::array<const char*, 2> m_stepperOptions{};
+    };
+
+    PresetsProvider m_presets_provider;
+    OptionsScrollList::WithCloseRow m_provider{m_presets_provider, CloseLabel(), CloseDescription()};
+};
+
+} // namespace Poseidon

--- a/tests/integration/ui/main_menu/options_shell.test.sqf
+++ b/tests/integration/ui/main_menu/options_shell.test.sqf
@@ -13,12 +13,16 @@ triClickText "Controls"
 triWaitFrames 5
 
 triClickText "Reset all to defaults"
+triAssertIncludes [(triVisibleTexts), "Preset"]
+triScreenshot "02_presets_page"
+
+triClickText "Reset all to preset"
 triAssertIncludes [(triVisibleTexts), "Cancel"]
-triScreenshot "02_confirm_modal"
+triScreenshot "03_confirm_modal"
 
 triSendKey 88
 triAssertExcludes [(triVisibleTexts), "Cancel"]
-triAssertIncludes [(triVisibleTexts), "Keyboard & Mouse"]
-triScreenshot "03_modal_closed_with_keypad_enter"
+triAssertIncludes [(triVisibleTexts), "Preset"]
+triScreenshot "04_modal_closed_with_keypad_enter"
 
 triEndTest

--- a/tests/integration/ui/options/controls/options_controls_gamepad_parity.test.sqf
+++ b/tests/integration/ui/options/controls/options_controls_gamepad_parity.test.sqf
@@ -37,10 +37,14 @@ triGpadPov 4            // Down -> Reset all to defaults
 triWaitFrames 5
 triAssert [(triGetControlFocused 1403)]
 
-triGpadButton 0         // A -> open confirm modal
+triGpadButton 0         // A -> open Presets page
 triWaitFrames 5
+triAssertIncludes [(triVisibleTexts), "Preset"]
+
+triGpadPov 4            // Down -> Reset all to preset
+triGpadButton 0         // A -> open confirm modal
 triAssert [(triGetControlFocused 9102)]   // Cancel default
-triAssertIncludes [(triVisibleTexts), "Reset all to defaults"]
+triAssertIncludes [(triVisibleTexts), "Reset all to ""Default"""]
 triAssertIncludes [(triVisibleTexts), "Cancel"]
 
 triGpadPov 6            // Left -> Reset
@@ -54,8 +58,8 @@ triScreenshot "02_reset_confirm_via_gamepad"
 
 triGpadButton 1         // B -> cancel modal
 triWaitFrames 5
-triAssert [(triGetControlFocused 1403)]
-triAssertIncludes [(triVisibleTexts), "Reset all to defaults"]
-triScreenshot "03_back_at_controls_after_gamepad_cancel"
+triAssert [(triGetControlFocused 711)]
+triAssertIncludes [(triVisibleTexts), "Preset"]
+triScreenshot "03_back_at_presets_after_gamepad_cancel"
 
 triEndTest

--- a/tests/unit/engine/Poseidon/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/CMakeLists.txt
@@ -475,6 +475,7 @@ list(APPEND POSEIDON_TEST_SOURCES
     UI/test_gameModule.cpp
     UI/test_viewer_cursor_overlay.cpp
     UI/test_game_cursor_overlay.cpp
+    UI/test_presets_page.cpp
     UI/InGame/test_inGameUI.cpp
     # Vehicles tests
     World/Entities/Vehicles/test_transport.cpp

--- a/tests/unit/engine/Poseidon/UI/test_presets_page.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_presets_page.cpp
@@ -1,0 +1,90 @@
+// PresetsPage Provider tests
+
+#include <Poseidon/UI/Options/PresetsPage.hpp>
+#include <Poseidon/UI/Options/OptionsScrollList.hpp>
+#include <Poseidon/UI/Locale/Stringtable/Stringtable.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <string>
+
+using namespace Poseidon;
+
+namespace
+{
+class TestablePresetsPage : public PresetsPage
+{
+  public:
+    OptionsScrollList::Provider& Provider() { return ProviderRef(); }
+};
+
+void LoadMainMenuStringtable()
+{
+    static bool loaded = false;
+    if (loaded)
+    {
+        SetLanguage("English");
+        return;
+    }
+
+    const std::filesystem::path csv =
+        std::filesystem::path(TESTS_ROOT_DIR) / "fixtures" / "stringtable" / "STRINGTABLE_MAINMENU.utf8.csv";
+    LoadStringtable("global", csv.string().c_str(), 0.0f, true);
+    SetLanguage("English");
+    loaded = true;
+}
+} // namespace
+
+// ---------------------------------------------------------------------------
+// TestablePresetsPage: stepper row + action rows + auto Close.
+
+TEST_CASE("PresetsPage: provider exposes stepper row + action row + close", "[UI][PresetsPage]")
+{
+    TestablePresetsPage page;
+    auto& p = page.Provider();
+    CHECK(p.RowCount() == 3);
+}
+
+TEST_CASE("PresetsPage: row labels", "[UI][PresetsPage]")
+{
+    LoadMainMenuStringtable();
+
+    TestablePresetsPage page;
+    auto& p = page.Provider();
+    CHECK(std::string(page.TitleText()) == "Reset All");
+    CHECK(std::string(p.RowLabel(0)) == "Preset");
+    CHECK(std::string(p.RowLabel(1)) == "Reset all to preset");
+}
+
+TEST_CASE("PresetsPage: row descriptions localize from the main menu shard", "[UI][PresetsPage]")
+{
+    LoadMainMenuStringtable();
+
+    TestablePresetsPage page;
+    auto& p = page.Provider();
+    CHECK(std::string(p.RowDescription(0)) == "Choose which preset to reset controls to.");
+    CHECK(std::string(p.RowDescription(1)) == "Apply the selected preset to all controls.");
+}
+
+TEST_CASE("PresetsPage: row kinds - presets stepper + apply action + close action", "[UI][PresetsPage]")
+{
+    TestablePresetsPage page;
+    auto& p = page.Provider();
+    CHECK(p.RowKind(0) == OptionsScrollList::KindStepper); // presets stepper
+    CHECK(p.RowKind(1) == OptionsScrollList::KindAction);  // apply preset
+    CHECK(p.RowKind(2) == OptionsScrollList::KindAction);  // Close
+}
+
+TEST_CASE("PresetsPage: selected preset cycles correctly", "[UI][GamepadTuningPage]")
+{
+    TestablePresetsPage page;
+    auto& p = page.Provider();
+
+    CHECK(p.RowValue(0) == 0);
+    p.SetRowValue(0, 1);
+    CHECK(p.RowValue(0) == 1);
+
+    // Out-of-range rejected.
+    p.SetRowValue(0, 99);
+    CHECK(p.RowValue(0) == 1);
+}


### PR DESCRIPTION
## What this adds

This allows for resetting all controls to presets included in the engine. This PR includes the defaults and an Arma 3 legacy preset (original A3 layout), and others can be added in the future.

Clicking "Reset all to defaults" in the Controls page of the Options menu navigates to a new screen, which allows picking between "Default" or "A3 Legacy" presets:

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/a9b80ed1-0a13-4122-9e68-9b184efd43f5" />

Selecting "Reset all to preset" on this screen will open the confirm screen:

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/3db82d6d-b133-4cbf-99a8-709359a649f6" />

Confirming the change will apply the preset (overwriting bindings) and return to the Controls page (one level up). Cancel returns to the underlying preset selection page.

## Caveats

### Menu entry

The "Reset all to defaults" string used in the options menu is determined by game code that is not part of CWR-CE and isn't licensed appropriately for inclusion. Because it lives in the game data, modifying the string for this entry entirely within CWR-CE is not a simple process, and this PR doesn't attempt to.

### Preset accuracy

Some functionality that would be needed to fully match Arma 2/Arma 3/Arma 3 Apex/Arma Reforger/etc. controls are not present (to my knowledge) in CWR-CE. Therefore, the A3 Legacy preset doesn't match Arma 3 as closely as it otherwise could, and I used my best judgement where there were differences. It may be that we add some of the missing functionality in this PR, or that we leave that for future iterations (and update the presets as new features come in).

Because of this, I am choosing not to add an Arma 2-like preset right now, even though it would be pretty similar to the existing A3 Legacy preset.

Arma 3 Apex (the current default in Arma 3) and Arma Reforger layouts are too functionally different to try adding right now, in my opinion. They need more functionality in the engine before they are reasonable to add.

I didn't try modifying controller presets. It could be that better-matching presets aren't needed, are added later in this PR, or are added in future iterations.

There might be ways I could improve the current controls without significant code changes.

## To do

While we might decide to add support for more binding types to get better preset accuracy, the big blocker before this is merged would be appropriate tests for the new UI and associated functionality.

There may be little places where I need to clean something up that isn't needed in the current implementation (as part of my iterations or copying code from other parts of the engine).

## Implementation

When reviewing, you may want to look closely at how the presets are implemented in both the `InputSubsystem` and `PresetsPage`. I tried to make this clean and similar-looking to other code in the engine (as well as I could with my C++ knowledge), but it might be that we want to implement things entirely differently.

## Related issues

This addresses some of the feedback from #27.