### PR TITLE
Fix gamma and brightness settings, restore original defaults

### DIFF
--- a/apps/cwr/Game/GameApplication.cpp
+++ b/apps/cwr/Game/GameApplication.cpp
@@ -384,6 +384,9 @@ void LoadAndApplyGraphicsConfig()
                  ramMB, path);
     }
 
+    if (cfg.Migrate() && cfg.Save(path))
+        LOG_INFO(Graphics, "LoadGraphicsConfig: migrated '{}' to version {}", path, GraphicsConfig::kVersion);
+
     LiveGraphicsEnv env;
     if (cfg.Normalize(env))
         LOG_INFO(Graphics, "LoadGraphicsConfig: normalized invalid fields (not persisted)");

--- a/engine/Poseidon/UI/Options/GraphicsPage.cpp
+++ b/engine/Poseidon/UI/Options/GraphicsPage.cpp
@@ -41,10 +41,12 @@ int FloatToSlider(float v, float lo, float hi)
     float c = std::clamp(v, lo, hi);
     return (int)std::lround((c - lo) / (hi - lo) * 100.0f);
 }
+// Snapped to 0.1 so the printed value is exactly the value that gets stored.
 float SliderToFloat(int s, float lo, float hi)
 {
     int c = std::clamp(s, 0, 100);
-    return lo + (c / 100.0f) * (hi - lo);
+    const float raw = lo + (c / 100.0f) * (hi - lo);
+    return std::round(raw * 10.0f) / 10.0f;
 }
 
 std::string GraphicsCfgPath()

--- a/engine/Poseidon/UI/Options/GraphicsPage.cpp
+++ b/engine/Poseidon/UI/Options/GraphicsPage.cpp
@@ -69,6 +69,12 @@ void RederivePreset(GraphicsConfig& cfg)
 }
 } // namespace
 
+// Bound at construction so row queries work on a page never shown.
+GraphicsPage::GraphicsPage()
+{
+    m_graphics.SetPage(this);
+}
+
 const char* GraphicsPage::TitleText() const
 {
     return LocalizeString("STR_DISP_MAIN_OPT_GRAPHICS");
@@ -196,6 +202,20 @@ int GraphicsPage::GraphicsProvider::RowValue(int row) const
     return 0;
 }
 
