### PR TITLE
Fix issues while running macOS tests with sanitizers

### DIFF
--- a/engine/Poseidon/Dev/Harness/HarnessServer.cpp
+++ b/engine/Poseidon/Dev/Harness/HarnessServer.cpp
@@ -168,9 +168,8 @@ void HarnessServer::Stop()
         _listenSock = HARNESS_INVALID_SOCKET;
     }
 
-    // Give the thread a moment to exit
-    for (int i = 0; i < 20 && _running.load(); ++i)
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    // Wait for the worker thread to finish.
+    Foundation::poThreadJoin(_threadId, nullptr);
 
     _running.store(false);
     LOG_INFO(Core, "[Harness] Server stopped");

--- a/engine/Poseidon/Foundation/Threads/PoCritical.cpp
+++ b/engine/Poseidon/Foundation/Threads/PoCritical.cpp
@@ -82,7 +82,8 @@ void PoCriticalSection::enter() const
     lockEnter(id);
 #endif
 #else
-    error = (pthread_mutex_lock(&mutex) != 0);
+    if (pthread_mutex_lock(&mutex) != 0)
+        error = true;
 #endif
 }
 
@@ -100,7 +101,6 @@ bool PoCriticalSection::tryEnter() const
     return true;
 #endif
 #else
-    error = false;
     return (pthread_mutex_trylock(&mutex) == 0);
 #endif
 }
@@ -117,7 +117,8 @@ void PoCriticalSection::leave() const
 #endif
     LeaveCriticalSection(&cs);
 #else
-    error = (pthread_mutex_unlock(&mutex) != 0);
+    if (pthread_mutex_unlock(&mutex) != 0)
+        error = true;
 #endif
 }
 

--- a/engine/Poseidon/Network/Legacy/NetPeer.hpp
+++ b/engine/Poseidon/Network/Legacy/NetPeer.hpp
@@ -2,6 +2,7 @@
 #include <Poseidon/Network/Legacy/NetApi.hpp>
 #include <Poseidon/Foundation/Common/Global.hpp>
 #include <Poseidon/Foundation/Threads/PoThread.hpp>
+#include <atomic>
 #ifdef _MSC_VER
 #pragma once
 #endif
@@ -31,8 +32,8 @@ class NetPeerUDP : public NetPeer
     Poseidon::Foundation::ThreadId listener;
     Poseidon::Foundation::ThreadId sender;
 
-    bool listen;  // is this port listening?
-    bool sending; // is this port sending?
+    std::atomic<bool> listen;  // is this port listening?
+    std::atomic<bool> sending; // is this port sending?
 
     friend THREAD_PROC_RETURN THREAD_PROC_MODE udpListen(void* param);
     friend THREAD_PROC_RETURN THREAD_PROC_MODE udpSend(void* param);

--- a/engine/Poseidon/Network/MasterServerBrowser.cpp
+++ b/engine/Poseidon/Network/MasterServerBrowser.cpp
@@ -164,6 +164,7 @@ void ClearMasterServerBrowser(MasterServerBrowser* browser)
 {
     if (browser != nullptr)
     {
+        browser->joinWorker();
         browser->serviceSessions.clear();
         browser->pendingFetch.reset();
     }

--- a/engine/Poseidon/UI/Locale/Stringtable/Stringtable.cpp
+++ b/engine/Poseidon/UI/Locale/Stringtable/Stringtable.cpp
@@ -497,7 +497,7 @@ RString StringTable::Localize(int ids)
         // empty by design — return empty silently in that case.
         extern bool g_stringtableSystemAvailable;
         if (!g_stringtableSystemAvailable)
-            return "";
+            return RString();
 
         // Context: -1 usually means an uninitialized IDS_* global (STRING() entry
         // whose STR_* key was missing from stringtable.csv). Large positive values
@@ -509,9 +509,10 @@ RString StringTable::Localize(int ids)
 
         LOG_ERROR(Core, "String id {} is not registered (registered count = {}){}", ids, _registered.Size(), hint);
 #if _ENABLE_CHEATS
-        return "!!! UNREGISTERED STRING";
+        static const RString kUnregistered = "!!! UNREGISTERED STRING";
+        return kUnregistered;
 #else
-        return "";
+        return RString();
 #endif
     }
     return _registered[ids].value;
@@ -600,9 +601,10 @@ RString StringTable::Localize(const char* str)
 
     RptF("String %s not found", (const char*)str);
 #if _ENABLE_CHEATS
-    return "!!! MISSING STRING";
+    static const RString kMissing = "!!! MISSING STRING";
+    return kMissing;
 #else
-    return "";
+    return RString();
 #endif
 }
 

--- a/tests/unit/engine/Poseidon/Foundation/Memory/test_memory_budget.cpp
+++ b/tests/unit/engine/Poseidon/Foundation/Memory/test_memory_budget.cpp
@@ -171,6 +171,7 @@ TEST_CASE("ProcessMemoryBudget - concurrent reserve/release stays exact", "[memo
     constexpr int kIters = 20000;
     constexpr size_t kChunk = 64;
 
+    std::atomic<bool> allReserved{true};
     std::vector<std::thread> threads;
     threads.reserve(kThreads);
     for (int t = 0; t < kThreads; ++t)
@@ -180,7 +181,8 @@ TEST_CASE("ProcessMemoryBudget - concurrent reserve/release stays exact", "[memo
             {
                 for (int i = 0; i < kIters; ++i)
                 {
-                    REQUIRE(b.Reserve(kChunk));
+                    if (!b.Reserve(kChunk))
+                        allReserved = false;
                     b.Reconcile(kChunk, kChunk);
                     b.Release(kChunk);
                 }
@@ -191,6 +193,7 @@ TEST_CASE("ProcessMemoryBudget - concurrent reserve/release stays exact", "[memo
 
     // Every reserve was balanced by a release — used must return to exactly 0,
     // and peak must have climbed at least one chunk (something was live).
+    REQUIRE(allReserved);
     REQUIRE(b.Used() == 0);
     REQUIRE(b.Peak() >= kChunk);
 }


### PR DESCRIPTION
Tested with `macos-arm64-clang-san` and `macos-arm64-clang-tsan` profiles, likely fixes issues on other platforms as well