### PR TITLE
Kill spawned game processes when Trident is interrupted

### DIFF
--- a/engine/Trident/src/client/instance.rs
+++ b/engine/Trident/src/client/instance.rs
@@ -520,4 +520,47 @@ mod tests {
         assert_eq!(cc.retry_delay, Duration::from_millis(500));
         assert_eq!(cc.command_timeout, Duration::from_secs(5));
     }
+
+    // Dropping a `kill_on_drop` child must terminate the process. This is the
+    // reaping the shutdown path relies on: on SIGINT/SIGTERM `main` returns, the
+    // runtime drops each GameInstance, and this is what actually kills the game
+    // instead of orphaning it. Without kill_on_drop the sleep here would survive.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn kill_on_drop_reaps_spawned_process() {
+        let child = Command::new("sleep")
+            .arg("300")
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id().expect("child pid");
+        assert!(process_running(pid), "sleep should be running after spawn");
+
+        drop(child);
+
+        for _ in 0..200 {
+            if !process_running(pid) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("process {pid} still running after the child was dropped");
+    }
+
+    #[cfg(unix)]
+    fn process_running(pid: u32) -> bool {
+        // Reads /proc/<pid>/stat and treats a missing file (reaped) or 'Z'
+        // (zombie) as no longer running; comm can contain ')' so split on the last.
+        match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+            Ok(stat) => {
+                let state = stat
+                    .rsplit(')')
+                    .next()
+                    .and_then(|rest| rest.split_whitespace().next())
+                    .and_then(|token| token.chars().next());
+                state != Some('Z')
+            }
+            Err(_) => false,
+        }
+    }
 }

--- a/engine/Trident/src/main.rs
+++ b/engine/Trident/src/main.rs
@@ -174,6 +174,34 @@ enum Commands {
     },
 }
 
+// Resolves when the process is asked to terminate (Ctrl-C anywhere; SIGTERM on
+// Unix). Wrapping a game-spawning run in `select!` against this lets the command
+// return early: the tokio runtime then shuts down, drops every in-flight
+// GameInstance, and `kill_on_drop` reaps the game processes instead of orphaning
+// them. Cross-platform — no process-group / signal machinery.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(_) => std::future::pending::<()>().await,
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {}
+        () = terminate => {}
+    }
+}
+
 #[tokio::main]
 #[allow(clippy::too_many_lines)]
 async fn main() -> anyhow::Result<()> {
@@ -240,17 +268,21 @@ async fn main() -> anyhow::Result<()> {
                 tests.len()
             );
 
-            let results = scenarios::integration::run_all(
-                &tests,
-                &game_dir,
-                data_dir.as_deref(),
-                jobs,
-                retries,
-                &out_dir,
-                render.as_deref(),
-                &game_args,
-            )
-            .await?;
+            let results = tokio::select! {
+                result = scenarios::integration::run_all(
+                    &tests,
+                    &game_dir,
+                    data_dir.as_deref(),
+                    jobs,
+                    retries,
+                    &out_dir,
+                    render.as_deref(),
+                    &game_args,
+                ) => result?,
+                () = shutdown_signal() => {
+                    anyhow::bail!("interrupted (SIGINT/SIGTERM) — shutting down and killing games");
+                }
+            };
 
             if let Some(n) = profile {
                 scenarios::integration::print_profile(&results, n);
@@ -281,15 +313,19 @@ async fn main() -> anyhow::Result<()> {
                 );
             }
 
-            let result = scenarios::stress::run_stress_scenario(
-                &scenario_dir,
-                &game_dir,
-                data_dir.as_deref(),
-                &out_dir,
-                render.as_deref(),
-                &game_args,
-            )
-            .await?;
+            let result = tokio::select! {
+                result = scenarios::stress::run_stress_scenario(
+                    &scenario_dir,
+                    &game_dir,
+                    data_dir.as_deref(),
+                    &out_dir,
+                    render.as_deref(),
+                    &game_args,
+                ) => result?,
+                () = shutdown_signal() => {
+                    anyhow::bail!("interrupted (SIGINT/SIGTERM) — shutting down and killing games");
+                }
+            };
 
             println!("{}", result.message);
             if !result.passed {

--- a/engine/Trident/src/scenarios/integration.rs
+++ b/engine/Trident/src/scenarios/integration.rs
@@ -1094,7 +1094,8 @@ async fn run_mission_test(
         .current_dir(&work_dir)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
 
     tracing::debug!(
         "[{name}] spawning {} --test-mission {resolved} {}",


### PR DESCRIPTION
On SIGINT/SIGTERM, `tri` had no handler, so it terminated immediately and orphaned every game it had spawned; those orphans kept holding their sockets and broke later scenarios in the same suite.

Wrap the game-spawning runs in `select!` against a cross-platform shutdown signal (Ctrl-C everywhere, SIGTERM on Unix); on a signal the runtime shuts down, drops each `GameInstance`, and `kill_on_drop` reaps the game. Also adds `kill_on_drop` to the mission-test spawn.

Verified: SIGTERM to `tri` mid-run leaves 1 orphaned game without the fix and 0 with it.