+// Brightness is a gain and gamma an exponent, so both rows print their value;
+// the bar carries the position in the range.
+const char* GraphicsPage::GraphicsProvider::SliderValueText(int row) const
+{
+    if (!m_page || (row != kRowBrightness && row != kRowGamma))
+        return nullptr;
+
+    const GraphicsConfig& c = m_page->m_cfg;
+    char buffer[16];
+    snprintf(buffer, sizeof(buffer), "%.1f", row == kRowBrightness ? c.brightness : c.gamma);
+    m_sliderValueText = buffer;
+    return m_sliderValueText.c_str();
+}
+
 void GraphicsPage::GraphicsProvider::SetRowValue(int row, int v)
 {
     if (!m_page)
@@ -282,8 +302,6 @@ void GraphicsPage::GraphicsProvider::SetRowValue(int row, int v)
 
 void GraphicsPage::Mount(OptionsShell& shell)
 {
-    m_graphics.SetPage(this);
-
     // Read graphics.cfg from disk so the rows reflect what's currently
     // live (which the boot path put there at autodetect time, and any
     // previous Unmount may have updated).  If the file is missing the

--- a/engine/Poseidon/UI/Options/GraphicsPage.hpp
+++ b/engine/Poseidon/UI/Options/GraphicsPage.hpp
@@ -15,8 +15,8 @@
 //   4 Particles & Volum.   Stepper Off/Low/High
 //   5 VSync                Stepper Off/On/Adaptive
 //   6 FPS Cap              Stepper Unlimited/30/60/90/120/144/240
-//   7 Brightness           Slider  0..100  (mapped 0.4..1.8 internally)
-//   8 Gamma                Slider  0..100  (mapped 0.5..2.3 internally)
+//   7 Brightness           Slider  0..100  (mapped 0.4..1.8, shown as the value)
+//   8 Gamma                Slider  0..100  (mapped 0.5..2.3, shown as the value)
 // + Close                  Action  (added by WithCloseRow)
 //
 // Quality Preset row is meta-state: selecting Low/Med/High/Ultra
@@ -38,6 +38,8 @@ namespace Poseidon
 class GraphicsPage : public ScrollListPage
 {
 public:
+	GraphicsPage();
+
 	const char* TitleText() const override;
 
 	static int BrightnessToSlider(float value);
@@ -81,9 +83,11 @@ private:
 		OptionsScrollList::RowDef RowFor(int row) const override;
 		int  RowValue(int row) const override;
 		void SetRowValue(int row, int v) override;
+		const char* SliderValueText(int row) const override;
 
 	private:
 		GraphicsPage* m_page = nullptr;
+		mutable std::string m_sliderValueText;
 	};
 
 	GraphicsConfig                  m_cfg;

--- a/engine/Poseidon/UI/Settings/GraphicsConfig.cpp
+++ b/engine/Poseidon/UI/Settings/GraphicsConfig.cpp
@@ -85,6 +85,21 @@ void GraphicsConfig::LoadDefaults()
     *this = GraphicsConfig{};
 }
 
+bool GraphicsConfig::Migrate()
+{
+    if (version >= kVersion)
+        return false;
+
+    // Only a file older than the version stamp reaches here, and its gamma is
+    // whatever first boot wrote.  1.0 is that stamped default and disables
+    // correction entirely; any other value was chosen, so it stays.
+    if (gamma == 1.0f)
+        gamma = 1.2f;
+
+    version = kVersion;
+    return true;
+}
+
 GraphicsConfig::Preset GraphicsConfig::PickPresetFromRam(int ramMB)
 {
     // Bucket boundaries in MB: 4 GB, 8 GB, 16 GB.  ramMB == 0 (unknown)
@@ -201,6 +216,10 @@ bool GraphicsConfig::Load(const std::string& path)
     ParamFile cfg;
     cfg.Parse(RString(path.c_str()));
 
+    version = 0;
+    if (auto* e = cfg.FindEntry("version"))
+        version = (int)*e;
+
     if (auto* e = cfg.FindEntry("qualityPreset"))
         qualityPreset = static_cast<Preset>((int)*e);
     if (auto* e = cfg.FindEntry("terrainDetail"))
@@ -249,6 +268,7 @@ bool GraphicsConfig::Save(const std::string& path) const
     cfg.Add("msaaSamples", msaaSamples);
     cfg.Add("brightness", brightness);
     cfg.Add("gamma", gamma);
+    cfg.Add("version", version);
 
     cfg.Save(RString(path.c_str()));
     return std::filesystem::exists(path, ec);

--- a/engine/Poseidon/UI/Settings/GraphicsConfig.hpp
+++ b/engine/Poseidon/UI/Settings/GraphicsConfig.hpp
@@ -78,8 +78,17 @@ public:
 	int       msaaSamples      = 0;             // MSAA on the frame target: 0 (off) / 2 / 4 / 8.
 	                                             // Default off — AA is being tuned via the dev panel
 	                                             // Render tab before a shipped default is picked
-	float     brightness       = 1.6f;          // 0.4..1.8 (1.6 = original CWA default: cfg.ReadValue("brightness",1.6))
-	float     gamma            = 1.0f;          // 0.5..2.3
+	float     brightness       = 1.6f;          // 0.4..1.8
+	float     gamma            = 1.2f;          // 0.5..2.3
+
+	// Schema version of the persisted file.  Load resets this to 0 first, so a
+	// file written before versioning reads back as 0 and Migrate can act on it.
+	static constexpr int kVersion = 1;
+	int       version          = kVersion;
+
+	// Bring a loaded config up to kVersion.  Returns true when the caller needs
+	// to persist the result.
+	bool Migrate();
 
 	// Reset every field to factory defaults.
 	void LoadDefaults();

--- a/engine/PoseidonGL33/EngineGL33.hpp
+++ b/engine/PoseidonGL33/EngineGL33.hpp
@@ -442,6 +442,18 @@ class EngineGL33 : public Engine
     // restore its full viewport.
     void BindFrameRenderTarget();
 
+    // Composite the gamma curve onto the finished frame.
+    void ApplyGammaPass();
+    void DestroyGammaTarget();
+    unsigned int _gammaTex = 0;
+    unsigned int _gammaVao = 0;
+    unsigned int _gammaProgram = 0;
+    int _gammaInvGammaLoc = -1;
+    int _gammaTexW = 0;
+    int _gammaTexH = 0;
+    // Latches so an unusable target is not rebuilt every frame.
+    bool _gammaUnavailable = false;
+
     // GL shader programs.  GL33 always uses shaders — there is no
     // fixed-function path to gate against.
     unsigned int _shaderProgram[NVertexShaders][NPixelShaderSpecular][NPixelShaderModes][NPixelShaders];
@@ -632,7 +644,6 @@ class EngineGL33 : public Engine
     int FrameTime() const;
     int AFrameTime() const override { return FrameTime(); }
 
-    void DoSetGamma();
     void SetGamma(float gamma) override;
     float GetGamma() const override { return _gamma; }
 

--- a/engine/PoseidonGL33/EngineGL33_Draw.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Draw.cpp
@@ -7,11 +7,6 @@
 #include <Poseidon/Graphics/Rendering/Lighting/Lights.hpp>
 #include <Poseidon/Graphics/Core/MatrixConversion.hpp>
 
-#include <SDL3/SDL.h>
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 void EngineGL33::SetFogColor(ColorVal /*fog*/)
 {
     if (!_glContext)
@@ -27,49 +22,10 @@ void EngineGL33::SetFogColor(ColorVal /*fog*/)
     UploadPSFogColor(_fogColor);
 }
 
-void EngineGL33::DoSetGamma()
-{
-#ifdef _WIN32
-    if (!_sdlWindow)
-        return;
-
-    SDL_PropertiesID props = SDL_GetWindowProperties(_sdlWindow);
-    HWND hwnd = (HWND)SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL);
-    if (!hwnd)
-        return;
-
-    HDC hdc = GetDC(hwnd);
-    if (!hdc)
-        return;
-
-    WORD ramp[3][256];
-    float eGamma = 1.0f / _gamma;
-    ramp[0][0] = ramp[1][0] = ramp[2][0] = 0;
-    for (int i = 1; i < 256; i++)
-    {
-        float x = i * (1.0f / 255.0f);
-        float fx = powf(x, eGamma);
-        int ifx = static_cast<int>(fx * 65535.0f);
-        if (ifx < 0)
-            ifx = 0;
-        if (ifx > 65535)
-            ifx = 65535;
-        ramp[0][i] = ramp[1][i] = ramp[2][i] = static_cast<WORD>(ifx);
-    }
-    SetDeviceGammaRamp(hdc, ramp);
-    ReleaseDC(hwnd, hdc);
-    LOG_DEBUG(Graphics, "GL33: set gamma {:.3f}", _gamma);
-#endif
-}
-
 void EngineGL33::SetGamma(float gamma)
 {
     saturate(gamma, 1e-3f, 1e3f);
     _gamma = gamma;
-    if (_sdlWindow)
-    {
-        DoSetGamma();
-    }
 }
 
 void EngineGL33::SetBias(int bias)

--- a/engine/PoseidonGL33/EngineGL33_Lifecycle.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Lifecycle.cpp
@@ -534,7 +534,6 @@ bool EngineGL33::ResetHard()
     PreReset(true);
     DestroySurfaces();
 
-    DoSetGamma();
     InitGL();
 
     PostReset();
@@ -1080,6 +1079,7 @@ void EngineGL33::ShutdownGL()
 
     DeinitVertexShaders();
     DeinitPixelShaders();
+    DestroyGammaTarget();
     DestroySamplerStates();
     DestroyVBTL();
     DestroyVB();

--- a/engine/PoseidonGL33/EngineGL33_Shaders.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Shaders.cpp
@@ -6,6 +6,7 @@
 #include <Poseidon/World/Scene/Camera/Camera.hpp>
 #include <Poseidon/Graphics/Rendering/Lighting/Lights.hpp>
 #include <Poseidon/Graphics/Core/MatrixConversion.hpp>
+#include <Poseidon/Graphics/Core/GLDepthStencilState.hpp>
 #include <Poseidon/Foundation/Common/GamePaths.hpp>
 
 #include <SDL3/SDL.h>
@@ -1605,6 +1606,128 @@ void EngineGL33::InitPixelShaders()
         UploadPSConstant(PSConstants::SlotRgbEyeCoef, _psConstants.rgbEyeCoef);
         DoSelectPixelShader(PSNormal, PSMDay, PSSNormal);
     }
