### PR TITLE
Store last 10 player logs by default, crash dumps into user dir and report startup errors

### DIFF
--- a/apps/cwr/Game/GameApplication.cpp
+++ b/apps/cwr/Game/GameApplication.cpp
@@ -8,6 +8,7 @@
 #include <Poseidon/Core/Config/Config.hpp>
 #include <Poseidon/Foundation/Platform/AppConfig.hpp>
 #include <Poseidon/Foundation/Platform/GamePaths.hpp>
+#include <Poseidon/Foundation/Platform/StartupError.hpp>
 #include <Poseidon/Audio/AudioFactory.hpp>
 #include <Poseidon/Audio/Voice/VoiceBackend.hpp>
 #include <Poseidon/UI/Settings/GameSettingsConfig.hpp>
@@ -617,14 +618,26 @@ int GameApplication::RunAfterArgumentParsing()
 {
     LOG_INFO(Core, "Game starting: version {}", (const char*)GetVersionString());
 
+    constexpr const char* kStartupErrorTitle = "Cold War Assault - Startup Error";
+
     if (!ReadConfiguration())
-        return 0;
+    {
+        Poseidon::Foundation::ShowStartupError(
+            kStartupErrorTitle, "Failed to load the game configuration.\nThe game data may be missing or invalid.");
+        return 1;
+    }
 
     if (!InitializeGraphicsEngine())
+    {
+        Poseidon::Foundation::ShowStartupError(kStartupErrorTitle, "Failed to initialize the graphics engine.");
         return 1;
+    }
 
     if (!CreateAndSetGraphicsEngine())
+    {
+        Poseidon::Foundation::ShowStartupError(kStartupErrorTitle, "Failed to create the graphics engine.");
         return 1;
+    }
 
     // Load display.cfg (eager-write defaults if missing) and apply
     // the persisted monitor / window-mode / resolution / refresh-rate
@@ -636,13 +649,22 @@ int GameApplication::RunAfterArgumentParsing()
     LoadAndApplyGraphicsConfig();
 
     if (!InitializeWorld())
+    {
+        Poseidon::Foundation::ShowStartupError(kStartupErrorTitle, "Failed to initialize the game world.");
         return 1;
+    }
 
     if (!InitializeSound())
+    {
+        Poseidon::Foundation::ShowStartupError(kStartupErrorTitle, "Failed to initialize sound.");
         return 1;
+    }
 
     if (!InitializeSubsystems())
+    {
+        Poseidon::Foundation::ShowStartupError(kStartupErrorTitle, "Failed to initialize a game subsystem.");
         return 1;
+    }
 
     ProgressFinish();
     EnableRendering();

--- a/apps/cwr/GameBase/GameBase.cpp
+++ b/apps/cwr/GameBase/GameBase.cpp
@@ -17,6 +17,7 @@
 #include <Poseidon/IO/Streams/QBStream.hpp>          // GUseFileBanks
 #include <Poseidon/Foundation/Platform/FPUSetup.hpp> // InitFPU
 #include <Poseidon/Foundation/Platform/CrashHandler.hpp>
+#include <Poseidon/Foundation/Platform/StartupError.hpp>
 #include <Poseidon/IO/ParamFile/InitLibraryElement.hpp>
 #include <string>
 #include <Poseidon/Foundation/Framework/Log.hpp>
@@ -96,6 +97,8 @@ bool GameBase::ParseCommandLine(const char* commandLine)
 #endif
         {
             LOG_ERROR(Core, "Failed to change working directory to: {}", workDir);
+            Poseidon::Foundation::ShowStartupError("Cold War Assault - Startup Error",
+                                                   ("Failed to change working directory to:\n" + workDir).c_str());
             m_startupExitCode = 2;
             return false;
         }
@@ -107,6 +110,9 @@ bool GameBase::ParseCommandLine(const char* commandLine)
     if (AppConfig::Instance().HasParseFatalError())
     {
         LOG_ERROR(Core, "Command-line parsing failed: {}", AppConfig::Instance().GetParseFatalError());
+        Poseidon::Foundation::ShowStartupError(
+            "Cold War Assault - Startup Error",
+            ("Command-line error:\n" + AppConfig::Instance().GetParseFatalError()).c_str());
         m_startupExitCode = AppConfig::Instance().GetParseFatalExitCode();
         return false;
     }
@@ -150,9 +156,46 @@ bool GameBase::ParseCommandLine(const char* commandLine)
                                      oldPathsRoot.c_str());
     Poseidon::ApplyGamePathsToLegacyGlobals();
 
-    // Refresh the crash handler after path setup. Linux uses the user dir for reports; Windows
-    // keeps minidumps beside the executable.
-    Poseidon::Foundation::InstallCrashHandler(GamePaths::Instance().UserDir().c_str());
+    // Diagnostics go to the discoverable user-content folder (Documents on Windows,
+    // XDG data on Linux): logs under logs/, crash reports under crashes/.
+    const std::string diagDir = GamePaths::Instance().UserContentDir();
+    const std::string crashesDir = (std::filesystem::path(diagDir) / "crashes").string();
+    std::error_code crashesEc;
+    std::filesystem::create_directories(crashesDir, crashesEc); // crash-time handler cannot create it
+    Poseidon::Foundation::InstallCrashHandler(crashesDir.c_str());
+
+    // Keep diagnostics from growing without bound (A3-style keep-last-N).
+    constexpr int kLogKeepN = 10;
+    constexpr int kCrashKeepN = 10;
+    Poseidon::Foundation::WipeOldFiles(crashesDir, "crash_", ".txt", kCrashKeepN); // Linux crash reports
+#ifdef _WIN32
+    Poseidon::Foundation::WipeOldFiles(crashesDir, "crash-", ".dmp", kCrashKeepN); // Windows minidumps
+#endif
+
+    // On a console-less launch (Steam/GUI) capture logs to a per-run file. --log-file
+    // overrides it; terminals, tests, the tri harness, and --check stay console-only.
+    if (AppConfig::Instance().GetLogFile().empty() && !AppConfig::Instance().NoLogFile() &&
+        Poseidon::Foundation::ShouldWriteAutoLog())
+    {
+        const std::string logsDir = (std::filesystem::path(diagDir) / "logs").string();
+        const std::string logPath =
+            (std::filesystem::path(logsDir) / Poseidon::Foundation::MakeTimestampedLogName("cwr")).string();
+        GetLoggingSystem().AttachFileSink(logPath.c_str());
+        if (Poseidon::Foundation::LoggingSystem::GetLogFilePath()[0])
+            LOG_INFO(Core, "Log file: {}", logPath);
+        // Trim after opening this run's file so keep-last-N counts the current run.
+        Poseidon::Foundation::WipeOldFiles(logsDir, "cwr_", ".log", kLogKeepN);
+    }
+
+    // A typo'd launch flag is otherwise dropped silently; surface it (now that any log
+    // file is attached) so the player can see it wasn't applied.
+    if (const auto& unknown = AppConfig::Instance().GetUnrecognizedArgs(); !unknown.empty())
+    {
+        std::string joined;
+        for (const std::string& arg : unknown)
+            joined += (joined.empty() ? "" : " ") + arg;
+        LOG_WARN(Core, "Ignoring unrecognized launch argument(s): {}", joined);
+    }
 
     LOG_INFO(Core, "Command-line parsing complete");
     LOG_INFO(Core, "  user_dir:  {}", GamePaths::Instance().UserDir());

