### PR TITLE
Fix mission description UTF-8 encoding

### DIFF
--- a/engine/Poseidon/UI/Controls/HtmlBodyText.hpp
+++ b/engine/Poseidon/UI/Controls/HtmlBodyText.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <Poseidon/Foundation/Strings/RString.hpp>
+
+namespace Poseidon
+{
+class QIStream;
+
+RString ReadHtmlBodyText(QIStream& in, int langID);
+} // namespace Poseidon

--- a/engine/Poseidon/UI/Controls/UIControlsExt.cpp
+++ b/engine/Poseidon/UI/Controls/UIControlsExt.cpp
@@ -1721,6 +1721,11 @@ void CHTMLContainer::LoadBuffer(const char* filenameHint, const char* utf8Text, 
             // text
             in.unget();
             RString text = ReadText(in, _fontP->GetLangID());
+
+            // Make sure newly-converted codepoints are in UTF-8 representation
+            const Poseidon::Codepage cp = Poseidon::CodepageForLanguage((const char*)GLanguage);
+            text = Poseidon::DecodeLegacyTextToRString(text.Data(), cp);
+
             switch (item.context)
             {
                 case HTMLNone:

--- a/engine/Poseidon/UI/Controls/UIControlsExt.cpp
+++ b/engine/Poseidon/UI/Controls/UIControlsExt.cpp
@@ -1,6 +1,7 @@
 
 #include <Poseidon/UI/Controls/UIControlsExtShared.hpp>
 #include <Poseidon/UI/Controls/HtmlTextWrap.hpp>
+#include <Poseidon/UI/Controls/HtmlBodyText.hpp>
 #include <Poseidon/Input/InputSubsystem.hpp>
 #include <Poseidon/World/World.hpp>
 #include <ctype.h>
@@ -988,7 +989,9 @@ static char ReadChar(QIStream& in)
     }
 }
 
-static RString ReadText(QIStream& in, int langID)
+namespace Poseidon
+{
+RString ReadHtmlBodyText(QIStream& in, int langID)
 {
     char buf[4 * 1024];
     int len = 0;
@@ -1016,7 +1019,11 @@ static RString ReadText(QIStream& in, int langID)
             }
             else if (c == '&')
             {
-                c = ReadChar(in);
+                // ReadChar decodes the entity to a Latin-1 codepoint; emit it as UTF-8
+                // so it composes with the surrounding already-UTF-8 body.
+                const unsigned char decoded = static_cast<unsigned char>(ReadChar(in));
+                len += Poseidon::Foundation::EncodeUtf8Codepoint(decoded, buf + len, sizeof(buf) - len);
+                goto ReadTextContinue;
             }
 
             if (len < sizeof(buf) - 1)
@@ -1031,6 +1038,7 @@ static RString ReadText(QIStream& in, int langID)
     buf[len] = 0;
     return buf;
 }
+} // namespace Poseidon
 
 static RString ConvertURL(RString src)
 {
@@ -1720,12 +1728,7 @@ void CHTMLContainer::LoadBuffer(const char* filenameHint, const char* utf8Text, 
         {
             // text
             in.unget();
-            RString text = ReadText(in, _fontP->GetLangID());
-
-            // Make sure newly-converted codepoints are in UTF-8 representation
-            const Poseidon::Codepage cp = Poseidon::CodepageForLanguage((const char*)GLanguage);
-            text = Poseidon::DecodeLegacyTextToRString(text.Data(), cp);
-
+            RString text = ReadHtmlBodyText(in, _fontP->GetLangID());
             switch (item.context)
             {
                 case HTMLNone:

--- a/tests/unit/engine/Poseidon/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/CMakeLists.txt
@@ -468,6 +468,7 @@ list(APPEND POSEIDON_TEST_SOURCES
     UI/test_gamepad_page.cpp
     UI/test_gamepad_tuning_page.cpp
     UI/test_graphics_page.cpp
+    UI/test_html_body_text.cpp
     UI/test_html_text_wrap.cpp
     UI/test_kbm_page.cpp
     UI/test_meter_widget.cpp

--- a/tests/unit/engine/Poseidon/UI/test_html_body_text.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_html_body_text.cpp
@@ -1,0 +1,53 @@
+// HTML entities in a mission description decode to UTF-8, and raw UTF-8 text in the
+// same run is left intact.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <Poseidon/UI/Controls/HtmlBodyText.hpp>
+#include <Poseidon/IO/Streams/QStream.hpp>
+
+#include <cstring>
+
+using namespace Poseidon;
+
+namespace
+{
+RString ProcessHtmlText(const char* html)
+{
+    QIStream in;
+    in.init(html, static_cast<int>(std::strlen(html)));
+    return ReadHtmlBodyText(in, 0);
+}
+} // namespace
+
+TEST_CASE("ReadHtmlBodyText: named accent entities across languages become UTF-8", "[ui][html][utf8]")
+{
+    CHECK(ProcessHtmlText("caf&eacute;<") == RString("caf\xC3\xA9"));
+    CHECK(ProcessHtmlText("gar&ccedil;on<") == RString("gar\xC3\xA7on"));
+    CHECK(ProcessHtmlText("gr&uuml;n<") == RString("gr\xC3\xBCn"));
+    CHECK(ProcessHtmlText("gro&szlig;<") == RString("gro\xC3\x9F"));
+    CHECK(ProcessHtmlText("a&ntilde;o<") == RString("a\xC3\xB1o"));
+    CHECK(ProcessHtmlText("citt&agrave;<") == RString("citt\xC3\xA0"));
+}
+
+TEST_CASE("ReadHtmlBodyText: numeric entity becomes UTF-8", "[ui][html][utf8]")
+{
+    CHECK(ProcessHtmlText("caf&#233;<") == RString("caf\xC3\xA9"));
+}
+
+TEST_CASE("ReadHtmlBodyText: non-breaking-space entity becomes UTF-8", "[ui][html][utf8]")
+{
+    // A `<p>&nbsp;</p>` spacer decodes to U+00A0.
+    CHECK(ProcessHtmlText("&nbsp;<") == RString("\xC2\xA0"));
+}
+
+TEST_CASE("ReadHtmlBodyText: ASCII entity stays a single ASCII byte", "[ui][html][utf8]")
+{
+    CHECK(ProcessHtmlText("R&amp;R<") == RString("R&R"));
+}
+
+TEST_CASE("ReadHtmlBodyText: raw UTF-8 next to an entity both stay UTF-8", "[ui][html][utf8]")
+{
+    // Raw UTF-8 e-acute next to the entity &agrave;; both stay UTF-8.
+    CHECK(ProcessHtmlText("\xC3\xA9&agrave;<") == RString("\xC3\xA9\xC3\xA0"));
+}


### PR DESCRIPTION
The HTML for mission descriptions was doing UTF-8 transcoding, then parsing the HTML. This caused HTML-encoded/escaped characters to not be UTF-8 encoded, which caused errors in the text. This pull request changes the behavior so an additional UTF-8 pass is done on the HTML body text, after the other processing has been done.

A couple example screenshots of this working now:

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/4d9e60d8-d2ae-41ce-899e-8282538eb961" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/1f2cdff6-cea3-44e6-82d9-ed2cae89aee7" />

This closes #96.