+}
+
+static const char* s_vsGammaGLSL = R"(#version 330 core
+out vec2 vUV;
+void main()
+{
+    // Fullscreen triangle from gl_VertexID; no vertex buffer needed.
+    vec2 p = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
+    vUV = p;
+    gl_Position = vec4(p * 2.0 - 1.0, 0.0, 1.0);
+}
+)";
+
+static const char* s_psGammaGLSL = R"(#version 330 core
+in vec2 vUV;
+uniform sampler2D frame;
+uniform float invGamma;
+out vec4 fragColor;
+void main()
+{
+    vec3 c = texture(frame, vUV).rgb;
+    fragColor = vec4(pow(c, vec3(invGamma)), 1.0);
+}
+)";
+
+void EngineGL33::DestroyGammaTarget()
+{
+    if (_gammaTex)
+    {
+        GL33Bind::OnTexDeleted(_gammaTex);
+        glDeleteTextures(1, &_gammaTex);
+    }
+    if (_gammaVao)
+    {
+        GL33Bind::OnVaoDeleted(_gammaVao);
+        glDeleteVertexArrays(1, &_gammaVao);
+    }
+    if (_gammaProgram)
+        glDeleteProgram(_gammaProgram);
+    _gammaTex = _gammaVao = _gammaProgram = 0;
+    _gammaInvGammaLoc = -1;
+    _gammaTexW = _gammaTexH = 0;
+    _gammaUnavailable = false;
+}
+
+void EngineGL33::ApplyGammaPass()
+{
+    if (!_glContext || _gammaUnavailable)
+        return;
+    if (_gamma > 0.999f && _gamma < 1.001f)
+        return;
+
+    int winW = _w, winH = _h;
+    if (_sdlWindow)
+        SDL_GetWindowSizeInPixels(_sdlWindow, &winW, &winH);
+    if (winW <= 0 || winH <= 0)
+        return;
+
+    if (!_gammaProgram)
+    {
+        GLuint vs = CompileGLShader(GL_VERTEX_SHADER, s_vsGammaGLSL, "vsGamma");
+        GLuint fs = CompileGLShader(GL_FRAGMENT_SHADER, s_psGammaGLSL, "psGamma");
+        if (vs && fs)
+            _gammaProgram = LinkGLProgram(vs, fs, "gamma");
+        if (vs)
+            glDeleteShader(vs);
+        if (fs)
+            glDeleteShader(fs);
+        if (!_gammaProgram)
+        {
+            LOG_ERROR(Graphics, "GL33: gamma program failed to build, gamma correction disabled");
+            _gammaUnavailable = true;
+            return;
+        }
+        glUseProgram(_gammaProgram);
+        glUniform1i(glGetUniformLocation(_gammaProgram, "frame"), 0);
+        _gammaInvGammaLoc = glGetUniformLocation(_gammaProgram, "invGamma");
+        glGenVertexArrays(1, &_gammaVao);
+        glGenTextures(1, &_gammaTex);
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, _gammaTex);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    }
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, _gammaTex);
+    if (_gammaTexW != winW || _gammaTexH != winH)
+    {
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, winW, winH, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+        _gammaTexW = winW;
+        _gammaTexH = winH;
+    }
+    // The default framebuffer cannot be sampled, so copy it into the texture.
+    glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, winW, winH);
+    glViewport(0, 0, winW, winH);
+
+    // Depth/blend/cull belong to ApplyPipeline; handed back below.
+    Poseidon::render::depthstencil::Disabled(/*hasStencil*/ false);
+    glDisable(GL_BLEND);
+    glDisable(GL_CULL_FACE);
+    glDisable(GL_SCISSOR_TEST);
+
+    glUseProgram(_gammaProgram);
+    glUniform1f(_gammaInvGammaLoc, 1.0f / _gamma);
+    // Unit 0's sampler object overrides the texture's own parameters; its mipmap
+    // min filter would leave this mipmap-less texture incomplete and sampling black.
+    glBindSampler(0, 0);
+    glBindVertexArray(_gammaVao);
+    glDrawArrays(GL_TRIANGLES, 0, 3);
+
+    glBindVertexArray(0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glBindSampler(0, _samplerObjects[0]);
+    glUseProgram(0);
+    // The shader selector short-circuits on its cached selection, so it must be
+    // told the bound program is gone or the next frame's sky draws through it.
+    _pixelShaderSel = PSNone;
+    GL33Bind::Invalidate();
+    InvalidatePipelineCache();
 }
 
 void EngineGL33::DeinitPixelShaders()