--- a/apps/cwr/Server/ServerApplication.cpp
+++ b/apps/cwr/Server/ServerApplication.cpp
@@ -147,7 +147,7 @@ int ServerApplication::RunServerStages()
         Poseidon::Foundation::gSoftAssert = true;
 
     if (!ReadConfiguration())
-        return 0;
+        return 1;
 
     // Configuration loading can reset engine flags, so set dedicated-server mode after it.
     ENGINE_CONFIG.doCreateDedicatedServer = true;

--- a/engine/Poseidon/Foundation/Common/GamePaths.cpp
+++ b/engine/Poseidon/Foundation/Common/GamePaths.cpp
@@ -48,6 +48,20 @@ GamePaths& GamePaths::Instance()
     return instance;
 }
 
+std::string GamePaths::ResolveUserDir(const char* codename)
+{
+    return resolveDir("POSEIDON_USER_DIR", getUserDataDir(codename));
+}
+
+std::string GamePaths::ResolveUserContentDir(const char* codename, const char* product)
+{
+    if (const char* env = std::getenv("POSEIDON_USER_CONTENT_DIR"); env && env[0] != '\0')
+        return resolveDir("POSEIDON_USER_CONTENT_DIR", "");
+    if (const char* env = std::getenv("POSEIDON_USER_DIR"); env && env[0] != '\0')
+        return resolveDir("", ResolveUserDir(codename) + "content");
+    return resolveDir("", getUserDocumentsDir(product));
+}
+
 ResolvedGamePaths GamePaths::Resolve(const char* codename, const char* cfgBase, const char* productName, bool oldPaths,
                                       const char* oldPathsRoot)
 {
@@ -78,7 +92,7 @@ ResolvedGamePaths GamePaths::Resolve(const char* codename, const char* cfgBase, 
 
     resolved.cacheDir = resolveDir("POSEIDON_CACHE_DIR", getUserCacheDir(codename));
     resolved.tempDir = resolveDir("POSEIDON_TEMP_DIR", getSystemTempDir(codename));
-    resolved.userDir = resolveDir("POSEIDON_USER_DIR", getUserDataDir(codename));
+    resolved.userDir = ResolveUserDir(codename);
 
     // Bulky, user-facing content (mods, editor missions) lives in a discoverable,
     // non-roaming root — Documents on Windows, XDG-data on Linux — NOT the
@@ -87,14 +101,7 @@ ResolvedGamePaths GamePaths::Resolve(const char* codename, const char* cfgBase, 
     //   2. sandboxed runs (POSEIDON_USER_DIR set, e.g. tests) keep content inside
     //      that sandbox so we never create folders in the real Documents;
     //   3. otherwise the platform Documents / XDG-data folder.
-    const char* contentEnv = std::getenv("POSEIDON_USER_CONTENT_DIR");
-    const char* userDirEnv = std::getenv("POSEIDON_USER_DIR");
-    if (contentEnv != nullptr && contentEnv[0] != '\0')
-        resolved.userContentDir = resolveDir("POSEIDON_USER_CONTENT_DIR", "");
-    else if (userDirEnv != nullptr && userDirEnv[0] != '\0')
-        resolved.userContentDir = resolveDir("", resolved.userDir + "content");
-    else
-        resolved.userContentDir = resolveDir("", getUserDocumentsDir(product.c_str()));
+    resolved.userContentDir = ResolveUserContentDir(codename, product.c_str());
 
     // ModsDir is independently overridable (POSEIDON_MODS_DIR) — the mod loader
     // reads it directly. Editor-mission folders, by contrast, are derived from

--- a/engine/Poseidon/Foundation/Common/GamePaths.hpp
+++ b/engine/Poseidon/Foundation/Common/GamePaths.hpp
@@ -69,6 +69,14 @@ public:
 	static ResolvedGamePaths Resolve(const char* codename, const char* cfgBase, const char* productName = nullptr,
 	                                 bool oldPaths = false, const char* oldPathsRoot = nullptr);
 
+	/// Resolve the user dir without Initialize() (POSEIDON_USER_DIR or platform
+	/// default, trailing-slash). Prefer UserDir() once initialized.
+	static std::string ResolveUserDir(const char* codename);
+
+	/// Resolve the user-content dir without Initialize() (Documents / XDG-data, or a
+	/// POSEIDON_USER_CONTENT_DIR / POSEIDON_USER_DIR override). Prefer UserContentDir().
+	static std::string ResolveUserContentDir(const char* codename, const char* product);
+
 	/// App codename used for directory paths (e.g. "CWR").
 	const std::string& Codename() const { return m_codename; }
 

--- a/engine/Poseidon/Foundation/Common/PlayerPrefs.cpp
+++ b/engine/Poseidon/Foundation/Common/PlayerPrefs.cpp
@@ -1,5 +1,5 @@
 #include <Poseidon/Foundation/Common/PlayerPrefs.hpp>
-#include <Poseidon/Foundation/Common/PlatformPaths.hpp>
+#include <Poseidon/Foundation/Common/GamePaths.hpp>
 #include <cstdlib>
 #include <fstream>
 #include <unordered_map>
@@ -10,14 +10,9 @@ namespace
 
 std::string prefsFilePath(const char* appName)
 {
-    // Honour POSEIDON_USER_DIR so prefs.cfg sits with the profiles and other
-    // user data (sandboxed/test runs set it). Without it, prefs would leak to
-    // the real roaming appdata while profiles live under the override, leaving
-    // the persisted profile name and the profile directories out of sync.
-    const char* env = std::getenv("POSEIDON_USER_DIR");
-    if (env != nullptr && env[0] != '\0')
-        return std::string(env) + "/prefs.cfg";
-    return Poseidon::Foundation::getUserConfigDir(appName) + "/prefs.cfg";
+    // Resolve via GamePaths so prefs.cfg honours POSEIDON_USER_DIR and stays with the
+    // profiles, instead of leaking to the real appdata under a test override.
+    return Poseidon::Foundation::GamePaths::ResolveUserDir(appName) + "prefs.cfg";
 }
 
 std::unordered_map<std::string, std::string> loadPrefs(const char* appName)

--- a/engine/Poseidon/Foundation/Logging/Logging.cpp
+++ b/engine/Poseidon/Foundation/Logging/Logging.cpp
@@ -6,12 +6,14 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/pattern_formatter.h>
+#include <algorithm>
 #include <atomic>
 #include <cstring>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <ctype.h>
+#include <filesystem>
 #include <spdlog/common.h>
 #include <spdlog/details/log_msg.h>
 #include <spdlog/formatter.h>
@@ -196,7 +198,7 @@ class JsonlSink : public spdlog::sinks::base_sink<std::mutex>
 class PoseidonFormatter : public spdlog::custom_flag_formatter
 {
   public:
-    explicit PoseidonFormatter(LoggingSystem* sys) : _sys(sys) {}
+    explicit PoseidonFormatter(LoggingSystem* sys, bool colored = true) : _sys(sys), _colored(colored) {}
 
     static LoggingSystem::Category MapCategoryPublic(const spdlog::string_view_t& name) { return MapCategory(name); }
 
@@ -205,23 +207,25 @@ class PoseidonFormatter : public spdlog::custom_flag_formatter
         // Map logger name to category enum for color lookup
         auto cat = MapCategory(msg.logger_name);
 
-        const char* appTag = LoggingSystem::GetAppTag();
+        const char* appTag = LoggingSystem::GetAppTag(); // always plain
         if (appTag[0])
         {
             dest.append(std::string_view(appTag));
             dest.push_back(' ');
         }
-        const char* lvl = LoggingSystem::GetFormattedLevel(msg.level);
+        const char* lvl =
+            _colored ? LoggingSystem::GetFormattedLevel(msg.level) : LoggingSystem::GetPlainLevel(msg.level);
         dest.append(std::string_view(lvl, strlen(lvl)));
         dest.push_back(' ');
-        const char* catTag = LoggingSystem::GetColoredCategoryTag(cat);
+        const char* catTag =
+            _colored ? LoggingSystem::GetColoredCategoryTag(cat) : LoggingSystem::GetPlainCategoryTag(cat);
         dest.append(std::string_view(catTag, strlen(catTag)));
         dest.push_back(' ');
     }
 
     [[nodiscard]] std::unique_ptr<custom_flag_formatter> clone() const override
     {
-        return std::make_unique<PoseidonFormatter>(_sys);
+        return std::make_unique<PoseidonFormatter>(_sys, _colored);
     }
 
   private:
@@ -249,12 +253,14 @@ class PoseidonFormatter : public spdlog::custom_flag_formatter
     }
 
     LoggingSystem* _sys;
+    bool _colored;
 };
 
 // Static per-process app tag — read by the log formatter/sink without a
 // LoggingSystem back-pointer (see GetAppTag in the header).
 char LoggingSystem::m_appTag[20] = {};
 char LoggingSystem::m_appTagRaw[12] = {};
+char LoggingSystem::m_logFilePath[1024] = {};
 
 LoggingSystem::LoggingSystem()
     : m_logger(nullptr), m_initialized(false), m_jsonlMode(false), m_hasFileSink(false), m_filterActive(false)
@@ -390,6 +396,26 @@ const char* LoggingSystem::GetLevelName(spdlog::level::level_enum level)
     if (idx < 0 || idx > 5)
         return "info";
     return names[idx];
+}
+
+const char* LoggingSystem::GetPlainLevel(spdlog::level::level_enum level)
+{
+    static thread_local char buffer[16];
+    const char* names[] = {"TRCE", "DBUG", "INFO", "WARN", "ERRR", "CRIT"};
+    int idx = static_cast<int>(level);
+    if (idx < 0 || idx > 5)
+        idx = 2;
+    snprintf(buffer, sizeof(buffer), "[%s]", names[idx]);
+    return buffer;
+}
+
+const char* LoggingSystem::GetPlainCategoryTag(Category category)
+{
+    static thread_local char buffer[32];
+    const char* name = GetCategoryName(category);
+    // Match GetColoredCategoryTag's layout (name padded to align to 9 chars), minus colour.
+    snprintf(buffer, sizeof(buffer), "[%s]%-*s", name, (int)(9 - strlen(name) - 2), "");
+    return buffer;
 }
 
 void LoggingSystem::Initialize(const char* logLevel, const char* categoryFilter, const char* logFormat,
@@ -556,7 +582,7 @@ void LoggingSystem::Initialize(const char* logLevel, const char* categoryFilter,
     {
         auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFile, true);
         auto formatter = std::make_unique<spdlog::pattern_formatter>();
-        formatter->add_flag<PoseidonFormatter>('*', this);
+        formatter->add_flag<PoseidonFormatter>('*', this, /*colored=*/false);
         formatter->set_pattern("[%Y-%m-%d %H:%M:%S.%e] %*%v");
         file_sink->set_formatter(std::move(formatter));
         sinks.push_back(file_sink);
@@ -588,6 +614,116 @@ void LoggingSystem::Initialize(const char* logLevel, const char* categoryFilter,
     spdlog::set_default_logger(m_logger);
 
     m_initialized = true;
+}
+
+void LoggingSystem::AttachFileSink(const char* path)
+{
+    if (!m_initialized || !path || !path[0] || m_hasFileSink)
+        return;
+
+    try
+    {
+        std::filesystem::path p(path);
+        if (p.has_parent_path())
+        {
+            std::error_code ec;
+            std::filesystem::create_directories(p.parent_path(), ec);
+        }
+
+        auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(path, true);
+        auto formatter = std::make_unique<spdlog::pattern_formatter>();
+        formatter->add_flag<PoseidonFormatter>('*', this, /*colored=*/false);
+        formatter->set_pattern("[%Y-%m-%d %H:%M:%S.%e] %*%v");
+        file_sink->set_formatter(std::move(formatter));
+
+        // Runs single-threaded at boot, before any worker logs, so appending to each
+        // live logger's own sink vector in place is safe. Flush every line.
+        constexpr int catCount = static_cast<int>(LogCategory::_Count);
+        for (int i = 0; i < catCount; ++i)
+        {
+            if (m_categoryLoggers[i])
+            {
+                m_categoryLoggers[i]->sinks().push_back(file_sink);
+                m_categoryLoggers[i]->flush_on(spdlog::level::trace);
+            }
+        }
+        if (m_logger)
+        {
+            m_logger->sinks().push_back(file_sink);
+            m_logger->flush_on(spdlog::level::trace);
+        }
+
+        m_hasFileSink = true;
+        snprintf(m_logFilePath, sizeof(m_logFilePath), "%s", path);
+    }
+    catch (const std::exception& e)
+    {
+        LOG_WARN(Core, "Could not open log file {}: {}", path, e.what());
+    }
+}
+
+std::string MakeTimestampedLogName(const char* prefix)
+{
+    std::time_t t = std::time(nullptr);
+    struct tm tmNow;
+#ifdef _WIN32
+    localtime_s(&tmNow, &t);
+    const int pid = _getpid();
+#else
+    localtime_r(&t, &tmNow);
+    const int pid = getpid();
+#endif
+    // The pid suffix stops a same-second relaunch from truncating the previous
+    // run's file (basic_file_sink opens with truncate).
+    char buf[160];
+    snprintf(buf, sizeof(buf), "%s_%04d-%02d-%02d_%02d-%02d-%02d_%d.log", (prefix && prefix[0]) ? prefix : "log",
+             tmNow.tm_year + 1900, tmNow.tm_mon + 1, tmNow.tm_mday, tmNow.tm_hour, tmNow.tm_min, tmNow.tm_sec, pid);
+    return buf;
+}
+
+void WipeOldFiles(const std::string& dir, const char* prefix, const char* ext, int keepN)
+{
+    if (keepN < 0)
+        return;
+
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (!fs::is_directory(dir, ec))
+        return;
+
+    try
+    {
+        const std::string pre = (prefix && prefix[0]) ? prefix : "";
+        const std::string suf = (ext && ext[0]) ? ext : "";
+        std::vector<std::pair<fs::file_time_type, fs::path>> matches;
+        for (const auto& entry : fs::directory_iterator(dir, ec))
+        {
+            std::error_code fileEc;
+            if (!entry.is_regular_file(fileEc))
+                continue;
+            const std::string name = entry.path().filename().string();
+            if (!pre.empty() && name.rfind(pre, 0) != 0)
+                continue;
+            if (!suf.empty() &&
+                (name.size() < suf.size() || name.compare(name.size() - suf.size(), suf.size(), suf) != 0))
+                continue;
+            matches.emplace_back(entry.last_write_time(fileEc), entry.path());
+        }
+
+        if (static_cast<int>(matches.size()) <= keepN)
+            return;
+
+        std::sort(matches.begin(), matches.end(), [](const auto& a, const auto& b) { return a.first > b.first; });
+        for (size_t i = static_cast<size_t>(keepN); i < matches.size(); ++i)
+        {
+            std::error_code rmEc;
+            fs::remove(matches[i].second, rmEc);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        LOG_WARN(Core, "Log cleanup in {} failed: {}", dir, e.what());
+    }
 }
 
 void LoggingSystem::Shutdown()

--- a/engine/Poseidon/Foundation/Logging/Logging.hpp
+++ b/engine/Poseidon/Foundation/Logging/Logging.hpp
@@ -39,6 +39,13 @@ public:
 	/// Generates a tag like "app-1a2b" using PID. CLI --app-tag overrides.
 	void InitializeFromConfig(const char* appPrefix);
 
+	/// Attach a file sink to every logger after Initialize (the per-run log, once the
+	/// user dir is known). No-op if uninitialized, path empty, or already attached.
+	void AttachFileSink(const char* path);
+
+	/// Absolute path of the attached log file, or "" if none.
+	static const char* GetLogFilePath() { return m_logFilePath; }
+
 	/// Shutdown logging (flushes buffers)
 	void Shutdown();
 	
@@ -87,6 +94,9 @@ public:
 	static const char* GetColoredCategoryTag(Category category);
 	static const char* GetFormattedLevel(spdlog::level::level_enum level);
 	static const char* GetLevelName(spdlog::level::level_enum level);
+	// Plain (no ANSI) variants for file sinks; a log file must never carry colour codes.
+	static const char* GetPlainCategoryTag(Category category);
+	static const char* GetPlainLevel(spdlog::level::level_enum level);
 
 private:
 	std::shared_ptr<spdlog::logger> m_logger;
@@ -98,8 +108,17 @@ private:
 	bool m_filterActive;
 	static char m_appTag[20];
 	static char m_appTagRaw[12];
+	static char m_logFilePath[1024];
 };
 
 // LOG_* macros live in Poseidon/Foundation/Framework/Log.hpp.
+
+/// Build a per-run log filename like "<prefix>_YYYY-MM-DD_HH-MM-SS.log" from the
+/// local time. Chronological, so a lexical or mtime sort orders runs.
+std::string MakeTimestampedLogName(const char* prefix);
+
+/// Keep the newest `keepN` `dir` files matching `prefix`*`ext`; delete the rest,
+/// oldest first. Swallows all filesystem errors; never throws.
+void WipeOldFiles(const std::string& dir, const char* prefix, const char* ext, int keepN);
 
 } // namespace Poseidon::Foundation

--- a/engine/Poseidon/Foundation/Platform/AppConfig.cpp
+++ b/engine/Poseidon/Foundation/Platform/AppConfig.cpp
@@ -231,6 +231,45 @@ AppConfig& AppConfig::Instance()
 
 AppConfig::AppConfig() {}
 
+std::string AppConfig::DescribeLaunchError(const std::string& cliError, int argc, const char* const* argv)
+{
+    std::string launchOptions;
+    bool attachedShort = false;
+    for (int i = 1; i < argc; ++i)
+    {
+        const char* a = argv[i];
+        if (!a || !a[0])
+            continue;
+        if (!launchOptions.empty())
+            launchOptions += ' ';
+        launchOptions += a;
+        if (a[0] == '-' && a[1] && a[1] != '-' && a[2])
+            attachedShort = true;
+    }
+
+    if (launchOptions.empty())
+        return cliError;
+
+    std::string expandedOption;
+    if (attachedShort && cliError.rfind("--", 0) == 0)
+    {
+        const size_t end = cliError.find_first_of(" :=", 2);
+        const std::string named = cliError.substr(0, end == std::string::npos ? cliError.size() : end);
+        if (named.size() > 2 && launchOptions.find(named) == std::string::npos)
+            expandedOption = named;
+    }
+
+    std::string message = cliError;
+    message += "\n\nYou launched with these options:\n" + launchOptions;
+    message += "\n\nIf you started the game from Steam or another launcher, open its "
+               "launch options and check them.";
+    if (!expandedOption.empty())
+        message += "\n\nA single dash takes the letters after it as the value, so -abc means -a bc "
+                   "(that is where " +
+                   expandedOption + " came from). Use two dashes for a long option.";
+    return message;
+}
+
 void AppConfig::ParseCommandLine(int argc, char** argv)
 {
     if (_parsed)
@@ -685,6 +724,7 @@ void AppConfig::ParseCommandLine(int argc, char** argv)
                                             "Max 10 chars, padded for alignment."),
                    serverRole ? CliHelpVisibility::Basic : CliHelpVisibility::Full);
         loggingGroup->add_option("--log-file", _logFile, "Write log output to a file in addition to console");
