### PR TITLE
Fix --benchmark on POSIX (mission never boots, wrong path, no warm-up)

### DIFF
--- a/apps/cwr/Game/GameApplication.cpp
+++ b/apps/cwr/Game/GameApplication.cpp
@@ -1685,6 +1685,11 @@ void GameApplication::StartGameMode()
         {
             snprintf(LoadFile, sizeof(LoadFile), "%s",
                      (const char*)"Users\\Test\\Missions\\Benchmark.Abel\\mission.sqm");
+            // Boot the benchmark mission into gameplay; without this the mission
+            // never loads (StartAutoTest is gated on AutoTest, WorldImpl.cpp) and
+            // the GModeArcade-gated benchmark FPS tracking never runs. Mirrors the
+            // test-mission branch above.
+            AutoTest = true;
         }
         if (AppConfig::Instance().IsViewerMode())
         {

--- a/apps/cwr/Game/GameApplication.cpp
+++ b/apps/cwr/Game/GameApplication.cpp
@@ -1172,9 +1172,11 @@ void GameApplication::RunMainLoop()
 
     // Benchmark tracking (mirrors Windows loop)
     const bool benchmarkMode = AppConfig::Instance().BenchmarkMode();
-    const int benchmarkMaxFrames = 300;
+    const int benchmarkMaxFrames = 1000;       // steadier sample than the old 300
+    const DWORD benchmarkWarmupMs = 4000;      // let the scene stream in before measuring
     int benchmarkFrameCount = 0;
     DWORD benchmarkStartTick = 0;
+    DWORD benchmarkFirstArcadeTick = 0;
     DWORD benchmarkLastLogTick = 0;
     int benchmarkLastLogFrame = 0;
 
@@ -1233,6 +1235,13 @@ void GameApplication::RunMainLoop()
         // Benchmark FPS tracking (only in arcade/gameplay mode)
         if (benchmarkMode && GWorld && GWorld->GetMode() == GModeArcade)
         {
+            // Warm-up: the scene streams in over the first seconds of gameplay, so
+            // measuring from frame 0 spends the whole frame budget on empty
+            // load-phase frames (draw=0). Wait benchmarkWarmupMs before counting.
+            if (benchmarkFirstArcadeTick == 0)
+                benchmarkFirstArcadeTick = Poseidon::Foundation::GlobalTickCount();
+            if (Poseidon::Foundation::GlobalTickCount() - benchmarkFirstArcadeTick >= benchmarkWarmupMs)
+            {
             if (benchmarkFrameCount == 0)
             {
                 benchmarkStartTick = Poseidon::Foundation::GlobalTickCount();
@@ -1272,6 +1281,7 @@ void GameApplication::RunMainLoop()
                          elapsed / 1000.0f, avgFps);
                 m_closeRequest = true;
             }
+            } // end warm-up gate
         }
 
         // Auto-screenshot capture

--- a/apps/cwr/Game/GameApplication.cpp
+++ b/apps/cwr/Game/GameApplication.cpp
@@ -1683,8 +1683,11 @@ void GameApplication::StartGameMode()
         }
         else if (Benchmark)
         {
-            snprintf(LoadFile, sizeof(LoadFile), "%s",
-                     (const char*)"Users\\Test\\Missions\\Benchmark.Abel\\mission.sqm");
+            // Forward slashes: on POSIX the backslash form is not normalized
+            // before StartIntro's FileExist() (WorldImpl.cpp:2219), so a
+            // "Users\\..." literal is never found and the mission silently does
+            // not load. Forward slashes resolve on POSIX and Windows both.
+            snprintf(LoadFile, sizeof(LoadFile), "%s", (const char*)"Users/Test/Missions/Benchmark.Abel/mission.sqm");
             // Boot the benchmark mission into gameplay; without this the mission
             // never loads (StartAutoTest is gated on AutoTest, WorldImpl.cpp) and
             // the GModeArcade-gated benchmark FPS tracking never runs. Mirrors the


### PR DESCRIPTION
`--benchmark` never produced a result on POSIX. Three bugs:
1. The benchmark branch set LoadFile but not AutoTest, so StartAutoTest() never ran, the mission never loaded and the game idled at the menu (no GModeArcade -> no BENCHMARK output).
2. The hardcoded path used Windows backslashes (Users\Test\…), which aren't separator-normalized before StartIntro's FileExist() on POSIX, so the mission was never found.
3. It counted 300 frames from the first gameplay frame, during scene streaming, so on a fast load it finished in ~1 s before objects rendered (draw=0). Added a 4 s warm-up and raised the sample to 1000 frames.

Now boots the mission, warms up, and logs BENCHMARK RESULT: N frames in Xs = Y avg FPS. (POSIX loop; the _WIN32 loop should get the same warm-up/sample change.)