### PR TITLE
Split Trident integration tests into a 4-shard CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,11 +188,15 @@ jobs:
         run: cargo test --locked
 
   trident-test:
-    name: Linux Trident
+    name: Linux Trident (shard ${{ matrix.shard }})
     runs-on: ubuntu-24.04
     needs:
       - build-linux
       - trident
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
     steps:
       - name: Checkout
@@ -284,6 +288,8 @@ jobs:
             exe/tri test \
             --output-dir "$TRI_OUTPUT_DIR" \
             --render "$TRIDENT_RENDER" \
+            --jobs 2 \
+            --shard ${{ matrix.shard }}/4 \
             --retries 2 \
             --skip-tag ci-host-blocked \
             --game-arg --audio \
@@ -295,7 +301,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: trident-output-${{ steps.build_metadata.outputs.sha_short }}
+          name: trident-output-${{ steps.build_metadata.outputs.sha_short }}-shard${{ matrix.shard }}
           path: trident-output
           if-no-files-found: ignore
 

--- a/engine/Trident/src/main.rs
+++ b/engine/Trident/src/main.rs
@@ -83,6 +83,15 @@ enum Commands {
         #[arg(long, default_value = "3")]
         retries: usize,
 
+        /// Run only shard I of N (1-based), e.g. --shard 1/4. Scenarios are
+        /// balanced across shards by declared timeout so slow tests spread evenly.
+        #[arg(long, value_name = "I/N")]
+        shard: Option<String>,
+
+        /// Print the selected test names (after tag/shard filtering) and exit.
+        #[arg(long)]
+        list: bool,
+
         /// Output directory for screenshots and artifacts (default: tmp/tri/<timestamp>)
         #[arg(long, env = "TRI_OUTPUT_DIR")]
         output_dir: Option<String>,
@@ -212,6 +221,8 @@ async fn main() -> anyhow::Result<()> {
             data_dir,
             jobs,
             retries,
+            shard,
+            list,
             output_dir,
             render,
             game_args,
@@ -221,11 +232,22 @@ async fn main() -> anyhow::Result<()> {
             tracing::info!("Output: {}", out_dir.display());
 
             let path_refs: Vec<&str> = paths.iter().map(String::as_str).collect();
-            let tests = scenarios::integration::filter_tests_by_tags(
+            let mut tests = scenarios::integration::filter_tests_by_tags(
                 scenarios::integration::resolve_tests(&path_refs)?,
                 &tags,
                 &skip_tags,
             );
+            if let Some(spec) = shard.as_deref() {
+                let (index, total) = scenarios::integration::parse_shard(spec)?;
+                tests = scenarios::integration::select_shard(tests, index, total);
+                println!("  \x1b[36mshard {index}/{total}\x1b[0m");
+            }
+            if list {
+                for test in &tests {
+                    println!("{}", test.name);
+                }
+                return Ok(());
+            }
             if tests.is_empty() {
                 if tags.is_empty() {
                     println!("No tests found");

--- a/engine/Trident/src/scenarios/integration.rs
+++ b/engine/Trident/src/scenarios/integration.rs
@@ -62,6 +62,13 @@ impl IntegrationTest {
         }
     }
 
+    /// The test's on-disk path (sqf file or scenario directory).
+    pub fn path(&self) -> &Path {
+        match &self.kind {
+            TestKind::Sqf(p) | TestKind::Mission(p) | TestKind::Multi(p) | TestKind::Seq(p) => p,
+        }
+    }
+
     /// Semaphore slots this test reserves in the parallel runner.
     ///
     /// Multi-instance tests reserve one slot per renderer process. Tests that need
@@ -479,6 +486,64 @@ pub fn filter_tests_by_tags(
             included && !excluded
         })
         .collect()
+}
+
+/// Parse a `--shard I/N` spec into a 1-based `(index, total)`.
+pub fn parse_shard(spec: &str) -> anyhow::Result<(usize, usize)> {
+    let (i, n) = spec
+        .split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("invalid --shard '{spec}', expected I/N (e.g. 1/4)"))?;
+    let index: usize = i
+        .trim()
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid shard index in '{spec}'"))?;
+    let total: usize = n
+        .trim()
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid shard total in '{spec}'"))?;
+    anyhow::ensure!(
+        total >= 1 && index >= 1 && index <= total,
+        "shard must be 1..=N (got '{spec}')"
+    );
+    Ok((index, total))
+}
+
+/// Weight used to balance shards: the test's declared timeout (seconds), which is
+/// a generic, tag-agnostic proxy for how slow a test is — a slow test declares a
+/// larger timeout regardless of how it is tagged.
+fn shard_weight(test: &IntegrationTest) -> u64 {
+    load_test_meta(test.path()).timeout.unwrap_or(120).max(1)
+}
+
+/// Balance tests across `total` shards by weight (longest-processing-time
+/// bin-packing) and return those assigned to shard `index` (1-based). Deterministic:
+/// heavier scenarios are placed first, each into the currently-lightest shard, so
+/// slow tests spread evenly across shards instead of clustering in one.
+pub fn select_shard(
+    tests: Vec<IntegrationTest>,
+    index: usize,
+    total: usize,
+) -> Vec<IntegrationTest> {
+    if total <= 1 {
+        return tests;
+    }
+    let mut weighted: Vec<(u64, IntegrationTest)> = tests
+        .into_iter()
+        .map(|test| (shard_weight(&test), test))
+        .collect();
+    weighted.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.name.cmp(&b.1.name)));
+    let mut loads = vec![0u64; total];
+    let mut keep = Vec::new();
+    for (weight, test) in weighted {
+        let target = (0..total)
+            .min_by_key(|&shard| (loads[shard], shard))
+            .unwrap();
+        loads[target] += weight;
+        if target + 1 == index {
+            keep.push(test);
+        }
+    }
+    keep
 }
 
 /// Load sidecar TOML metadata for a test.