+        loggingGroup->add_flag("--no-log-file", _noLogFile, "Disable the automatic per-run log file");
         showOption(loggingGroup->add_option("--perf-trace", _perfTracePath,
                                             "Write newline-delimited JSON of every ScopedTimer event to this path. "
                                             "Reads in DuckDB via read_json_auto for tabular analysis; convert to "
@@ -732,6 +772,10 @@ void AppConfig::ParseCommandLine(int argc, char** argv)
                 normalizedArgv.push_back(arg.c_str());
 
             app.parse(static_cast<int>(normalizedArgv.size()), normalizedArgv.data());
+
+            // With allow_extras(), unmatched args are tolerated but otherwise dropped.
+            // Capture them so GameBase can warn the player once logging is up.
+            _unrecognizedArgs = app.remaining(true);
 
             // Track which options were explicitly provided
             _windowFlagExplicit = windowOpt->count() > 0;
@@ -910,30 +954,27 @@ void AppConfig::ParseCommandLine(int argc, char** argv)
     }
     catch (const CLI::ParseError& e)
     {
-        // CLI11 throws ParseError for --help, --version, and actual errors
-        // The exit code tells us if it's success (0 for --help) or error (!=0)
+        // exitCode 0 is the clean --help/--version path; a real error routes through
+        // _parseFatalError so GameBase surfaces it instead of exiting inside the parser.
         int exitCode = e.get_exit_code();
-
-        // Output to stderr for errors
         if (exitCode != 0)
         {
             const char* usageHint = BuildInfo::ReleaseBuild
                                         ? "Use --help for basic usage or --help-full for advanced usage"
                                         : "Use --help for basic usage, --help-full for advanced usage, or --help --dev "
                                           "for developer options";
-#ifdef _WIN32
-            std::string errorMsg = "\nCommand-line error: " + std::string(e.what()) + "\n\n" + usageHint + "\n\n";
-            WriteCliText(STD_ERROR_HANDLE, stderr, errorMsg);
-#else
-            fprintf(stderr, "\nCommand-line error: %s\n\n%s\n\n", e.what(), usageHint);
-#endif
+            std::string msg = DescribeLaunchError(e.what(), argc, argv);
+            msg += "\n\n";
+            msg += usageHint;
+            _parseFatalError = msg;
+            _parseFatalExitCode = exitCode;
+            return;
         }
 
 #ifdef _WIN32
         Sleep(100);    // Brief delay to ensure output is flushed
         FreeConsole(); // Detach from console before exiting
 #endif
-
         std::exit(exitCode);
     }
     catch (const std::exception& e)
@@ -941,7 +982,7 @@ void AppConfig::ParseCommandLine(int argc, char** argv)
         // Any other exception during setup or parsing. Do not print directly here:
         // GameBase initializes the normal logger after parsing and reports this
         // through the same log sinks as every other startup failure.
-        _parseFatalError = e.what();
+        _parseFatalError = DescribeLaunchError(e.what(), argc, argv);
         _parseFatalExitCode = 2;
         return;
     }

