### PR TITLE
Fix multiplayer server-shutdown deadlock on session teardown

### DIFF
--- a/engine/Poseidon/Network/NetServerPeerTeardown.hpp
+++ b/engine/Poseidon/Network/NetServerPeerTeardown.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <Poseidon/Foundation/Threads/PoCritical.hpp>
+
+namespace Poseidon
+{
+// Runs `join` (which blocks until the server peer's UDP threads have stopped)
+// with `poolLock` released, then re-acquires it. The peer's listener thread
+// takes poolLock inside ctrlReceive, so joining the peer while holding poolLock
+// deadlocks. Callers must hold `poolLock` on entry; it is held again on return.
+template <class JoinFn>
+inline void JoinServerPeerWithoutPoolLock(Foundation::PoCriticalSection& poolLock, JoinFn&& join)
+{
+    poolLock.leave();
+    join();
+    poolLock.enter();
+}
+} // namespace Poseidon

--- a/engine/Poseidon/Network/NetTransportNet.cpp
+++ b/engine/Poseidon/Network/NetTransportNet.cpp
@@ -2,6 +2,7 @@
 #include <Poseidon/Network/NetTransportNetInternal.hpp>
 #include <Poseidon/Network/NetTransportClientVoiceInit.hpp>
 #include <Poseidon/Network/NetTransportPlayerValidationPolicy.hpp>
+#include <Poseidon/Network/NetServerPeerTeardown.hpp>
 #include <Poseidon/Network/NetTransportServerVoiceRouting.hpp>
 #ifndef _WIN32
 #include <arpa/inet.h>
@@ -2043,13 +2044,18 @@ NetServer::~NetServer()
     // Now stop UDP threads and clean up the serverPeer.
     // The serverPeer is global/static, so we need to explicitly clean it up
     // to prevent threads from running after this NetServer instance is destroyed.
+    // serverPeer->close() joins the UDP listener, which itself takes poolLock
+    // inside ctrlReceive; joining under poolLock deadlocks, so the join runs with
+    // poolLock released. serverPeer stays set across the join so a late
+    // ctrlReceive resolves the existing peer instead of creating a fresh one.
     poolLock.enter();
-    if (serverPeer)
+    RefD<NetPeer> localServerPeer = serverPeer;
+    if (localServerPeer)
     {
-        serverPeer->close(); // Stops UDP listener/sender threads via poThreadJoin
+        JoinServerPeerWithoutPoolLock(poolLock, [&]() { localServerPeer->close(); });
         if (pool)
         {
-            pool->deletePeer(serverPeer); // Remove from pool
+            pool->deletePeer(localServerPeer); // Remove from pool
         }
         serverPeer = nullptr; // Reset global so next attempt creates fresh peer
     }

--- a/tests/unit/engine/Poseidon/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/CMakeLists.txt
@@ -48,6 +48,7 @@ set(POSEIDON_CORE_TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/engine/Poseidon/Network/test_network_predicate_parity.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/engine/Poseidon/Network/test_master_server_browser.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/engine/Poseidon/Network/test_net_transport_termination.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/engine/Poseidon/Network/test_net_server_teardown.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/engine/Evaluator/test_evaluator_complex.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/engine/Evaluator/test_evaluator_data.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/engine/Evaluator/test_evaluator_edge.cpp

--- a/tests/unit/engine/Poseidon/Network/test_net_server_teardown.cpp
+++ b/tests/unit/engine/Poseidon/Network/test_net_server_teardown.cpp
@@ -1,0 +1,95 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <Poseidon/Network/NetServerPeerTeardown.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using Poseidon::JoinServerPeerWithoutPoolLock;
+using Poseidon::Foundation::PoCriticalSection;
+
+// Mirrors NetServer::~NetServer's serverPeer teardown. The peer's UDP listener
+// takes poolLock inside ctrlReceive, so joining the peer (peer->close()) while
+// holding poolLock deadlocks. JoinServerPeerWithoutPoolLock releases poolLock
+// across the join; regressing that discipline reintroduces the deadlock, which
+// this test catches via the watchdog below.
+TEST_CASE("server peer join releases poolLock so a concurrent ctrlReceive can finish",
+          "[network][termination][deadlock]")
+{
+    using namespace std::chrono_literals;
+
+    // Heap-allocated so a thread still blocked on the lock (only on a regression)
+    // never touches a destroyed mutex; leaked on that failure path on purpose.
+    auto* poolLock = new PoCriticalSection(true);
+
+    std::atomic<bool> teardownHoldsLock{false};
+    std::atomic<bool> contenderStarted{false};
+    std::atomic<bool> contenderDone{false};
+    std::atomic<bool> joinReturned{false};
+
+    // The teardown thread holds poolLock and then joins the peer via the helper.
+    std::thread teardown(
+        [&]()
+        {
+            poolLock->enter();
+            teardownHoldsLock.store(true);
+            while (!contenderStarted.load())
+            {
+                std::this_thread::sleep_for(1ms);
+            }
+            std::this_thread::sleep_for(50ms); // let the contender block on poolLock->enter()
+
+            // The "join" waits for the contender to finish; the contender can only
+            // finish once it acquires poolLock, which requires the helper to have
+            // released it. If the helper held poolLock here, this would deadlock.
+            JoinServerPeerWithoutPoolLock(*poolLock,
+                                          [&]()
+                                          {
+                                              while (!contenderDone.load())
+                                              {
+                                                  std::this_thread::sleep_for(1ms);
+                                              }
+                                          });
+            poolLock->leave();
+            joinReturned.store(true);
+        });
+
+    while (!teardownHoldsLock.load())
+    {
+        std::this_thread::sleep_for(1ms);
+    }
+
+    // Mimics a ctrlReceive that must take poolLock to complete a CreatePlayer.
+    std::thread contender(
+        [&]()
+        {
+            contenderStarted.store(true);
+            poolLock->enter();
+            poolLock->leave();
+            contenderDone.store(true);
+        });
+
+    for (int i = 0; i < 300 && !joinReturned.load(); ++i)
+    {
+        std::this_thread::sleep_for(10ms);
+    }
+
+    const bool ok = joinReturned.load();
+    CHECK(ok);
+
+    if (ok)
+    {
+        teardown.join();
+        contender.join();
+        CHECK(contenderDone.load());
+        delete poolLock;
+    }
+    else
+    {
+        // Regression: poolLock was held across the join, so both threads are
+        // deadlocked. Detach them and leak poolLock; the process exit reaps them.
+        teardown.detach();
+        contender.detach();
+    }
+}


### PR DESCRIPTION
`NetServer::~NetServer` held `poolLock` across `serverPeer->close()`, which joins the UDP listener thread. That listener takes `poolLock` inside `ctrlReceive` while handling a `CreatePlayer`, so if a `CreatePlayer` arrives during teardown the process deadlocks and never exits.

Run the peer close/join with `poolLock` released (via a small `JoinServerPeerWithoutPoolLock` helper); `serverPeer` stays set across the join so a late `ctrlReceive` resolves the existing peer instead of creating a new one.

Includes a deterministic regression test that deadlocks (its watchdog trips) without the fix.
