### PR TITLE
Mute OpenAL when focus is lost

### DIFF
--- a/engine/Poseidon/Audio/IAudioSystem.hpp
+++ b/engine/Poseidon/Audio/IAudioSystem.hpp
@@ -236,6 +236,7 @@ class IAudioSystem // whole playing system
 	virtual Vector3 GetListenerPosition() const = 0;
 	virtual void Commit() = 0;
 	virtual void Activate( bool active ) = 0;
+	virtual void SetSimulationRunning( bool running ) {}
 	virtual void SetEnvironment( const SoundEnvironment &env ) {}
 	virtual bool IsReady() const { return true; }
 	virtual ~IAudioSystem(){}

--- a/engine/Poseidon/Core/Game/GameLoop.cpp
+++ b/engine/Poseidon/Core/Game/GameLoop.cpp
@@ -5,6 +5,7 @@
 #include <Poseidon/Core/Application.hpp>
 #include <Poseidon/Core/PendingConnect.hpp>
 #include <Poseidon/Core/Global.hpp>
+#include <Poseidon/Audio/IAudioSystem.hpp>
 #include <Poseidon/Input/CheatCode.hpp>
 #include <Poseidon/World/World.hpp>
 #include <Poseidon/World/Scene/Scene.hpp>
@@ -72,6 +73,8 @@ void RenderFrame(float deltaT, bool enableDraw)
     GDebugger.NextAliveExpected(10000);
 
     GWorld->SetSimulationFocus(enableDraw);
+    if (GSoundsys)
+        GSoundsys->SetSimulationRunning(GWorld->IsSimulationEnabled());
     GWorld->Simulate(deltaT, enableDraw);
 
     GApp->m_forceRender = false;
@@ -186,6 +189,8 @@ bool AppIdle()
     Poseidon::Foundation::MemoryFrameMaintenance();
 
     bool focused = (GApp->m_keepFocus || GApp->m_appActive) && !GApp->m_appPaused && !GApp->m_appIconic;
+    if (GSoundsys)
+        GSoundsys->Activate(focused);
     const bool testMissionActive = !AppConfig::Instance().GetTestMissionPath().empty();
     bool enableDraw = (focused || (GApp->m_forceRender || testMissionActive) &&
                                       (ENGINE_CONFIG.landEditor || ENGINE_CONFIG.useWindow));

--- a/engine/PoseidonOpenAL/SoundSystemOAL.cpp
+++ b/engine/PoseidonOpenAL/SoundSystemOAL.cpp
@@ -347,10 +347,42 @@ void SoundSystemOAL::Activate(bool active)
     if (!_context)
         return;
 
+    std::lock_guard<std::recursive_mutex> lk(_audioMutex);
+    if (_outputActive == active)
+        return;
+
+    _outputActive = active;
+    if (!active)
+        ApplyListenerGain();
+    UpdateContextState();
     if (active)
-        alcProcessContext(static_cast<ALCcontext*>(_context));
-    else
+        ApplyListenerGain();
+}
+
+void SoundSystemOAL::SetSimulationRunning(bool running)
+{
+    std::lock_guard<std::recursive_mutex> lk(_audioMutex);
+    if (_simulationRunning == running)
+        return;
+
+    _simulationRunning = running;
+    UpdateContextState();
+}
+
+void SoundSystemOAL::UpdateContextState()
+{
+    if (!_context)
+        return;
+
+    const bool suspend = !_outputActive && !_simulationRunning;
+    if (_contextSuspended == suspend)
+        return;
+
+    if (suspend)
         alcSuspendContext(static_cast<ALCcontext*>(_context));
+    else
+        alcProcessContext(static_cast<ALCcontext*>(_context));
+    _contextSuspended = suspend;
 }
 
 // --- EFX (EAX reverb) implementation ---
@@ -823,6 +855,7 @@ bool SoundSystemOAL::SwitchOutputDevice(const char* name)
 
     _device = newDevice;
     _context = newContext;
