### PR TITLE
Fix flaky master-server browser clear test

### DIFF
--- a/tests/unit/engine/Poseidon/Network/test_master_server_browser.cpp
+++ b/tests/unit/engine/Poseidon/Network/test_master_server_browser.cpp
@@ -131,7 +131,15 @@ TEST_CASE("MasterServerBrowser clear discards an in-flight fetch result", "[netw
     }
 
     ClearMasterServerBrowser(browser);
-    ThinkMasterServerBrowser(browser);
+
+    // The worker sets fetchDone after the fetch stub signals GFetchReturned, so a
+    // single Think can still see the fetch in flight and bail. Think is polled
+    // every frame in production; poll it here until the worker's result is reaped.
+    for (int i = 0; i < 200 && GetMasterServerBrowserState(browser) != MasterServerBrowserState::Idle; ++i)
+    {
+        ThinkMasterServerBrowser(browser);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
 
     REQUIRE(GetMasterServerBrowserState(browser) == MasterServerBrowserState::Idle);
     REQUIRE(GetMasterServerBrowserCount(browser) == 0);


### PR DESCRIPTION
The test waited for the fetch stub's `GFetchReturned` signal, then called `Think` once. The worker sets `fetchDone` only *after* the fetch returns (after `GFetchReturned` is signaled), so a single `Think` could still observe the fetch in flight and bail, leaving `serviceState` at `ListTransfer` and failing the `Idle` assertion — a flake that occasionally fails the Linux build job (ctest has no retries).

Poll `Think` until the worker's result is reaped, matching the sibling test and how `Think` is driven every frame in production. Test-only change.

Verified: widening the `fetchDone` window makes the single-`Think` version fail deterministically (5/5); with the poll loop it passes (40/40).