--- a/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
+++ b/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
@@ -567,6 +567,9 @@ void EngineGL33::BackToFront()
     // pixels the user sees.
     ResolveSSAAToDefault();
 
+    // Before the overlay and the capture: corrects game + HUD, not the overlay.
+    ApplyGammaPass();
+
     // ImGui composites on top of game + HUD.  Render BEFORE the screenshot
     // capture so trident captures include the overlay (same pixels the user
     // sees after SwapWindow).  Both calls are safe no-ops when disabled.

--- a/tests/unit/engine/Poseidon/UI/Settings/test_graphicsConfig.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_graphicsConfig.cpp
@@ -8,6 +8,8 @@
 #include <Poseidon/UI/Settings/GraphicsConfig.hpp>
 
 #include <filesystem>
+#include <fstream>
+#include <iterator>
 #include <random>
 #include <string>
 #include <initializer_list>
@@ -44,9 +46,74 @@ TEST_CASE("GraphicsConfig: factory defaults match spec", "[Settings][GraphicsCon
     CHECK(c.shadowQuality == GraphicsConfig::TierHigh); // Ultra preset caps shadow at High
     CHECK(c.particlesQuality == GraphicsConfig::TierHigh);
     CHECK(c.vsync == GraphicsConfig::VsyncOn);
-    CHECK(c.fpsCap == 0);        // Unlimited
-    CHECK(c.brightness == 1.6f); // matches the original CWA default (engine.cpp cfg.ReadValue("brightness",1.6))
+    CHECK(c.fpsCap == 0); // Unlimited
+    CHECK(c.brightness == 1.6f);
+    CHECK(c.gamma == 1.2f);
+    CHECK(c.version == GraphicsConfig::kVersion);
+}
+
+// Migrate only touches a version-0 file whose gamma is still the stamped 1.0.
+TEST_CASE("GraphicsConfig: Migrate lifts an untouched gamma once", "[Settings][GraphicsConfig]")
+{
+    GraphicsConfig c;
+    c.version = 0;
+    c.gamma = 1.0f;
+
+    REQUIRE(c.Migrate());
+    CHECK(c.gamma == 1.2f);
+    CHECK(c.version == GraphicsConfig::kVersion);
+
+    CHECK_FALSE(c.Migrate());
+    CHECK(c.gamma == 1.2f);
+}
+
+TEST_CASE("GraphicsConfig: Migrate keeps a gamma the user chose", "[Settings][GraphicsConfig]")
+{
+    for (float chosen : {0.5f, 0.9f, 1.1f, 1.4f, 2.3f})
+    {
+        GraphicsConfig c;
+        c.version = 0;
+        c.gamma = chosen;
+
+        CHECK(c.Migrate());
+        CHECK(c.gamma == chosen);
+        CHECK(c.version == GraphicsConfig::kVersion);
+    }
+}
+
+TEST_CASE("GraphicsConfig: a versioned file is never migrated", "[Settings][GraphicsConfig]")
+{
+    GraphicsConfig c;
+    c.version = GraphicsConfig::kVersion;
+    c.gamma = 1.0f;
+
+    CHECK_FALSE(c.Migrate());
     CHECK(c.gamma == 1.0f);
+}
+
+TEST_CASE("GraphicsConfig: a file without a version reloads as version 0", "[Settings][GraphicsConfig]")
+{
+    const std::string path = TmpPath("graphics.cfg");
+    GraphicsConfig saved;
+    saved.LoadDefaults();
+    REQUIRE(saved.Save(path));
+
+    std::string text;
+    {
+        std::ifstream in(path);
+        text.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+    }
+    const std::string::size_type at = text.find("version=");
+    REQUIRE(at != std::string::npos);
+    text.erase(at, text.find('\n', at) - at + 1);
+    {
+        std::ofstream out(path, std::ios::trunc);
+        out << text;
+    }
+
+    GraphicsConfig loaded;
+    REQUIRE(loaded.Load(path));
+    CHECK(loaded.version == 0);
 }
 
 TEST_CASE("GraphicsConfig: Save then Load round-trips every field", "[Settings][GraphicsConfig]")

