### PR TITLE
Decode legacy-codepage world names in the editor and on the map

### DIFF
--- a/engine/Poseidon/UI/DisplayUI.cpp
+++ b/engine/Poseidon/UI/DisplayUI.cpp
@@ -14,6 +14,7 @@
 #include <Poseidon/World/Scene/Camera/Camera.hpp>
 
 #include <Poseidon/IO/Streams/QBStream.hpp>
+#include <Poseidon/UI/Locale/Stringtable/CodepageTranscode.hpp>
 #include <Poseidon/UI/Locale/Stringtable/Stringtable.hpp>
 
 #include <Random/randomGen.hpp>
@@ -1212,7 +1213,8 @@ Control* DisplaySelectIsland::OnCreateCtrl(int type, int idc, const ParamEntry& 
                     continue;
                 }
 
-                int index = lbox->AddString(Pars >> "CfgWorlds" >> name >> "description");
+                int index = lbox->AddString(
+                    Poseidon::DecodeLegacyTextToRString(Pars >> "CfgWorlds" >> name >> "description", GLanguage));
                 lbox->SetData(index, name);
                 if (stricmp(name, Glob.header.worldname) == 0)
                 {
@@ -1526,7 +1528,8 @@ void DisplayCustomArcade::InsertGames()
 
             CTreeItem* itemWorld = itemCampaign->AddChild();
 
-            itemWorld->text = Pars >> "CfgWorlds" >> name >> "description";
+            itemWorld->text =
+                Poseidon::DecodeLegacyTextToRString(Pars >> "CfgWorlds" >> name >> "description", GLanguage);
             itemWorld->data = name;
             bool wexp = stricmp(Glob.header.worldname, name) == 0;
             if (wexp && Glob.header.filename[0] == 0)
@@ -1601,7 +1604,8 @@ void DisplayCustomArcade::InsertGames()
 
                     CTreeItem* itemWorld = itemCampaign->AddChild();
 
-                    itemWorld->text = Pars >> "CfgWorlds" >> name >> "description";
+                    itemWorld->text =
+                        Poseidon::DecodeLegacyTextToRString(Pars >> "CfgWorlds" >> name >> "description", GLanguage);
                     itemWorld->data = name;
                     bool wexp = stricmp(Glob.header.worldname, name) == 0;
                     _finddata_t info;

--- a/engine/Poseidon/UI/DisplayUIMultiplayer.cpp
+++ b/engine/Poseidon/UI/DisplayUIMultiplayer.cpp
@@ -1,6 +1,8 @@
 #include <Poseidon/UI/Map/UIMap.hpp>
 using namespace Poseidon;
 #include <Poseidon/Core/Config/EngineConfig.hpp>
+#include <Poseidon/UI/Locale/Stringtable/CodepageTranscode.hpp>
+#include <Poseidon/UI/Locale/Stringtable/Stringtable.hpp>
 #include <Poseidon/Core/Config/UserConfig.hpp>
 #include <Poseidon/Core/resincl.hpp>
 #include <Poseidon/World/Terrain/Landscape.hpp>
@@ -2116,7 +2118,8 @@ Control* DisplayServer::OnCreateCtrl(int type, int idc, const ParamEntry& cls)
                     continue;
                 }
 