--- a/engine/Poseidon/Foundation/Platform/AppConfig.hpp
+++ b/engine/Poseidon/Foundation/Platform/AppConfig.hpp
@@ -2,6 +2,7 @@
 
 #include <Poseidon/Foundation/Strings/RString.hpp>
 #include <string>
+#include <vector>
 
 // Forward declaration for CLI11
 namespace CLI {
@@ -26,6 +27,11 @@ public:
     bool HasParseFatalError() const { return _parseFatalExitCode != 0; }
     int GetParseFatalExitCode() const { return _parseFatalExitCode; }
     const std::string& GetParseFatalError() const { return _parseFatalError; }
+
+    static std::string DescribeLaunchError(const std::string& cliError, int argc, const char* const* argv);
+    // Args tolerated by allow_extras() but matched to no option; reported so a typo'd
+    // launch flag isn't silently dropped.
+    const std::vector<std::string>& GetUnrecognizedArgs() const { return _unrecognizedArgs; }
 
     /// Apply parsed config values to process-wide globals.
     void ApplyToLegacyGlobals();
@@ -292,6 +298,9 @@ public:
 	/// Log file path (--log-file), empty = no file logging
 	const std::string& GetLogFile() const { return _logFile; }
 
+	/// True when --no-log-file disables the automatic per-run log file.
+	bool NoLogFile() const { return _noLogFile; }
+
 	/// Chrome trace JSON output path (--perf-trace), empty = disabled.
 	/// File loads in https://ui.perfetto.dev/ or chrome://tracing.
 	const std::string& GetPerfTracePath() const { return _perfTracePath; }
@@ -442,6 +451,7 @@ private:
 	std::string _appTag = "";        // App identifier tag for log lines (--app-tag)
 	bool _legacyLogs = false;         // Show legacy bridge logs (--legacy-logs)
 	std::string _logFile = "";        // Log file path (--log-file), empty = no file
+	bool _noLogFile = false;          // Disable the automatic per-run log file (--no-log-file)
 	std::string _perfTracePath = "";  // Chrome trace JSON path (--perf-trace), empty = disabled
     // Mission file
     std::string _missionFile;
@@ -468,6 +478,7 @@ private:
     bool _parsed = false;
     int _parseFatalExitCode = 0;
     std::string _parseFatalError;
+    std::vector<std::string> _unrecognizedArgs;
 };
 
 } // namespace Poseidon::Foundation