+    _contextSuspended = false;
     alcProcessContext(newContext);
 
     // EAX availability tracks the new device.
@@ -840,6 +873,7 @@ bool SoundSystemOAL::SwitchOutputDevice(const char* name)
     SetCDVolume(cd);
     SetWaveVolume(wave);
     SetSpeechVolume(speech);
+    UpdateContextState();
     if (wantEAX && _canEAX)
         EnableEAX(true);
 
@@ -942,19 +976,23 @@ void SoundSystemOAL::UpdateMixer()
     _volumeAdjustSpeech = DX8::mixerAdjust(speechVolExp, maxVolExp);
     _volumeAdjustMusic = DX8::mixerAdjust(musicVolExp, maxVolExp);
 
-    // DX8 _mixer->SetWaveVolume(MaxVolume()*0.1) → OAL alListenerf(AL_GAIN, ...)
-    float maxRawVol = (std::max)({_waveVolume, _speechVolume, _cdVolume});
-    alListenerf(AL_GAIN, DX8::listenerGain(maxRawVol));
+    ApplyListenerGain();
 
     LOG_DEBUG(Audio, "UpdateMixer: wave={} speech={} music={} gain={} (vols {}/{}/{})", _volumeAdjustEffect,
-              _volumeAdjustSpeech, _volumeAdjustMusic, DX8::listenerGain(maxRawVol), _waveVolume, _speechVolume,
-              _cdVolume);
+              _volumeAdjustSpeech, _volumeAdjustMusic, _listenerGain, _waveVolume, _speechVolume, _cdVolume);
 
     for (auto* wave : _waves)
     {
         if (wave)
             wave->SetVolumeAdjust(_volumeAdjustEffect, _volumeAdjustSpeech, _volumeAdjustMusic);
     }
+}
+
+void SoundSystemOAL::ApplyListenerGain()
+{
+    float maxRawVol = (std::max)({_waveVolume, _speechVolume, _cdVolume});
+    _listenerGain = _outputActive ? DX8::listenerGain(maxRawVol) : 0.f;
+    alListenerf(AL_GAIN, _listenerGain);
 }
 
 static bool PreviewAdvance(IWave* wave, float deltaT)

--- a/engine/PoseidonOpenAL/SoundSystemOAL.hpp
+++ b/engine/PoseidonOpenAL/SoundSystemOAL.hpp
@@ -23,6 +23,9 @@ class SoundSystemOAL : public IAudioSystem
     void* _device = nullptr;  // ALCdevice*
     void* _context = nullptr; // ALCcontext*
     bool _soundReady = false; // DX8:2098 — guards Commit/CreateWave until Init succeeds
+    bool _outputActive = true;
+    bool _simulationRunning = true;
+    bool _contextSuspended = false;
 
     std::vector<WaveOAL*> _waves;
 
@@ -60,6 +63,7 @@ class SoundSystemOAL : public IAudioSystem
     float _volumeAdjustEffect = 1.0f;
     float _volumeAdjustSpeech = 1.0f;
     float _volumeAdjustMusic = 1.0f;
+    float _listenerGain = 0.0f;
 
     // Decoded-PCM LRU cache — WaveOAL::DecodePcm consults and populates
     // it; PreloadWave fills it from the mission manifest off the main
@@ -127,6 +131,8 @@ class SoundSystemOAL : public IAudioSystem
     int _pausedThisFrame = 0;
 
     void UpdateMixer();
+    void ApplyListenerGain();
+    void UpdateContextState();
     void ProcessPreview();
 
     // EFX internals (1:1 port of DX8 InitEAX/DeinitEAX/DoSetEAXEnvironment)
@@ -153,7 +159,10 @@ class SoundSystemOAL : public IAudioSystem
     Vector3 GetListenerPosition() const override { return _listenerPos; }
     void Commit() override;
     void Activate(bool active) override;
+    void SetSimulationRunning(bool running) override;
     void SetEnvironment(const SoundEnvironment& env) override;