--- a/tests/unit/engine/Poseidon/UI/test_graphics_page.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_graphics_page.cpp
@@ -1,8 +1,19 @@
 #include <Poseidon/UI/Options/GraphicsPage.hpp>
+#include <Poseidon/UI/Options/OptionsScrollList.hpp>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <string>
+
 using namespace Poseidon;
+namespace
+{
+class TestableGraphicsPage : public GraphicsPage
+{
+  public:
+    OptionsScrollList::Provider& Provider() { return ProviderRef(); }
+};
+} // namespace
 TEST_CASE("GraphicsPage brightness slider conversion clamps into range", "[UI][GraphicsPage]")
 {
     CHECK(GraphicsPage::BrightnessToSlider(0.1f) == 0);
@@ -29,6 +40,21 @@ TEST_CASE("GraphicsPage gamma slider conversion clamps into range", "[UI][Graphi
     CHECK(GraphicsPage::SliderToGamma(50) == Catch::Approx(1.4f));
     CHECK(GraphicsPage::SliderToGamma(100) == Catch::Approx(2.3f));
     CHECK(GraphicsPage::SliderToGamma(120) == Catch::Approx(2.3f));
+}
+
+// Pins brightness and gamma to value text; other slider rows keep percent.
+TEST_CASE("GraphicsPage brightness and gamma rows show values, not percentages", "[UI][GraphicsPage]")
+{
+    TestableGraphicsPage page;
+    auto& p = page.Provider();
+
+    // Rows 7/8 are Brightness/Gamma; an unmounted page holds the cfg defaults.
+    REQUIRE(p.SliderValueText(7) != nullptr);
+    CHECK(std::string(p.SliderValueText(7)) == "1.6");
+    REQUIRE(p.SliderValueText(8) != nullptr);
+    CHECK(std::string(p.SliderValueText(8)) == "1.0");
+
+    CHECK(p.SliderValueText(5) == nullptr);
 }
 
 TEST_CASE("GraphicsPage fps-cap index mapping falls back to unlimited for unknown values", "[UI][GraphicsPage]")

--- a/tests/unit/engine/Poseidon/UI/test_graphics_page.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_graphics_page.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <cmath>
 #include <string>
 
 using namespace Poseidon;
@@ -40,6 +41,21 @@ TEST_CASE("GraphicsPage gamma slider conversion clamps into range", "[UI][Graphi
     CHECK(GraphicsPage::SliderToGamma(50) == Catch::Approx(1.4f));
     CHECK(GraphicsPage::SliderToGamma(100) == Catch::Approx(2.3f));
     CHECK(GraphicsPage::SliderToGamma(120) == Catch::Approx(2.3f));
+}
+
+// The row text prints one decimal, so every slider position must land on one.
+TEST_CASE("GraphicsPage slider values snap to one decimal", "[UI][GraphicsPage]")
+{
+    for (int s = 0; s <= 100; ++s)
+    {
+        const float g = GraphicsPage::SliderToGamma(s);
+        CHECK(g == Catch::Approx(std::round(g * 10.0f) / 10.0f));
+        const float b = GraphicsPage::SliderToBrightness(s);
+        CHECK(b == Catch::Approx(std::round(b * 10.0f) / 10.0f));
+    }
+
+    CHECK(GraphicsPage::SliderToGamma(GraphicsPage::GammaToSlider(1.2f)) == Catch::Approx(1.2f));
+    CHECK(GraphicsPage::SliderToBrightness(GraphicsPage::BrightnessToSlider(1.6f)) == Catch::Approx(1.6f));
 }
 
 // Pins brightness and gamma to value text; other slider rows keep percent.

--- a/tests/unit/engine/Poseidon/UI/test_graphics_page.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_graphics_page.cpp
@@ -52,7 +52,7 @@ TEST_CASE("GraphicsPage brightness and gamma rows show values, not percentages",
     REQUIRE(p.SliderValueText(7) != nullptr);
     CHECK(std::string(p.SliderValueText(7)) == "1.6");
     REQUIRE(p.SliderValueText(8) != nullptr);
-    CHECK(std::string(p.SliderValueText(8)) == "1.0");
+    CHECK(std::string(p.SliderValueText(8)) == "1.2");
 
     CHECK(p.SliderValueText(5) == nullptr);
 }


### PR DESCRIPTION
- move to shader based gamma as recommended by SDL
- revert units back to original ones over percentages (which makes no sense)
- restore original 1.99 defaults (different to 1:96 and earlier bwt.)
- migrate gracefully from old configs (apply new defaults if not touched before)

<img width="793" height="627" alt="image" src="https://github.com/user-attachments/assets/9bc8da2d-2a07-4a45-8671-dcd5b4298e84" />

closes https://github.com/ofpisnotdead-com/CWR-CE/issues/149
closes https://github.com/ofpisnotdead-com/CWR-CE/issues/104