### PR TITLE
Arm text input/IME only while a real text field has focus

### DIFF
--- a/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
@@ -160,6 +160,7 @@ GameValue TriSetRenderScale(const GameState*, GameValuePar);
 GameValue TriSetMsaa(const GameState*, GameValuePar);
 GameValue TriPerfStats(const GameState*, GameValuePar);
 GameValue TriSetVsync(const GameState*, GameValuePar);
+GameValue TriTextInputActive(const GameState*);
 GameValue TriPerfDumpShapes(const GameState*, GameValuePar);
 GameValue TriPerfReset(const GameState*, GameValuePar);
 GameValue TriShadowSetDarkness(const GameState*, GameValuePar);
@@ -2862,6 +2863,7 @@ INIT_MODULE(GameStateExtTest, 3)
     GGameState.NewFunction(GameFunction(GameString, "triCheatMapTeleport", TriCheatMapTeleport, GameBool));
     GGameState.NewNularOp(GameNular(GameScalar, "triViewDistance", TriViewDistance));
     GGameState.NewNularOp(GameNular(GameScalar, "triFps", TriFps));
+    GGameState.NewNularOp(GameNular(GameScalar, "triTextInputActive", TriTextInputActive));
     GGameState.NewNularOp(GameNular(GameScalar, "triMemoryMB", TriMemoryMB));
     GGameState.NewFunction(GameFunction(GameString, "triConsoleRun", TriConsoleRun, GameString));
     GGameState.NewFunction(

--- a/engine/Poseidon/Game/Commands/GameStateExtTestRender.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestRender.cpp
@@ -404,6 +404,12 @@ GameValue TriSetVsync(const GameState* /*state*/, GameValuePar arg)
     LOG_INFO(Core, "[tri] triSetVsync {}", v);
     return GameValue("OK");
 }
+/// triTextInputActive - whether SDL's text-input/IME session is currently armed.
+GameValue TriTextInputActive(const GameState* /*state*/)
+{
+    return GameValue((GEngine && GEngine->IsTextInputActive()) ? 1.0f : 0.0f);
+}
+
 /// triPerfStats — frame-phase profiler rolling stats as a machine-readable
 /// string: "fps=F frame=avg/p95/max setup=avg/p95 draw=... calls=N frames=N".
 GameValue TriPerfStats(const GameState* /*state*/, GameValuePar /*arg*/)

--- a/engine/Poseidon/Graphics/IGraphicsEngine.hpp
+++ b/engine/Poseidon/Graphics/IGraphicsEngine.hpp
@@ -79,6 +79,10 @@ class IGraphicsEngine
     virtual bool SetSwapInterval(int /*interval*/) { return false; }
     virtual int GetSwapInterval() const { return 1; }
 
+    virtual void StartTextInput() {}
+    virtual void StopTextInput() {}
+    virtual bool IsTextInputActive() const { return false; }
+
     virtual void SetGamma(float g) = 0;
     virtual float GetGamma() const = 0;
 

--- a/engine/Poseidon/UI/Controls/UIControlsBase.hpp
+++ b/engine/Poseidon/UI/Controls/UIControlsBase.hpp
@@ -79,6 +79,7 @@ public:
 	virtual bool OnSetFocus(bool up = true, bool def = false);	// return false if focus cannot not be gained
 
 	virtual bool OnKillFocus();	// return false if focus cannot be killed
+	virtual bool WantsTextInput() const {return false;}	// true for real text-entry controls (CEdit/C3DEdit)
 	virtual bool CanBeDefault() const {return false;}
 	bool IsDefault() {return _default;}
 	void SetDefault() {_default = true;}

--- a/engine/Poseidon/UI/Controls/UIControlsWidgets.hpp
+++ b/engine/Poseidon/UI/Controls/UIControlsWidgets.hpp
@@ -80,6 +80,7 @@ public:
 	void OnLButtonDown(float x, float y) override;
 	void OnLButtonUp(float x, float y) override;
 	void OnMouseMove(float x, float y, bool active = true) override;
+	bool WantsTextInput() const override {return true;}
 
 protected:
 	bool IsMulti() const override;