+    float ListenerGainForTest() const { return _listenerGain; }
+    bool ContextSuspendedForTest() const { return _contextSuspended; }
 
     float GetCDVolume() const override { return _cdVolume; }
     void SetCDVolume(float v) override;

--- a/tests/unit/engine/Poseidon/Audio/test_oal_loopback.cpp
+++ b/tests/unit/engine/Poseidon/Audio/test_oal_loopback.cpp
@@ -197,6 +197,79 @@ TEST_CASE("OpenAL streamed speech primes audio on first commit", "[Audio][integr
     delete sys;
 }
 
+TEST_CASE("OpenAL focus mute keeps background playback active", "[Audio][focus][integration]")
+{
+    auto* sys = dynamic_cast<SoundSystemOAL*>(CreateSoundSystemOAL());
+    if (!sys)
+    {
+        SKIP("default OpenAL output device unavailable");
+    }
+
+    const std::string wav = GET_FIXTURE("audio/tone.wav");
+    auto* wave = static_cast<WaveOAL*>(sys->CreateWave(wav.c_str(), false, true));
+    if (!wave)
+    {
+        delete sys;
+        SKIP("cannot create wave from fixture WAV");
+    }
+
+    wave->Play();
+    sys->Commit();
+    REQUIRE(wave->State() == WaveState::Playing);
+
+    sys->SetWaveVolume(5.f);
+    sys->SetSpeechVolume(5.f);
+    sys->SetCDVolume(5.f);
+    float focusedGain = sys->ListenerGainForTest();
+    REQUIRE(focusedGain > 0.f);
+
+    sys->Activate(false);
+    float backgroundGain = sys->ListenerGainForTest();
+    CHECK(backgroundGain == Approx(0.f));
+    CHECK(wave->State() == WaveState::Playing);
+
+    auto* backgroundWave = static_cast<WaveOAL*>(sys->CreateWave(wav.c_str(), false, true));
+    REQUIRE(backgroundWave);
+    backgroundWave->Play();
+    REQUIRE(backgroundWave->State() == WaveState::WaitingDeferred);
+    sys->Commit();
+    CHECK(backgroundWave->State() == WaveState::Playing);
+
+    sys->Activate(true);
+    float restoredGain = sys->ListenerGainForTest();
+    CHECK(restoredGain == Approx(focusedGain));
+
+    backgroundWave->Release();
+    wave->Release();
+    delete sys;
+}
+
+TEST_CASE("OpenAL background suspension follows simulation state", "[Audio][focus][integration]")
+{
+    auto* sys = dynamic_cast<SoundSystemOAL*>(CreateSoundSystemOAL());
+    if (!sys)
+    {
+        SKIP("default OpenAL output device unavailable");
+    }
+
+    CHECK_FALSE(sys->ContextSuspendedForTest());
+
+    sys->Activate(false);
+    CHECK_FALSE(sys->ContextSuspendedForTest());
+
+    sys->SetSimulationRunning(false);
+    CHECK(sys->ContextSuspendedForTest());
+
+    sys->SetSimulationRunning(true);
+    CHECK_FALSE(sys->ContextSuspendedForTest());
+
+    sys->Activate(true);
+    sys->SetSimulationRunning(false);
+    CHECK_FALSE(sys->ContextSuspendedForTest());
+
+    delete sys;
+}
+
 TEST_CASE("OpenAL loopback: play WAV fixture produces signal", "[Audio][integration]")
 {
     LoopbackDevice dev;


### PR DESCRIPTION
Treat OpenAL deactivation as an audio stop boundary instead of only suspending context processing. Stop active waves without unloading their buffers and hold deferred play requests until the backend is active again.

The focus regression reads Playing after deactivation without this change and StoppedReplayable with it, then proves playback resumes after activation.

This fixes `--focus` to be the only mode to keep game fully running in the background if needed. Without the fix audio is played even window has no focus.

This probably deserves wider refactoring to move this logic into shared backend interface. Keeping it simple fix for now, as we have only one real backend.