### PR TITLE
Fix AppName containing a filesystem-illegal character

### DIFF
--- a/engine/Poseidon/Core/Application.cpp
+++ b/engine/Poseidon/Core/Application.cpp
@@ -13,8 +13,7 @@
 
 // Application name — default for all apps, can be overridden per-app before engine init.
 // Also used as a filesystem path component (PlayerPrefs' config directory), so it must
-// not contain characters reserved by a target filesystem: ':' is illegal in NTFS paths
-// outside a drive letter and silently breaks directory creation there.
+// not contain characters reserved by a target filesystem.
 const char* AppName = "CWR";
 
 namespace Poseidon

--- a/engine/Poseidon/Core/Application.cpp
+++ b/engine/Poseidon/Core/Application.cpp
@@ -11,8 +11,11 @@
 
 #endif
 
-// Application name — default for all apps, can be overridden per-app before engine init
-const char* AppName = "ARMA:CWA-RE-CE";
+// Application name — default for all apps, can be overridden per-app before engine init.
+// Also used as a filesystem path component (PlayerPrefs' config directory), so it must
+// not contain characters reserved by a target filesystem: ':' is illegal in NTFS paths
+// outside a drive letter and silently breaks directory creation there.
+const char* AppName = "CWR";
 
 namespace Poseidon
 {

--- a/engine/Poseidon/Foundation/Common/PlatformPaths_posix.cpp
+++ b/engine/Poseidon/Foundation/Common/PlatformPaths_posix.cpp
@@ -1,5 +1,8 @@
 #include <Poseidon/Foundation/Common/PlatformPaths.hpp>
+#include <Poseidon/Foundation/Framework/Log.hpp>
 #include <cstdlib>
+#include <cerrno>
+#include <cstring>
 #include <sys/stat.h>
 #include <string>
 #include <unistd.h>
@@ -19,7 +22,10 @@ void ensureDirectory(const std::string& path)
             mkdir(partial.c_str(), 0755);
         }
     }
-    mkdir(path.c_str(), 0755);
+    if (mkdir(path.c_str(), 0755) != 0 && errno != EEXIST)
+    {
+        LOG_ERROR(Core, "Failed to create user directory '{}': {}", path, std::strerror(errno));
+    }
 }
 
 std::string getXdgDir(const char* envVar, const char* defaultSuffix, const char* appName)

--- a/engine/Poseidon/Foundation/Common/PlatformPaths_win.cpp
+++ b/engine/Poseidon/Foundation/Common/PlatformPaths_win.cpp
@@ -1,4 +1,5 @@
 #include <Poseidon/Foundation/Common/PlatformPaths.hpp>
+#include <Poseidon/Foundation/Framework/Log.hpp>
 #include <Poseidon/IO/Filesystem/Utf8Paths.hpp>
 #include <ShlObj.h>
 
@@ -12,7 +13,10 @@ std::string getWindowsFolder(int csidl, const char* appName)
     {
         std::wstring dir = std::wstring(buf) + L"\\" + Poseidon::Utf8PathToWide(appName);
         std::string utf8 = Poseidon::WidePathToUtf8(dir.c_str());
-        Poseidon::CreateDirectoryUtf8(utf8.c_str());
+        if (!Poseidon::CreateDirectoryUtf8(utf8.c_str()))
+        {
+            LOG_ERROR(Core, "Failed to create user directory '{}'", utf8);
+        }
         return utf8;
     }
     return std::string(".\\") + appName;

--- a/engine/Poseidon/Foundation/Common/PlayerPrefs.cpp
+++ b/engine/Poseidon/Foundation/Common/PlayerPrefs.cpp
@@ -1,5 +1,6 @@
 #include <Poseidon/Foundation/Common/PlayerPrefs.hpp>
 #include <Poseidon/Foundation/Common/GamePaths.hpp>
+#include <Poseidon/Foundation/Framework/Log.hpp>
 #include <Poseidon/IO/Filesystem/Utf8Paths.hpp>
 #include <cstdlib>
 #include <fstream>