--- a/engine/Poseidon/Foundation/Platform/CrashHandler.cpp
+++ b/engine/Poseidon/Foundation/Platform/CrashHandler.cpp
@@ -13,6 +13,8 @@ namespace Poseidon::Foundation
 {
 namespace
 {
+char g_crashDir[MAX_PATH] = {}; // where to write the minidump; empty = beside the exe
+
 LONG WINAPI CrashFilter(EXCEPTION_POINTERS* ep)
 {
     static bool reentered = false;
@@ -76,30 +78,44 @@ LONG WINAPI CrashFilter(EXCEPTION_POINTERS* ep)
     }
     fflush(stderr);
 
-    char path[MAX_PATH];
-    DWORD n = GetModuleFileNameA(nullptr, path, MAX_PATH);
-    if (n > 0 && n < MAX_PATH)
+    char dir[MAX_PATH] = {};
+    if (g_crashDir[0])
     {
-        char* last = std::strrchr(path, '\\');
+        snprintf(dir, sizeof(dir), "%s", g_crashDir);
+    }
+    else
+    {
+        DWORD n = GetModuleFileNameA(nullptr, dir, MAX_PATH);
+        if (n == 0 || n >= MAX_PATH)
+            return EXCEPTION_EXECUTE_HANDLER;
+        char* last = std::strrchr(dir, '\\');
         if (last)
             *last = 0;
-        char dmp[MAX_PATH];
-        snprintf(dmp, sizeof(dmp), "%s\\crash-%lu.dmp", path, GetCurrentProcessId());
-        HANDLE f = CreateFileA(dmp, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, nullptr);
-        if (f != INVALID_HANDLE_VALUE)
-        {
-            MINIDUMP_EXCEPTION_INFORMATION mei = {GetCurrentThreadId(), ep, FALSE};
-            MiniDumpWriteDump(proc, GetCurrentProcessId(), f, MiniDumpWithDataSegs, &mei, nullptr, nullptr);
-            CloseHandle(f);
-            fprintf(stderr, "  minidump: %s\n", dmp);
-        }
+    }
+
+    char dmp[MAX_PATH];
+    snprintf(dmp, sizeof(dmp), "%s\\crash-%lu.dmp", dir, GetCurrentProcessId());
+    HANDLE f = CreateFileA(dmp, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, nullptr);
+    if (f != INVALID_HANDLE_VALUE)
+    {
+        MINIDUMP_EXCEPTION_INFORMATION mei = {GetCurrentThreadId(), ep, FALSE};
+        MiniDumpWriteDump(proc, GetCurrentProcessId(), f, MiniDumpWithDataSegs, &mei, nullptr, nullptr);
+        CloseHandle(f);
+        fprintf(stderr, "  minidump: %s\n", dmp);
     }
     return EXCEPTION_EXECUTE_HANDLER;
 }
 } // namespace
 