-                int index = lbox->AddString(Pars >> "CfgWorlds" >> name >> "description");
+                int index = lbox->AddString(
+                    Poseidon::DecodeLegacyTextToRString(Pars >> "CfgWorlds" >> name >> "description", GLanguage));
                 lbox->SetData(index, name);
                 if (stricmp(name, Glob.header.worldname) == 0)
                 {
@@ -2723,7 +2726,8 @@ Control* DisplayRemoteMissions::OnCreateCtrl(int type, int idc, const ParamEntry
                     continue;
                 }
 
-                int index = lbox->AddString(Pars >> "CfgWorlds" >> name >> "description");
+                int index = lbox->AddString(
+                    Poseidon::DecodeLegacyTextToRString(Pars >> "CfgWorlds" >> name >> "description", GLanguage));
                 lbox->SetData(index, name);
                 if (stricmp(name, Glob.header.worldname) == 0)
                 {

--- a/engine/Poseidon/UI/Locale/Stringtable/CodepageTranscode.cpp
+++ b/engine/Poseidon/UI/Locale/Stringtable/CodepageTranscode.cpp
@@ -347,6 +347,38 @@ static bool ContainsStrongCentralEuropeanWord(const std::string& text)
     return false;
 }
 
+static bool ContainsStrongWesternEuropeanWord(const std::string& text)
+{
+    // å/Å/æ/Æ have no equivalent codepoint in CP1250 or CP1251, so their presence
+    // overrides the preferred codepage. ø/Ø is deliberately excluded even though it
+    // shares that property: byte 0xF8 is CP1250's common ř, so treating it as Nordic
+    // evidence would misread genuine Czech text (IsLikelyCentralEuropeanMojibakeInCp1252
+    // already flags it as a mojibake risk for the same reason).
+    static constexpr const char* kStrongLetters[] = {
+        "\xC3\xA5", // å
+        "\xC3\x85", // Å
+        "\xC3\xA6", // æ
+        "\xC3\x86", // Æ
+    };
+
+    for (const char* letter : kStrongLetters)
+    {
+        size_t pos = text.find(letter);
+        while (pos != std::string::npos)
+        {
+            const bool leftAscii = pos > 0 && IsAsciiAlpha(static_cast<unsigned char>(text[pos - 1]));
+            const size_t after = pos + std::strlen(letter);
+            const bool rightAscii = after < text.size() && IsAsciiAlpha(static_cast<unsigned char>(text[after]));
+            if (leftAscii || rightAscii)
+            {
+                return true;
+            }
+            pos = text.find(letter, pos + 1);
+        }
+    }
+    return false;
+}
+
 static int CountUtf8CodepointsInRange(const std::string& text, uint32_t first, uint32_t last)
 {
     int count = 0;
@@ -581,6 +613,13 @@ Codepage SelectLegacyTextCodepage(const std::string& input, Codepage preferredCp
             if (IsCyrillicDominant(candidate.decoded) && ContainsCyrillicMojibake(cp1252))
             {
                 candidate.score -= 220;
+            }
+        }
+        else if (candidate.cp == Codepage::CP1252)
+        {
+            if (ContainsStrongWesternEuropeanWord(candidate.decoded))
+            {
+                candidate.score -= 180;
             }
         }
     }

--- a/engine/Poseidon/UI/Map/UIArcadeWaypoint.cpp
+++ b/engine/Poseidon/UI/Map/UIArcadeWaypoint.cpp
@@ -3,6 +3,8 @@
 
 #include <Poseidon/Core/resincl.hpp>
 #include <Poseidon/UI/Locale/StringtableExt.hpp>
+#include <Poseidon/UI/Locale/Stringtable/CodepageTranscode.hpp>
+#include <Poseidon/UI/Locale/Stringtable/Stringtable.hpp>
 #include <Poseidon/Game/Mission/MissionPathLoader.hpp>
 #include <Poseidon/IO/Streams/QBStream.hpp>
 
@@ -501,7 +503,8 @@ Control* DisplayTemplateLoad::OnCreateCtrl(int type, int idc, const ParamEntry& 
                 continue;
             }
 
-            int index = combo->AddString(Pars >> "CfgWorlds" >> name >> "description");
+            int index = combo->AddString(
+                Poseidon::DecodeLegacyTextToRString(Pars >> "CfgWorlds" >> name >> "description", GLanguage));
             combo->SetData(index, name);
 
             if (stricmp(name, Glob.header.worldname) == 0)

--- a/engine/Poseidon/UI/Map/UIMap.cpp
+++ b/engine/Poseidon/UI/Map/UIMap.cpp
@@ -3,6 +3,8 @@
 #include <Poseidon/Core/Config/EngineConfig.hpp>
 #include <Poseidon/Core/Config/UserConfig.hpp>
 #include <Poseidon/UI/Map/UIMap.hpp>
+#include <Poseidon/UI/Locale/Stringtable/CodepageTranscode.hpp>
+#include <Poseidon/UI/Locale/Stringtable/Stringtable.hpp>
 // #include "win.h"
 #include <SDL3/SDL_scancode.h>
 #include <Poseidon/World/Entities/Infantry/Person.hpp>
@@ -1176,7 +1178,7 @@ void CStaticMap::DrawName(const ParamEntry& cls)
     float size = _sizeNames * (_invScaleX * 0.05);
     saturate(size, 0.5 * _fontNames->Height(), 2.0 * _fontNames->Height());
 
-    RString text = cls >> "name";
+    RString text = Poseidon::DecodeLegacyTextToRString(cls >> "name", GLanguage);
     float h = size;
     float w = GEngine->GetTextWidth(size, _fontNames, text);
 

--- a/tests/fixtures/mods-nordicnames/@nordicnames/bin/config.cpp
+++ b/tests/fixtures/mods-nordicnames/@nordicnames/bin/config.cpp
@@ -1,0 +1,29 @@
+// Fixture for editor_select_island_nordic_chars.test.sqf. NordicTest has no base
+// class: CfgWorlds/CfgWorldList are add-only (access=1), but the stock worlds are
+// access=3 (fully locked) and inheriting from one here breaks the overlay's
+// standalone parse. worldName points at the Demo package's own terrain so no .wrp
+// is needed. description is a real on-disk CP1252 byte for "Malmö" (0xF6) -- the
+// config parser has no \xNN escape, so this must be a raw byte, not a UTF-8
+// encoding of it (same approach as tests/fixtures/mods-configmerge).
+class CfgPatches
+{
+    class NordicNames
+    {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = 0.1;
+    };
+};
+class CfgWorldList
+{
+    class NordicTest {};
+};
+class CfgWorlds
+{
+    class NordicTest
+    {
+        worldName = "\demo\demo.wrp";
+        icon = "_abel.paa";
+        description = "Malmö";
+    };
+};

--- a/tests/integration/ui/editor/editor_select_island_nordic_chars.test.sqf
+++ b/tests/integration/ui/editor/editor_select_island_nordic_chars.test.sqf
@@ -1,0 +1,26 @@
+// Regression: å/ä/ö (legacy CP1252 bytes in a CfgWorlds `description`) don't show
+// in the editor's "Select Island" world list. DisplayUI.cpp's IDC_SELECT_ISLAND
+// handler passes the description straight to C3DListBox::AddString, which stores
+// it raw; CStatic::SetText decodes through Poseidon::DecodeLegacyTextToRString
+// first (UIControls.cpp's DecodeControlText), but AddString never goes through
+// that path, so the raw CP1252 byte is invalid UTF-8 and the glyph drops.
+//
+// The @nordicnames fixture mod adds a world whose description is a real on-disk
+// CP1252 byte for "Malmö" (0xF6 for ö).
+//
+// Teeth: without the fix, the invalid-UTF-8 byte reaching the row text breaks
+// the tri harness's own wire protocol when it reports the mismatch back -- the
+// connection drops with "broken pipe" instead of a clean assertion failure, but
+// it's still a deterministic failure on the current broken state.
+
+triSetLanguage "English"
+triAssertEq [(triDisplay), 0]
+triClick 115
+triAssertEq [(triDisplay), 51]
+
+// IDC_SELECT_ISLAND = 101 (the world listbox on the "Select Island" dialog).
+triAssertListText [101, "Malmö"]
+
+triClick 2
+triAssertEq [(triDisplay), 0]
+triEndTest

--- a/tests/integration/ui/editor/editor_select_island_nordic_chars.test.toml
+++ b/tests/integration/ui/editor/editor_select_island_nordic_chars.test.toml
@@ -1,0 +1,6 @@
+# Boots with the fixture mod @nordicnames mounted on the mod path (--mod), adding
+# a world with a raw-CP1252-byte "Malmö" description. --mods-dir lets the relative
+# --mod name resolve; game CWD under tri is the data dir (packages/Demo). Its own
+# isolated fixtures dir so the scan-based mods_* tests aren't contaminated.
+extra_args = ["--mods-dir", "../../tests/fixtures/mods-nordicnames", "--mod", "@nordicnames"]
+tags = ["headless", "full_game"]

--- a/tests/unit/engine/Poseidon/UI/Locale/Stringtable/test_codepage_transcode.cpp
+++ b/tests/unit/engine/Poseidon/UI/Locale/Stringtable/test_codepage_transcode.cpp
@@ -20,6 +20,11 @@ TEST_CASE("CodepageForLanguage - Western European -> CP1252", "[codepage][mappin
     REQUIRE(CodepageForLanguage("Spanish") == Codepage::CP1252);
     REQUIRE(CodepageForLanguage("Dutch") == Codepage::CP1252);
     REQUIRE(CodepageForLanguage("Portuguese") == Codepage::CP1252);
+    REQUIRE(CodepageForLanguage("Danish") == Codepage::CP1252);
+    REQUIRE(CodepageForLanguage("Swedish") == Codepage::CP1252);
+    REQUIRE(CodepageForLanguage("Norwegian") == Codepage::CP1252);
+    REQUIRE(CodepageForLanguage("Finnish") == Codepage::CP1252);
+    REQUIRE(CodepageForLanguage("Icelandic") == Codepage::CP1252);
 }
 
 TEST_CASE("CodepageForLanguage - Central European -> CP1250", "[codepage][mapping]")
@@ -284,6 +289,24 @@ TEST_CASE("DecodeLegacyTextToUtf8 - all supported language preferences repair Ce
     }
 }
 