@@ -877,6 +878,7 @@ public:
 	void OnLButtonDown(float x, float y) override;
 	void OnLButtonUp(float x, float y) override;
 	void OnMouseMove(float x, float y, bool active = true) override;
+	bool WantsTextInput() const override {return true;}
 
 protected:
 	bool IsMulti() const override;

--- a/engine/Poseidon/UI/Map/UIContainers.cpp
+++ b/engine/Poseidon/UI/Map/UIContainers.cpp
@@ -1433,6 +1433,13 @@ bool ControlsContainer::SetFocus(ControlId& id, bool up, bool def)
         ctrl->OnSetFocus(up, def);
     }
     _indexFocused = id;
+    if (GEngine)
+    {
+        if (ctrl && ctrl->WantsTextInput())
+            GEngine->StartTextInput();
+        else
+            GEngine->StopTextInput();
+    }
     return true;
 }
 

--- a/engine/PoseidonGL33/EngineGL33.hpp
+++ b/engine/PoseidonGL33/EngineGL33.hpp
@@ -607,6 +607,9 @@ class EngineGL33 : public Engine
     bool GetRequestedFullscreenMode(int& w, int& h, int& refresh) const override;
     bool SetSwapInterval(int interval) override;
     int GetSwapInterval() const override;
+    void StartTextInput() override;
+    void StopTextInput() override;
+    bool IsTextInputActive() const override;
 
     void DestroySurfaces();
 

--- a/engine/PoseidonGL33/EngineGL33_Lifecycle.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Lifecycle.cpp
@@ -650,6 +650,23 @@ int EngineGL33::GetSwapInterval() const
     return v;
 }
 
+void EngineGL33::StartTextInput()
+{
+    if (_sdlWindow)
+        SDL_StartTextInput(_sdlWindow);
+}
+
+void EngineGL33::StopTextInput()
+{
+    if (_sdlWindow)
+        SDL_StopTextInput(_sdlWindow);
+}
+
+bool EngineGL33::IsTextInputActive() const
+{
+    return _sdlWindow && SDL_TextInputActive(_sdlWindow);
+}
+
 bool EngineGL33::SetWindowMode(WindowMode mode)
 {
     if (!_sdlWindow)

--- a/engine/PoseidonGL33/SDLEventWindow.hpp
+++ b/engine/PoseidonGL33/SDLEventWindow.hpp
@@ -46,7 +46,8 @@ class SDLEventWindow
         {
             if (_mouseGrab)
                 SDL_SetWindowRelativeMouseMode(_sdlWindow, true);
-            SDL_StartTextInput(_sdlWindow);
+            // Baseline off; ControlsContainer::SetFocus arms it per focused control.
+            SDL_StopTextInput(_sdlWindow);
         }
 
         extern void SetMouseAcquired(bool acquired);

--- a/tests/integration/ui/main_menu/text_input_not_armed_without_focus.test.sqf
+++ b/tests/integration/ui/main_menu/text_input_not_armed_without_focus.test.sqf
@@ -1,0 +1,9 @@
+// ControlsContainer::SetFocus arms text input/IME per focused control;
+// nothing has focus at the main menu, so this must read inactive.
+
+triSetLanguage "English"
+triAssertEq [(triDisplay), 0]
+triSimFrames 30
+
+triAssertEq [(triTextInputActive), 0];
+triEndTest

--- a/tests/integration/ui/main_menu/text_input_not_armed_without_focus.test.toml
+++ b/tests/integration/ui/main_menu/text_input_not_armed_without_focus.test.toml
@@ -1,0 +1,3 @@
+binary = "PoseidonGame"
+timeout = 60
+tags = ["headless"]


### PR DESCRIPTION
SDLEventWindow::Attach() called SDL_StartTextInput() once, unconditionally, with no matching SDL_StopTextInput anywhere, so SDL's text-input mode stayed armed for the whole session. Per SDL3's docs that can show an unwanted IME popup and swallow key events on some platforms (and pop a software keyboard on platforms that have one), even outside any text field.

Added IControl::WantsTextInput() (true only for CEdit/C3DEdit) and toggle SDL_StartTextInput/StopTextInput from ControlsContainer::SetFocus based on the newly focused control.

Without the fix, triTextInputActive reads 1 at the main menu, where nothing has focus; with it, 0.

reported by @Dahlgren 