-void InstallCrashHandler(const char*)
+void InstallCrashHandler(const char* crashDir)
 {
+    if (crashDir && crashDir[0])
+    {
+        snprintf(g_crashDir, sizeof(g_crashDir), "%s", crashDir);
+        size_t len = std::strlen(g_crashDir);
+        while (len > 0 && (g_crashDir[len - 1] == '\\' || g_crashDir[len - 1] == '/'))
+            g_crashDir[--len] = 0;
+    }
     SetUnhandledExceptionFilter(CrashFilter);
 }
 } // namespace Poseidon::Foundation

--- a/engine/Poseidon/Foundation/Platform/StartupError.cpp
+++ b/engine/Poseidon/Foundation/Platform/StartupError.cpp
@@ -1,7 +1,6 @@
 #include <Poseidon/Foundation/Platform/StartupError.hpp>
 
 #include <Poseidon/Foundation/Common/GamePaths.hpp>
-#include <Poseidon/Foundation/Common/PlatformPaths.hpp>
 #include <Poseidon/Foundation/Logging/Logging.hpp>
 #include <Poseidon/Foundation/Platform/AppConfig.hpp>
 
@@ -34,13 +33,13 @@ bool TestHarnessEnv()
     return v && v[0] && strcmp(v, "0") != 0 && strcmp(v, "false") != 0 && strcmp(v, "off") != 0;
 }
 
-// Directory holding the log/crash files. Resolves the same folder without the
-// singleton, for failures before GamePaths is initialized.
+// The user-content folder holding the log/crash files. Resolves the same folder
+// without the singleton, for failures before GamePaths is initialized.
 std::string DiagnosticsDir()
 {
     if (GamePaths::Instance().IsInitialized())
-        return GamePaths::Instance().UserDir();
-    return getUserConfigDir("CWR");
+        return GamePaths::Instance().UserContentDir();
+    return GamePaths::ResolveUserContentDir("CWR", "Cold War Assault");
 }
 } // namespace
 
@@ -89,18 +88,15 @@ void ShowStartupError(const char* title, const char* message)
     const char* logPath = LoggingSystem::GetLogFilePath();
     const std::string diagDir = DiagnosticsDir();
 
+    // diagDir carries a trailing separator, so append leaf names directly.
     std::string body = message;
     body += "\n\n";
     if (logPath && logPath[0])
         body += std::string("Log file:\n") + logPath;
     else
-        body += std::string("Logs:\n") + diagDir + "/logs";
+        body += "Logs:\n" + diagDir + "logs";
     body += "\n\n";
-#ifdef _WIN32
-    body += "Crash reports:\nbeside the game executable";
-#else
-    body += "Crash reports:\n" + diagDir;
-#endif
+    body += "Crash reports:\n" + diagDir + "crashes";
 
     fprintf(stderr, "\n%s\n%s\n\n", title, body.c_str());
     fflush(stderr);

--- a/engine/Poseidon/Foundation/Platform/StartupError.cpp
+++ b/engine/Poseidon/Foundation/Platform/StartupError.cpp
@@ -1,0 +1,111 @@
+#include <Poseidon/Foundation/Platform/StartupError.hpp>
+
+#include <Poseidon/Foundation/Common/GamePaths.hpp>
+#include <Poseidon/Foundation/Common/PlatformPaths.hpp>
+#include <Poseidon/Foundation/Logging/Logging.hpp>
+#include <Poseidon/Foundation/Platform/AppConfig.hpp>
+
+#include <SDL3/SDL_messagebox.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace Poseidon::Foundation
+{
+namespace
+{
+bool EnvSet(const char* name)
+{
+    const char* v = std::getenv(name);
+    return v && v[0];
+}
+
+bool TestHarnessEnv()
+{
+    const char* v = std::getenv("POSEIDON_TEST");
+    return v && v[0] && strcmp(v, "0") != 0 && strcmp(v, "false") != 0 && strcmp(v, "off") != 0;
+}
+
+// Directory holding the log/crash files. Resolves the same folder without the
+// singleton, for failures before GamePaths is initialized.
+std::string DiagnosticsDir()
+{
+    if (GamePaths::Instance().IsInitialized())
+        return GamePaths::Instance().UserDir();
+    return getUserConfigDir("CWR");
+}
+} // namespace
+
+bool HasInteractiveConsole()
+{
+#ifdef _WIN32
+    return GetConsoleWindow() != nullptr;
+#else
+    return isatty(STDERR_FILENO) != 0;
+#endif
+}
+
+bool ShouldWriteAutoLog()
+{
+    if (TestHarnessEnv())
+        return false;
+    const AppConfig& cfg = AppConfig::Instance();
+    if (cfg.CheckInitAndExit() || cfg.GetHarnessPort() >= 0)
+        return false;
+    // Screenshot capture-and-exit runs headless with a display but no user, so a
+    // blocking dialog would hang it.
+    if (!cfg.GetScreenshotPath().empty() || !cfg.GetAutoScreenshot().empty())
+        return false;
+    return !HasInteractiveConsole();
+}
+
+bool ShouldShowGuiError()
+{
+    if (!ShouldWriteAutoLog())
+        return false;
+#ifndef _WIN32
+    // Headless (no display): the SDL box would fail; the stderr write covers it.
+    if (!EnvSet("DISPLAY") && !EnvSet("WAYLAND_DISPLAY"))
+        return false;
+#endif
+    return true;
+}
+
+void ShowStartupError(const char* title, const char* message)
+{
+    if (!title || !title[0])
+        title = "Startup Error";
+    if (!message || !message[0])
+        message = "The game could not start.";
+
+    const char* logPath = LoggingSystem::GetLogFilePath();
+    const std::string diagDir = DiagnosticsDir();
+
+    std::string body = message;
+    body += "\n\n";
+    if (logPath && logPath[0])
+        body += std::string("Log file:\n") + logPath;
+    else
+        body += std::string("Logs:\n") + diagDir + "/logs";
+    body += "\n\n";
+#ifdef _WIN32
+    body += "Crash reports:\nbeside the game executable";
+#else
+    body += "Crash reports:\n" + diagDir;
+#endif
+
+    fprintf(stderr, "\n%s\n%s\n\n", title, body.c_str());
+    fflush(stderr);
+
+    if (ShouldShowGuiError())
+        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title, body.c_str(), nullptr);
+}
+} // namespace Poseidon::Foundation