@@ -37,9 +38,13 @@ std::unordered_map<std::string, std::string> loadPrefs(const char* appName)
 
 void savePrefs(const char* appName, const std::unordered_map<std::string, std::string>& prefs)
 {
-    std::ofstream file(Poseidon::FilesystemPathFromUtf8(prefsFilePath(appName)));
+    const std::string path = prefsFilePath(appName);
+    std::ofstream file(Poseidon::FilesystemPathFromUtf8(path));
     if (!file.is_open())
+    {
+        LOG_ERROR(Core, "Failed to open prefs file for writing: '{}'", path);
         return;
+    }
 
     for (auto& [key, value] : prefs)
     {

--- a/tests/unit/engine/Poseidon/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/CMakeLists.txt
@@ -178,6 +178,7 @@ list(APPEND POSEIDON_TEST_SOURCES
     UI/Locale/test_supported_languages.cpp
     Core/test_engine_config.cpp
     Core/test_application_exit.cpp
+    Core/test_app_name_filesystem_safety.cpp
     Core/test_window_close.cpp
     Core/test_user_config.cpp
     Core/test_user_config_serialization.cpp

--- a/tests/unit/engine/Poseidon/Core/test_app_name_filesystem_safety.cpp
+++ b/tests/unit/engine/Poseidon/Core/test_app_name_filesystem_safety.cpp
@@ -1,0 +1,24 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <Poseidon/Core/Application.hpp>
+
+#include <string>
+
+TEST_CASE("AppName contains no characters reserved by common filesystems", "[core][application][filesystem]")
+{
+    const std::string name = AppName;
+    REQUIRE_FALSE(name.empty());
+
+    // Characters reserved in path components on supported filesystems.
+    static const std::string reserved = "<>:\"/\\|?*";
+
+    for (unsigned char c : name)
+    {
+        CAPTURE(c);
+        CHECK(reserved.find(static_cast<char>(c)) == std::string::npos);
+        CHECK(c >= 0x20);
+    }
+
+    CHECK(name.back() != '.');
+    CHECK(name.back() != ' ');
+}

--- a/tests/unit/engine/Poseidon/Foundation/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/Foundation/CMakeLists.txt
@@ -26,6 +26,7 @@ set(POSEIDON_BASE_TEST_SOURCES
     Common/test_mathND.cpp
     Common/test_platform.cpp
     Common/test_platformPaths.cpp
+    Common/test_playerPrefs.cpp
     Platform/test_cpp_runtime_warning.cpp
     Platform/test_crash_handler.cpp
     Platform/test_launch_diagnostics.cpp

--- a/tests/unit/engine/Poseidon/Foundation/Common/test_playerPrefs.cpp
+++ b/tests/unit/engine/Poseidon/Foundation/Common/test_playerPrefs.cpp
@@ -1,0 +1,129 @@
+#include <catch2/catch_test_macros.hpp>
+#include <Poseidon/Foundation/Common/PlayerPrefs.hpp>
+
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+struct ScopedEnv
+{
+    std::string name;
+    std::string oldValue;
+    bool hadOld;
+
+    ScopedEnv(const char* varName, const std::string& value) : name(varName)
+    {
+#ifdef _WIN32
+        const char* prev = std::getenv(varName);
+        hadOld = (prev != nullptr);
+        if (hadOld)
+            oldValue = prev;
+        _putenv_s(varName, value.c_str());
+#else
+        const char* prev = getenv(varName);
+        hadOld = (prev != nullptr);
+        if (hadOld)
+            oldValue = prev;
+        setenv(varName, value.c_str(), 1);
+#endif
+    }
+
+    ~ScopedEnv()
+    {
+#ifdef _WIN32
+        _putenv_s(name.c_str(), hadOld ? oldValue.c_str() : "");
+#else
+        if (hadOld)
+            setenv(name.c_str(), oldValue.c_str(), 1);
+        else
+            unsetenv(name.c_str());
+#endif
+    }
+};
+
+struct TempDir
+{
+    fs::path path;
+
+    explicit TempDir(const char* name) : path(fs::temp_directory_path() / name) { fs::create_directories(path); }
+
+    ~TempDir() { fs::remove_all(path); }
+};
+
+} // anonymous namespace
+
+TEST_CASE("PlayerPrefs: missing key returns the supplied default", "[playerPrefs]")
+{
+    TempDir dir("cwr_playerprefs_test_missing");
+    ScopedEnv env("POSEIDON_USER_DIR", dir.path.string());
+
+    CHECK(Poseidon::Foundation::prefsGetString("TestApp", "NoSuchKey", "fallback") == "fallback");
+}
+
+TEST_CASE("PlayerPrefs: set then get round-trips a value", "[playerPrefs]")
+{
+    TempDir dir("cwr_playerprefs_test_roundtrip");
+    ScopedEnv env("POSEIDON_USER_DIR", dir.path.string());
+
+    Poseidon::Foundation::prefsSetString("TestApp", "LastProfile", "aaaa");
+    CHECK(Poseidon::Foundation::prefsGetString("TestApp", "LastProfile") == "aaaa");
+}
+
+TEST_CASE("PlayerPrefs: a later set overwrites an earlier one for the same key", "[playerPrefs]")
+{
+    TempDir dir("cwr_playerprefs_test_overwrite");
+    ScopedEnv env("POSEIDON_USER_DIR", dir.path.string());
+
+    Poseidon::Foundation::prefsSetString("TestApp", "LastProfile", "first");
+    Poseidon::Foundation::prefsSetString("TestApp", "LastProfile", "second");
+    CHECK(Poseidon::Foundation::prefsGetString("TestApp", "LastProfile") == "second");
+}
+
+TEST_CASE("PlayerPrefs: value persists across a fresh load (simulated restart)", "[playerPrefs]")
+{
+    TempDir dir("cwr_playerprefs_test_persist");
+    ScopedEnv env("POSEIDON_USER_DIR", dir.path.string());
+
+    Poseidon::Foundation::prefsSetString("TestApp", "LastProfile", "bbbb");
+
+    REQUIRE(fs::exists(dir.path / "prefs.cfg"));
+
+    CHECK(Poseidon::Foundation::prefsGetString("TestApp", "LastProfile") == "bbbb");
+}
+
+TEST_CASE("PlayerPrefs: distinct app names use distinct prefs files", "[playerPrefs]")
+{
+    TempDir dirA("cwr_playerprefs_test_appA");
+    TempDir dirB("cwr_playerprefs_test_appB");
+
+    {
+        ScopedEnv env("POSEIDON_USER_DIR", dirA.path.string());
+        Poseidon::Foundation::prefsSetString("AppA", "LastProfile", "from-a");
+    }
+    {
+        ScopedEnv env("POSEIDON_USER_DIR", dirB.path.string());
+        Poseidon::Foundation::prefsSetString("AppB", "LastProfile", "from-b");
+    }
+    {
+        ScopedEnv env("POSEIDON_USER_DIR", dirA.path.string());
+        CHECK(Poseidon::Foundation::prefsGetString("AppA", "LastProfile") == "from-a");
+    }
+    {
+        ScopedEnv env("POSEIDON_USER_DIR", dirB.path.string());
+        CHECK(Poseidon::Foundation::prefsGetString("AppB", "LastProfile") == "from-b");
+    }
+}
+
+TEST_CASE("PlayerPrefs: a value containing '=' round-trips intact", "[playerPrefs]")
+{
+    TempDir dir("cwr_playerprefs_test_equals");
+    ScopedEnv env("POSEIDON_USER_DIR", dir.path.string());
+
+    Poseidon::Foundation::prefsSetString("TestApp", "Key", "a=b");
+    CHECK(Poseidon::Foundation::prefsGetString("TestApp", "Key") == "a=b");
+}


### PR DESCRIPTION
## Problem

`AppName` is used as a directory-name component when `PlayerPrefs` resolves its configuration path. Its previous value, `ARMA:CWA-RE-CE`, contains a colon, which is not valid in a Windows path component. Directory creation therefore failed and the last-selected profile was not persisted.

## Fix

- Rename `AppName` to the filesystem-safe `CWR`, matching the codename already used for the main user-data directory.
- Log failures to create user directories or open the preferences file for writing.
- Add regression coverage for filesystem-safe application names and PlayerPrefs persistence behavior.

## Verification

- clang-format 21.1.8: exact CI lint file set passes with `--dry-run --Werror`.
- `PoseidonFoundationTests [playerPrefs]`: 8 assertions in 6 test cases pass.
- `PoseidonTests "AppName contains no characters reserved by common filesystems"`: 9 assertions pass.
- Windows manual test: before the change, selecting a non-default profile did not survive a restart; after the change, the selected profile persists and reloads correctly.
