### PR TITLE
MathOpt: use SSE rsqrtss for InvSqrt on x86 instead of a table lookup

### DIFF
--- a/engine/Poseidon/Foundation/Math/MathOpt.cpp
+++ b/engine/Poseidon/Foundation/Math/MathOpt.cpp
@@ -8,7 +8,21 @@
 
 #pragma optimize("t", on)
 
-#ifndef _KNI
+// Use the SSE rsqrtss + one Newton-Raphson step on x86 (SSE2 baseline); the
+// Graphics Gems table approximation below is the portable fallback.  rsqrtss
+// (~12-bit) with one refinement reaches ~23-bit accuracy, comparable to the
+// table's 2*LOOKUP_BITS, but is a single hardware instruction instead of a
+// table lookup plus bit manipulation and a memory load.  This SSE path already
+// existed below, gated on the long-dead _KNI (Intel KNI / Pentium III) macro.
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+#define POSEIDON_INVSQRT_SSE 1
+#include <xmmintrin.h>
+#endif
+
+namespace Poseidon::Foundation
+{
+
+#ifndef POSEIDON_INVSQRT_SSE
 
 // Fast inverse square root (Graphics Gems V).
 // note: LOOKUP_BITS 12 seems to be a little bit faster (1-2% overall)
@@ -34,8 +48,6 @@
 #define GET_EMANT(a) (((a) >> LOOKUP_POS) & LOOKUP_MASK)   // Extended mantissa MSB's
 #define SET_MANTSEED(a) (((unsigned long)(a)) << SEED_POS) // Set mantissa SEED_BITS MSB's
 
-namespace Poseidon::Foundation
-{
 class InverseSqrtCalculator
 {
     SEED_TYPE _iSqrt[TABLE_SIZE];


### PR DESCRIPTION
InvSqrt() used a Graphics Gems table approximation. An SSE rsqrtss + Newton-step version already existed in this file but was dead code behind the long-dead _KNI (Pentium III) macro, and it never actually compiled: its `namespace Poseidon::Foundation {` open sat inside the `#ifndef` table branch, so enabling it left InvSqrt in the global namespace with an unmatched closing brace.

Hoist the namespace open above the `#ifndef` (wrapping both branches) and gate the SSE path on x86 (SSE2 baseline, gcc/clang/MSVC). rsqrtss (~12-bit) with one Newton refinement reaches ~23-bit accuracy, comparable to the table, in a hardware instruction with no seed-table memory load. Non-x86 keeps the table fallback.

Verified: clang and gcc both emit rsqrtss; InvSqrt in the binary is now rsqrtss + one Newton step. Modest micro-optimization (InvSqrt was ~4% of frame CPU in profiling, and rsqrtss vs a warm-L1 table is a small per-call gain), but it also removes a lookup table and fixes never-compilable code.