### PR TITLE
perf: gate heavy AI validators out of release builds

### DIFF
--- a/engine/Poseidon/AI/AIArcade.cpp
+++ b/engine/Poseidon/AI/AIArcade.cpp
@@ -1942,7 +1942,7 @@ void ProcessJoinGroups(AIGroup* from, AIGroup* to)
     bool allow = to->Leader()->IsGetInAllowed();
     AllowGetIn(to, allow);
 
-    PoseidonAssert(to->AssertValid());
+    AI_HEAVY_CHECK(to->AssertValid());
 }
 namespace Poseidon
 {
@@ -1952,8 +1952,8 @@ static void JoinGroups(AIGroup* from, AIGroup* to)
     AI_ERROR(from);
     AI_ERROR(to);
     AI_ERROR(from != to);
-    PoseidonAssert(from->AssertValid());
-    PoseidonAssert(to->AssertValid());
+    AI_HEAVY_CHECK(from->AssertValid());
+    AI_HEAVY_CHECK(to->AssertValid());
 
     ApplyEffects(from, from->GetCurrent()->_fsm->Var(0));
 

--- a/engine/Poseidon/AI/AICenterImplPreview.cpp
+++ b/engine/Poseidon/AI/AICenterImplPreview.cpp
@@ -526,12 +526,12 @@ void AICenter::UpdateGroup()
 
 void AICenter::Think()
 {
-    PoseidonAssert(AssertValid());
+    AI_HEAVY_CHECK(AssertValid());
 
     if (_side == TLogic)
     {
         UpdateGroup();
-        PoseidonAssert(AssertValid());
+        AI_HEAVY_CHECK(AssertValid());
         return;
     }
 
@@ -568,7 +568,7 @@ void AICenter::Think()
     UpdateGroup();
     AddNewExposures();
 
-    PoseidonAssert(AssertValid());
+    AI_HEAVY_CHECK(AssertValid());
 }
 
 void AICenter::SendMission(AIGroup* to, Mission& mis)

--- a/engine/Poseidon/AI/AISubgroup.cpp
+++ b/engine/Poseidon/AI/AISubgroup.cpp
@@ -1229,7 +1229,7 @@ void AISubgroup::AddUnitWithCargo(AIUnit* unit)
         return;
     }
 
-    PoseidonAssert(AssertValid());
+    AI_HEAVY_CHECK(AssertValid());
 
     Transport* veh = unit->GetVehicleIn();
     if (veh)
@@ -1273,7 +1273,7 @@ void AISubgroup::AddUnitWithCargo(AIUnit* unit)
     SelectLeader();
     RefreshPlan();
 
-    PoseidonAssert(AssertValid());
+    AI_HEAVY_CHECK(AssertValid());
 }
 
 } // namespace Poseidon
@@ -1392,7 +1392,7 @@ void AISubgroup::SelectLeader(AIUnit* unit)
 
     _doRefresh = true; // process DoRefresh in next Think
 
-    PoseidonAssert(AssertValid());
+    AI_HEAVY_CHECK(AssertValid());
 }
 namespace Poseidon
 {
@@ -1429,7 +1429,7 @@ void AISubgroup::JoinToSubgroup(AISubgroup* subgrp)
     }
     AI_ERROR(this != GetGroup()->MainSubgroup());
 
-    PoseidonAssert(AssertValid());
+    AI_HEAVY_CHECK(AssertValid());
 
     ClearAllCommands();
 
@@ -1456,7 +1456,7 @@ void AISubgroup::JoinToSubgroup(AISubgroup* subgrp)
     subgrp->RefreshPlan();
     subgrp->UpdateFormationPos();
 
-    PoseidonAssert(subgrp->AssertValid());
+    AI_HEAVY_CHECK(subgrp->AssertValid());
 }
 
 // Mind
@@ -1557,7 +1557,7 @@ bool AISubgroup::Think(ThinkImportance prec)
 #endif
         }
 
-        PoseidonAssert(GLOB_WORLD->CheckVehicleStructure());
+        AI_HEAVY_CHECK(GLOB_WORLD->CheckVehicleStructure());
 
         // Refresh command
         if (Leader() && Leader()->GetExposureChange() >= CRITICAL_EXPOSURE_CHANGE || Glob.time >= _refreshTime)
@@ -1573,7 +1573,7 @@ bool AISubgroup::Think(ThinkImportance prec)
             Leader()->ClearExposureChange();
         }
 
-        PoseidonAssert(GLOB_WORLD->CheckVehicleStructure());
+        AI_HEAVY_CHECK(GLOB_WORLD->CheckVehicleStructure());
     }
 
     bool path = false;
@@ -1590,7 +1590,7 @@ bool AISubgroup::Think(ThinkImportance prec)
         }
     }
 
-    PoseidonAssert(GLOB_WORLD->CheckVehicleStructure());
+    AI_HEAVY_CHECK(GLOB_WORLD->CheckVehicleStructure());
 
     return path; // OperPath called - return busy
 }
@@ -1612,7 +1612,7 @@ void AISubgroup::ReceiveAnswer(AIUnit* from, Answer answer)
         case AI::UnitDestroyed:
         {
             AICenter* center = GetGroup()->GetCenter();
-            PoseidonAssert(center->AssertValid());
+            AI_HEAVY_CHECK(center->AssertValid());
             {
                 Ref<AIGroup> group = GetGroup(); // group may be removed from center
                 AI_ERROR(group);
@@ -1692,7 +1692,7 @@ void AISubgroup::ReceiveAnswer(AIUnit* from, Answer answer)
                 }
                 // group are not destroyed even when all units are destroyed
             }
-            PoseidonAssert(center->AssertValid());
+            AI_HEAVY_CHECK(center->AssertValid());
         }
         break;
         default:

--- a/engine/Poseidon/Foundation/Framework/DebugLog.hpp
+++ b/engine/Poseidon/Foundation/Framework/DebugLog.hpp
@@ -92,6 +92,18 @@ extern bool gSoftAssert;
 #define NET_ERROR(expr) POSEIDON_LOG_CHECK(Network, expr)
 #define AI_ERROR(expr) POSEIDON_LOG_CHECK(AI, expr)
 
+// AI_HEAVY_CHECK: like AI_ERROR, but for expensive O(n) validators such as
+// AssertValid() / CheckVehicleStructure() that would otherwise run every frame.
+// Unlike AI_ERROR (evaluated in release by design), this compiles out under
+// NDEBUG so the structural sweep costs nothing in shipping builds. Reserve it
+// for heavy validators; keep AI_ERROR for cheap one-liners that should stay in
+// release logs.
+#ifdef NDEBUG
+#define AI_HEAVY_CHECK(expr) ((void)0)
+#else
+#define AI_HEAVY_CHECK(expr) POSEIDON_LOG_CHECK(AI, expr)
+#endif
+
 #include <stdio.h>
 
 #pragma warning(disable : 4996)


### PR DESCRIPTION
AIUnit::AssertValid() and World::CheckVehicleStructure() are O(n) structural sweeps wrapped in AI_ERROR, which, unlike PoseidonAssert, is evaluated even under NDEBUG.
[pmcstat](https://man.freebsd.org/cgi/man.cgi?query=pmcstat) on a unit-heavy scene put them at 2.82% + 1.19% of frame CPU in a shipping build. Add AI_HEAVY_CHECK (same as AI_ERROR in debug, compiled out under NDEBUG) and convert the 16 heavy call sites.
Verified: both symbols stay in the binary but draw 0 profile samples after the change; behavior unchanged (checks still run in debug/test).