### PR TITLE
Warn about old MSVC runtimes

### DIFF
--- a/apps/cwr/Game/WinMain.cpp
+++ b/apps/cwr/Game/WinMain.cpp
@@ -5,10 +5,12 @@
 #include "GameApplication.hpp"
 #include <Poseidon/Core/ProgressSystem.hpp> // Needed for complete type in Application
 #include <Poseidon/Foundation/Common/ConsoleUtils.hpp>
+#include <Poseidon/Foundation/Platform/CppRuntimeWarning.hpp>
 #include <Poseidon/Foundation/Platform/CrashHandler.hpp>
 
 int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw)
 {
+    Poseidon::Foundation::WarnIfCppRuntimeIsOlder();
     Poseidon::Foundation::InstallCrashHandler(nullptr);
     if (!strstr(szCmdLine, "--check"))
         Poseidon::Foundation::attachParentConsole();

--- a/apps/cwr/GameDemo/WinMain.cpp
+++ b/apps/cwr/GameDemo/WinMain.cpp
@@ -6,10 +6,12 @@
 #include "GameDemoApplication.hpp"
 #include <Poseidon/Core/ProgressSystem.hpp>
 #include <Poseidon/Foundation/Common/ConsoleUtils.hpp>
+#include <Poseidon/Foundation/Platform/CppRuntimeWarning.hpp>
 #include <Poseidon/Foundation/Platform/CrashHandler.hpp>
 
 int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw)
 {
+    Poseidon::Foundation::WarnIfCppRuntimeIsOlder();
     Poseidon::Foundation::InstallCrashHandler(nullptr);
     if (!strstr(szCmdLine, "--check"))
         Poseidon::Foundation::attachParentConsole();

--- a/engine/Poseidon/Foundation/Platform/CppRuntimeWarning.cpp
+++ b/engine/Poseidon/Foundation/Platform/CppRuntimeWarning.cpp
@@ -1,0 +1,71 @@
+#include "CppRuntimeWarning.hpp"
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+namespace
+{
+constexpr Poseidon::Foundation::CppRuntimeVersion RequiredCppRuntimeVersion()
+{
+    return {14, static_cast<std::uint16_t>(_MSC_VER % 100)};
+}
+} // namespace
+
+void Poseidon::Foundation::WarnIfCppRuntimeIsOlder()
+{
+    const HMODULE runtime = GetModuleHandleW(L"msvcp140.dll");
+    if (!runtime)
+        return;
+
+    wchar_t path[MAX_PATH];
+    if (GetModuleFileNameW(runtime, path, MAX_PATH) == 0)
+        return;
+
+    DWORD unused = 0;
+    const DWORD infoSize = GetFileVersionInfoSizeW(path, &unused);
+    if (infoSize == 0)
+        return;
+
+    const HANDLE heap = GetProcessHeap();
+    void* const info = HeapAlloc(heap, 0, infoSize);
+    if (!info)
+        return;
+
+    VS_FIXEDFILEINFO* versionInfo = nullptr;
+    UINT versionInfoSize = 0;
+    const bool found = GetFileVersionInfoW(path, 0, infoSize, info) &&
+                       VerQueryValueW(info, L"\\", reinterpret_cast<void**>(&versionInfo), &versionInfoSize) &&
+                       versionInfoSize >= sizeof(VS_FIXEDFILEINFO) && versionInfo->dwSignature == VS_FFI_SIGNATURE;
+
+    if (found)
+    {
+        const CppRuntimeVersion installed = {
+            HIWORD(versionInfo->dwFileVersionMS),
+            LOWORD(versionInfo->dwFileVersionMS),
+        };
+        constexpr CppRuntimeVersion required = RequiredCppRuntimeVersion();
+        if (IsCppRuntimeOlder(installed, required))
+        {
+            wchar_t message[512];
+            wsprintfW(message,
+                      L"An older Microsoft Visual C++ runtime was detected.\n\n"
+                      L"Detected: %u.%u.%u\n"
+                      L"Minimum: %u.%u\n\n"
+                      L"Please install a newer runtime from https://aka.ms/vcruntime\n\n"
+                      L"The game could crash or fail to start with the installed runtime.",
+                      installed.major, installed.minor, HIWORD(versionInfo->dwFileVersionLS), required.major,
+                      required.minor);
+            MessageBoxW(nullptr, message, L"Arma: Cold War Assault - Remastered",
+                        MB_OK | MB_ICONWARNING | MB_SETFOREGROUND);
+        }
+    }
+
+    HeapFree(heap, 0, info);
+}
+
+#else
+
+void Poseidon::Foundation::WarnIfCppRuntimeIsOlder() {}
+
+#endif

--- a/engine/Poseidon/Foundation/Platform/CppRuntimeWarning.hpp
+++ b/engine/Poseidon/Foundation/Platform/CppRuntimeWarning.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Poseidon::Foundation
+{
+struct CppRuntimeVersion
+{
+    std::uint16_t major;
+    std::uint16_t minor;
+};
+
+constexpr bool IsCppRuntimeOlder(CppRuntimeVersion installed, CppRuntimeVersion required)
+{
+    if (installed.major != required.major)
+        return installed.major < required.major;
+    return installed.minor < required.minor;
+}
+
+void WarnIfCppRuntimeIsOlder();
+} // namespace Poseidon::Foundation

--- a/tests/unit/engine/Poseidon/Foundation/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/Foundation/CMakeLists.txt
@@ -26,6 +26,7 @@ set(POSEIDON_BASE_TEST_SOURCES
     Common/test_mathND.cpp
     Common/test_platform.cpp
     Common/test_platformPaths.cpp
+    Platform/test_cpp_runtime_warning.cpp
     Platform/test_crash_handler.cpp
     Platform/test_launch_diagnostics.cpp
     Containers/test_cachelist.cpp

--- a/tests/unit/engine/Poseidon/Foundation/Platform/test_cpp_runtime_warning.cpp
+++ b/tests/unit/engine/Poseidon/Foundation/Platform/test_cpp_runtime_warning.cpp
@@ -1,0 +1,17 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <Poseidon/Foundation/Platform/CppRuntimeWarning.hpp>
+
+using Poseidon::Foundation::CppRuntimeVersion;
+using Poseidon::Foundation::IsCppRuntimeOlder;
+
+TEST_CASE("C++ runtime version check rejects an older redistributable", "[platform][runtime]")
+{
+    constexpr CppRuntimeVersion required{14, 44};
+
+    REQUIRE(IsCppRuntimeOlder({14, 27}, required));
+    REQUIRE(IsCppRuntimeOlder({14, 43}, required));
+    REQUIRE(IsCppRuntimeOlder({13, 99}, required));
+    REQUIRE_FALSE(IsCppRuntimeOlder(required, required));
+    REQUIRE_FALSE(IsCppRuntimeOlder({14, 51}, required));
+}


### PR DESCRIPTION
Some users had old MSVC C++ runtime installed (even Steam installs the proper version). Read the loaded msvcp140.dll before normal client startup and show a native warning when its v14 release band is older than the clang-cl target. App continue after acknowledgement. That way user is warned about potential issues.