--- a/engine/Poseidon/Foundation/Platform/StartupError.hpp
+++ b/engine/Poseidon/Foundation/Platform/StartupError.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace Poseidon::Foundation
+{
+// True when an interactive console/terminal is attached to stderr (a developer
+// running from a shell). A Steam/GUI launch has none.
+bool HasInteractiveConsole();
+
+// True when the automatic per-run log file should be written: no interactive
+// console AND not a test / tri-harness / --check run.
+bool ShouldWriteAutoLog();
+
+// True when a startup failure should pop a GUI dialog: ShouldWriteAutoLog()'s
+// conditions plus, on Linux, a usable display.
+bool ShouldShowGuiError();
+
+// Report a fatal startup error: always to stderr, plus a native SDL dialog when
+// ShouldShowGuiError(). Names the log and crash paths. Never throws; safe pre-init.
+void ShowStartupError(const char* title, const char* message);
+} // namespace Poseidon::Foundation

--- a/tests/unit/engine/Poseidon/Core/test_logging.cpp
+++ b/tests/unit/engine/Poseidon/Core/test_logging.cpp
@@ -11,6 +11,10 @@
 #include <spdlog/spdlog.h>
 #include <stddef.h>
 #include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -245,4 +249,98 @@ TEST_CASE("strict mode: err-level log latches the trip; warn/info do not", "[log
     CHECK_FALSE(LS::StrictTripped());
 
     LS::SetStrictMode(false); // don't leak strict into sibling tests in this binary
+}
+
+TEST_CASE("AttachFileSink captures log lines into the file", "[logging][file]")
+{
+    namespace fs = std::filesystem;
+    const fs::path path = fs::temp_directory_path() / "cwr_attach_sink_test.log";
+    std::error_code ec;
+    fs::remove(path, ec);
+
+    Poseidon::Foundation::LoggingSystem logSys;
+    logSys.Initialize("info");
+    logSys.AttachFileSink(path.string().c_str());
+    CHECK(std::string(Poseidon::Foundation::LoggingSystem::GetLogFilePath()) == path.string());
+
+    LOG_INFO(Core, "attach sink probe 12345");
+    logSys.Shutdown();
+
+    std::ifstream in(path);
+    bool found = false;
+    bool hasAnsi = false;
+    std::string line;
+    while (std::getline(in, line))
+    {
+        if (line.find("attach sink probe 12345") != std::string::npos)
+            found = true;
+        if (line.find("\033[") != std::string::npos)
+            hasAnsi = true;
+    }
+    CHECK(found);
+    CHECK_FALSE(hasAnsi);
+
+    fs::remove(path, ec);
+}
+
+TEST_CASE("MakeTimestampedLogName builds a fixed-width dated .log name", "[logging][wiper]")
+{
+    const std::string name = Poseidon::Foundation::MakeTimestampedLogName("cwr");
+    // Shape: cwr_YYYY-MM-DD_HH-MM-SS_<pid>.log
+    CHECK(name.rfind("cwr_", 0) == 0);
+    CHECK(name.substr(name.size() - 4) == ".log");
+    CHECK(name[8] == '-');
+    CHECK(name[11] == '-');
+    CHECK(name[14] == '_');
+    CHECK(name[17] == '-');
+    CHECK(name[20] == '-');
+    CHECK(name[23] == '_');
+    CHECK(name.size() > 24);
+}
+
+TEST_CASE("WipeOldFiles keeps the newest N matching files and ignores the rest", "[logging][wiper]")
+{
+    namespace fs = std::filesystem;
+    const fs::path root = fs::temp_directory_path() / "cwr_wipe_test";
+    std::error_code ec;
+    fs::remove_all(root, ec);
+    fs::create_directories(root);
+
+    const auto base = fs::file_time_type::clock::now();
+    auto touch = [&](const char* fmt, int i, int secs)
+    {
+        char n[32];
+        snprintf(n, sizeof(n), fmt, i);
+        const fs::path p = root / n;
+        std::ofstream(p) << "x";
+        fs::last_write_time(p, base + std::chrono::seconds(secs));
+        return p;
+    };
+
+    std::vector<fs::path> logs;
+    for (int i = 0; i < 15; ++i)
+        logs.push_back(touch("cwr_%02d.log", i, i));
+    const fs::path other = root / "keepme.txt";
+    std::ofstream(other) << "y";
+
+    Poseidon::Foundation::WipeOldFiles(root.string(), "cwr_", ".log", 10);
+
+    for (int i = 0; i < 5; ++i)
+        CHECK_FALSE(fs::exists(logs[i]));
+    for (int i = 5; i < 15; ++i)
+        CHECK(fs::exists(logs[i]));
+    CHECK(fs::exists(other));
+
+    std::vector<fs::path> crashes;
+    for (int i = 0; i < 4; ++i)
+        crashes.push_back(touch("crash_%02d.txt", i, i));
+    Poseidon::Foundation::WipeOldFiles(root.string(), "crash_", ".txt", 2);
+    CHECK_FALSE(fs::exists(crashes[0]));
+    CHECK_FALSE(fs::exists(crashes[1]));
+    CHECK(fs::exists(crashes[2]));
+    CHECK(fs::exists(crashes[3]));
+    CHECK(fs::exists(logs[14]));
+    CHECK(fs::exists(other));
+
+    fs::remove_all(root, ec);
 }