@@ -2301,6 +2366,54 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    fn fake_test(name: &str) -> IntegrationTest {
+        IntegrationTest {
+            name: name.to_string(),
+            kind: TestKind::Sqf(PathBuf::from(format!("/x/{name}.test.sqf"))),
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn shards_cover_every_test_exactly_once_and_deterministically() {
+        let mk_all = || {
+            (0..37)
+                .map(|i| fake_test(&format!("t{i:02}")))
+                .collect::<Vec<_>>()
+        };
+        let total = 4;
+        let mut seen = std::collections::BTreeSet::new();
+        for index in 1..=total {
+            for test in select_shard(mk_all(), index, total) {
+                assert!(
+                    seen.insert(test.name.clone()),
+                    "'{}' assigned to >1 shard",
+                    test.name
+                );
+            }
+        }
+        let expected: std::collections::BTreeSet<String> =
+            mk_all().into_iter().map(|t| t.name).collect();
+        assert_eq!(seen, expected, "union of shards must equal the full set");
+
+        let names = |i| {
+            select_shard(mk_all(), i, total)
+                .into_iter()
+                .map(|t| t.name)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(names(1), names(1), "same code must produce the same shard");
+    }
+
+    #[test]
+    fn parse_shard_accepts_valid_and_rejects_invalid() {
+        assert_eq!(parse_shard("1/4").unwrap(), (1, 4));
+        assert_eq!(parse_shard("4/4").unwrap(), (4, 4));
+        for bad in ["0/4", "5/4", "1/0", "x/4", "1", "1/2/3"] {
+            assert!(parse_shard(bad).is_err(), "'{bad}' should be rejected");
+        }
+    }
 
     #[test]
     fn eta_average_rate_is_sane() {


### PR DESCRIPTION
`tri test` gains `--shard I/N`: it balances scenarios across N shards by declared timeout (a generic, tag-agnostic proxy for slowness) using longest-processing-time bin-packing, so slow tests spread evenly rather than clustering. The split is deterministic and a complete, disjoint partition — every scenario runs in exactly one shard, and the same code produces the same split on every runner. Adds `--list` to print the selected scenarios.

The Linux Trident CI job becomes a `fail-fast: false` 4-way matrix, each shard running `--shard i/4 --jobs 2`.

## Verified
- Split is complete (union = all 111 scenarios), disjoint (0 overlap), deterministic, and balanced (~2445–2535s declared-timeout per shard). Unit tests cover the partition and `--shard` parsing.
- Ran the full 4-shard `--jobs 2` matrix on CI end-to-end: all four shards passed; per-shard wall-clock 5–10 min (vs ~31–35 min for the old single sequential job) — roughly 3.3x faster, and the load spreads evenly.