+TEST_CASE("DecodeLegacyTextToUtf8 - all supported language preferences repair Nordic mod names",
+          "[codepage][legacy][detect]")
+{
+    // A raw CfgWorlds description has no stringtable column to fall back on, so
+    // without å/æ evidence this would follow whichever codepage the active game
+    // language prefers -- misdecoding Swedish "Skärgården" as Czech under a
+    // Czech/Polish/Russian UI language (CP1250 byte 0xE5 is ĺ, not å).
+    const char* languages[] = {"English", "French", "Italian", "Spanish", "German", "Czech", "Polish", "Russian"};
+    const std::string cp1252 = "Sk\xE4rg\xE5rden"; // Skärgården (Swedish: "the archipelago")
+    const std::string expected = "Sk\xC3\xA4rg\xC3\xA5rden";
+
+    for (const char* language : languages)
+    {
+        REQUIRE(SelectLegacyTextCodepage(cp1252, CodepageForLanguage(language)) == Codepage::CP1252);
+        REQUIRE(DecodeLegacyTextToUtf8(cp1252, CodepageForLanguage(language)) == expected);
+    }
+}
+
 TEST_CASE("DecodeLegacyTextToUtf8 - all supported language preferences repair Cyrillic mod text",
           "[codepage][legacy][detect]")
 {
@@ -381,6 +404,18 @@ TEST_CASE("DecodeLegacyTextToRString - repairs Western European place names in s
 {
     const RString decoded = DecodeLegacyTextToRString("Warnem\xFCnde", Codepage::CP1250);
     REQUIRE(std::string(decoded.Data()) == "Warnem\xC3\xBCnde");
+}
+
+// Real CfgWorlds `description` values pulled from long-published OFP community island
+// mods (Emsalo Lite by Instructor, Krono by Hornet85, Varmdolandet by Hornet85 -- see
+// https://ofp-faguss.com/islands), confirming actual legacy addon content -- not just
+// hand-built fixtures -- decodes correctly.
+TEST_CASE("DecodeLegacyTextToRString - repairs real-world island mod descriptions", "[codepage][decode][rstring]")
+{
+    REQUIRE(std::string(DecodeLegacyTextToRString("Emsal\xF6 Lite", Codepage::CP1252).Data()) == "Emsal\xC3\xB6 Lite");
+    REQUIRE(std::string(DecodeLegacyTextToRString("Kron\xF6", Codepage::CP1252).Data()) == "Kron\xC3\xB6");
+    REQUIRE(std::string(DecodeLegacyTextToRString("V\xE4rmd\xF6landet", Codepage::CP1252).Data()) ==
+            "V\xC3\xA4rmd\xC3\xB6landet");
 }
 
 TEST_CASE("TranscodeToUtf8 - Undefined codepage slot becomes U+FFFD", "[codepage][undefined]")


### PR DESCRIPTION
CfgWorlds descriptions and map location names are CP1252-encoded, but the Select Island listbox, mission tree, MP island lists, waypoint combo, and map labels all skipped Poseidon::DecodeLegacyTextToRString, so accented letters broke as invalid UTF-8. Also added the missing codepage-detection evidence for å/Å/æ/Æ, so this stays correct regardless of the active UI language, and broadened the regression tests with real island-mod names.

<img width="678" height="771" alt="image" src="https://github.com/user-attachments/assets/4f86dcd4-ff8b-4936-824b-7df9cce08ca5" />

<img width="433" height="428" alt="image" src="https://github.com/user-attachments/assets/044a9a66-bdcd-4b08-addf-95c5588e9691" />

cc @Dahlgren