--- a/tests/unit/engine/Poseidon/Foundation/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/Foundation/CMakeLists.txt
@@ -27,6 +27,7 @@ set(POSEIDON_BASE_TEST_SOURCES
     Common/test_platform.cpp
     Common/test_platformPaths.cpp
     Platform/test_crash_handler.cpp
+    Platform/test_launch_diagnostics.cpp
     Containers/test_cachelist.cpp
     Containers/test_compactbuf.cpp
     Containers/test_array.cpp

--- a/tests/unit/engine/Poseidon/Foundation/Common/test_gamePaths.cpp
+++ b/tests/unit/engine/Poseidon/Foundation/Common/test_gamePaths.cpp
@@ -77,6 +77,40 @@ TEST_CASE("GamePaths: not initialized before Initialize()", "[gamePaths]")
     CHECK(gp.TempDir().empty());
 }
 
+TEST_CASE("GamePaths: ResolveUserDir honours POSEIDON_USER_DIR before Initialize", "[gamePaths]")
+{
+#ifndef _WIN32
+    ScopedEnv env("POSEIDON_USER_DIR", "/tmp/cwr_resolve_test");
+    CHECK(GamePaths::ResolveUserDir("CWR") == "/tmp/cwr_resolve_test/");
+#endif
+}
+
+TEST_CASE("GamePaths: ResolveUserDir falls back to the platform user dir", "[gamePaths]")
+{
+#ifndef _WIN32
+    ScopedEnv env("POSEIDON_USER_DIR", "");
+    const std::string dir = GamePaths::ResolveUserDir("CWR");
+    CHECK(dir.find("/CWR") != std::string::npos);
+    REQUIRE_FALSE(dir.empty());
+    CHECK(dir.back() == '/');
+#endif
+}
+
+TEST_CASE("GamePaths: ResolveUserContentDir honours its overrides before Initialize", "[gamePaths]")
+{
+#ifndef _WIN32
+    {
+        ScopedEnv content("POSEIDON_USER_CONTENT_DIR", "/tmp/cwr_content_test");
+        CHECK(GamePaths::ResolveUserContentDir("CWR", "Cold War Assault") == "/tmp/cwr_content_test/");
+    }
+    {
+        ScopedEnv content("POSEIDON_USER_CONTENT_DIR", "");
+        ScopedEnv user("POSEIDON_USER_DIR", "/tmp/cwr_sandbox");
+        CHECK(GamePaths::ResolveUserContentDir("CWR", "Cold War Assault") == "/tmp/cwr_sandbox/content/");
+    }
+#endif
+}
+
 TEST_CASE("GamePaths: Initialize sets codename and cfg name", "[gamePaths]")
 {
     auto& gp = GamePaths::Instance();

--- a/tests/unit/engine/Poseidon/Foundation/Platform/test_launch_diagnostics.cpp
+++ b/tests/unit/engine/Poseidon/Foundation/Platform/test_launch_diagnostics.cpp
@@ -1,0 +1,57 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <Poseidon/Foundation/Platform/AppConfig.hpp>
+
+#include <string>
+#include <vector>
+
+using Catch::Matchers::ContainsSubstring;
+using Poseidon::Foundation::AppConfig;
+
+namespace
+{
+std::string Describe(const std::string& cliError, std::vector<const char*> args)
+{
+    return AppConfig::DescribeLaunchError(cliError, static_cast<int>(args.size()), args.data());
+}
+} // namespace
+
+TEST_CASE("DescribeLaunchError echoes the raw launch options", "[appconfig][cli]")
+{
+    const std::string out = Describe("--anim: File does not exist: bc", {"game", "-abc", "-C", "packages/Game"});
+    REQUIRE_THAT(out, ContainsSubstring("You launched with these options:\n-abc -C packages/Game"));
+}
+
+TEST_CASE("DescribeLaunchError points players at their launcher options", "[appconfig][cli]")
+{
+    const std::string out = Describe("--width: value out of range", {"game", "-wabc"});
+    REQUIRE_THAT(out, ContainsSubstring("Steam or another launcher"));
+}
+
+TEST_CASE("DescribeLaunchError explains a bundled short option that expanded", "[appconfig][cli]")
+{
+    const std::string out = Describe("--anim: File does not exist: bc", {"game", "-abc"});
+    REQUIRE_THAT(out, ContainsSubstring("-abc means -a bc"));
+    REQUIRE_THAT(out, ContainsSubstring("--anim came from"));
+}
+
+TEST_CASE("DescribeLaunchError omits the expansion note for a verbatim long option", "[appconfig][cli]")
+{
+    const std::string out = Describe("--anim: File does not exist: /bad", {"game", "--anim", "/bad"});
+    REQUIRE_THAT(out, ContainsSubstring("You launched with these options"));
+    REQUIRE_THAT(out, !ContainsSubstring("came from"));
+}
+
+TEST_CASE("DescribeLaunchError omits the expansion note for a spaced short value", "[appconfig][cli]")
+{
+    const std::string out = Describe("--width: Value abc not in range", {"game", "-w", "abc"});
+    REQUIRE_THAT(out, ContainsSubstring("You launched with these options"));
+    REQUIRE_THAT(out, !ContainsSubstring("came from"));
+}
+
+TEST_CASE("DescribeLaunchError returns the bare error when no options were given", "[appconfig][cli]")
+{
+    REQUIRE(Describe("some parse error", {"game"}) == "some parse error");
+}


### PR DESCRIPTION
There were various reports of the game not starting, either from wrong CLI params or with no logs stored by default. Let's report startup issues in a pop-up (Windows and Linux using SDL dialog) and store logs and crashes in the user documents folder for quick access. To not overwhelm the player, keep only the last ten of each.

Details
- On a no-console launch (Steam/GUI), this run's log goes to `Documents\Cold War Assault\logs` on Windows, or the XDG data folder on Linux, next to the crash reports. `--log-file` still forces a file, `--no-log-file` turns the automatic one off. Logs are plain text (no escape sequences for colors).
- A bad launch option no longer quits silently from inside the parser. The pop-up names the log and crash paths, echoes the options the player typed, and points them at their launcher's launch options. Also various startup crashes are properly reported now using SDL window.
- The pop-up shows only for a real desktop launch, never in tests, the harness, --check, or a terminal.

## example (running game with `-abc`)

<img width="1768" height="854" alt="image" src="https://github.com/user-attachments/assets/5ee257cb-ac30-4d7a-ad67-53cf1c031a68" />

## example default user dir after few runs and (sadly) crash

```
● C:\Users\retro\Documents\Cold War Assault\
  ├── logs\
  │   ├── cwr_2026-07-22_18-03-11_10432.log
  │   ├── cwr_2026-07-22_18-45-27_10995.log
  │   └── cwr_2026-07-22_20-05-12_11703.log
  ├── crashes\
  │   └── crash-11703.dmp
  ├── Mods\
  ├── missions\
  ├── MPMissions\
  └── Workshop\
```