### PR TITLE
Separate cosmetic-effect RNG from the simulation RNG stream

### DIFF
--- a/engine/Poseidon/Audio/DynSound.cpp
+++ b/engine/Poseidon/Audio/DynSound.cpp
@@ -330,7 +330,7 @@ void DynSoundObject::Simulate(Object* source, float deltaT, SimulationImportance
         return; // continue playing or pause
     }
     // select sound source
-    float rand = GRandGen.RandomValue();
+    float rand = GFxRandGen.RandomValue();
     const SoundEntry& pars = _dynSound->SelectSound(rand);
     bool loop = _dynSound->IsOneLoopingSound();
     // play selected sound
@@ -341,11 +341,11 @@ void DynSoundObject::Simulate(Object* source, float deltaT, SimulationImportance
         float rndVol = 1;
         if (pars.freqRnd)
         {
-            rndFreq = 1 + GRandGen.RandomValue() * pars.freqRnd - pars.freqRnd * 0.5;
+            rndFreq = 1 + GFxRandGen.RandomValue() * pars.freqRnd - pars.freqRnd * 0.5;
         }
         if (pars.volRnd)
         {
-            rndVol = 1 + GRandGen.RandomValue() * pars.volRnd - pars.volRnd * 0.5;
+            rndVol = 1 + GFxRandGen.RandomValue() * pars.volRnd - pars.volRnd * 0.5;
         }
         if (loop)
         {
@@ -365,7 +365,7 @@ void DynSoundObject::Simulate(Object* source, float deltaT, SimulationImportance
     // random time to live
     if (!loop)
     {
-        float delay = GRandGen.Gauss(pars._min_delay, pars._mid_delay, pars._max_delay);
+        float delay = GFxRandGen.Gauss(pars._min_delay, pars._mid_delay, pars._max_delay);
         if (wave)
         {
             delay += wave->GetLength();

--- a/engine/Poseidon/Audio/Speaker.cpp
+++ b/engine/Poseidon/Audio/Speaker.cpp
@@ -23,7 +23,7 @@ using Poseidon::Foundation::EnumName;
 static RStringB RandomMicOut()
 {
     const ParamEntry& micOuts = Pars >> "CfgVoice" >> "micOuts";
-    int i = toInt(GRandGen.RandomValue() * micOuts.GetSize());
+    int i = toInt(GFxRandGen.RandomValue() * micOuts.GetSize());
     return micOuts[i];
 }
 

--- a/engine/Poseidon/Graphics/Rendering/Effects/Smokes.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Effects/Smokes.cpp
@@ -103,13 +103,13 @@ bool SmokeSource::Simulate(Vector3Par pos, Vector3Par speed, float deltaT, Simul
             _nextTime += _interval * _generalize * _generalize;
             float size05 = 0.5 * _sourceSize;
             Vector3Val windSpeed = GLandscape->GetWind() * 0.5;
-            Vector3 speed(GRandGen.RandomValue() * (1 + _sourceSize) - (0.5 + size05) + _speed[0],
-                          GRandGen.RandomValue() - 0.5 + _speed[1],
-                          GRandGen.RandomValue() * (1 + _sourceSize) - (0.5 + size05) + _speed[2]);
-            Vector3 offset((GRandGen.RandomValue() * 2 - 1) * _sourceSize,
-                           (GRandGen.RandomValue() * 2 - 1) * _sourceSize,
-                           (GRandGen.RandomValue() * 2 - 1) * _sourceSize);
-            CloudletSource::SetSize((GRandGen.RandomValue() + 2) * _size * 2);
+            Vector3 speed(GFxRandGen.RandomValue() * (1 + _sourceSize) - (0.5 + size05) + _speed[0],
+                          GFxRandGen.RandomValue() - 0.5 + _speed[1],
+                          GFxRandGen.RandomValue() * (1 + _sourceSize) - (0.5 + size05) + _speed[2]);
+            Vector3 offset((GFxRandGen.RandomValue() * 2 - 1) * _sourceSize,
+                           (GFxRandGen.RandomValue() * 2 - 1) * _sourceSize,
+                           (GFxRandGen.RandomValue() * 2 - 1) * _sourceSize);
+            CloudletSource::SetSize((GFxRandGen.RandomValue() + 2) * _size * 2);
             CloudletSource::SetAlpha(_inOutDensity * _density * 0.7);
             //  simulate cloudlet source
             Cloudlet* cloudlet = Drop(pos + offset, speed);
@@ -261,7 +261,7 @@ void SmokeSourceVehicle::SimulateExplosion()
         AmmoType type = *aType;
         if (GetObject())
         {
-            float gauss = GRandGen.RandomValue() + GRandGen.RandomValue();
+            float gauss = GFxRandGen.RandomValue() + GFxRandGen.RandomValue();
             float randomFactor = gauss * (_maxExplosionFactor - _minExplosionFactor) + _minExplosionFactor;
 
             float hit = GetObject()->GetExplosives() * randomFactor;
@@ -280,13 +280,13 @@ void SmokeSourceVehicle::SimulateExplosion()
             _darkFire.SetSize(fireSize);
             _fire.Start(fireTime);
             _darkFire.Start(fireTime);
-            float rndTime = GRandGen.RandomValue() * 0.4 + 0.8;
+            float rndTime = GFxRandGen.RandomValue() * 0.4 + 0.8;
             SetSourceTimes(0, 40 * rndTime, 40 * rndTime);
             // sound of explosion
             const ParamEntry& par = Pars >> "CfgDestroy" >> "EngineHit";
             SoundPars soundPars;
             GetValue(soundPars, par >> "sound");
-            float rndFreq = GRandGen.RandomValue() * 0.1 + 0.95;
+            float rndFreq = GFxRandGen.RandomValue() * 0.1 + 0.95;
             IWave* sound = GSoundScene->OpenAndPlayOnce(soundPars.name, Position(), VZero, soundPars.vol,
                                                         soundPars.freq * rndFreq);
             if (sound)
@@ -865,7 +865,7 @@ Cloudlet* CloudletSource::Drop(Vector3Par pos, Vector3Par speed)
     Color colorA0 = _cloudletColor;
     colorA0.SetA(0);
     cloudlet->SetColor(PackedColor(colorA0));
-    float delta = _cloudletDeltaT * (0.7 + 0.6 * GRandGen.RandomValue());
+    float delta = _cloudletDeltaT * (0.7 + 0.6 * GFxRandGen.RandomValue());
     cloudlet->SetTemperature(_cloudletInitT, delta, _cloudletTTable);
     cloudlet->SetPosition(pos);
     return cloudlet;
@@ -1077,13 +1077,13 @@ void DustSource::Simulate(Vector3Par pos, Vector3Par speed, float density, float
         const float size2 = 2 * _size;
         const float size05 = 0.5 * _size;
         Vector3Val windSpeed = GLandscape->GetWind() * _windCoef;
-        Vector3 cSpeed((GRandGen.RandomValue() * (1 + _size) - (0.5 + size05)) * 2,
-                       GRandGen.RandomValue() * 1 + size2 * 1,
-                       (GRandGen.RandomValue() * (1 + _size) - (0.5 + size05)) * 2);
-        Vector3 offset((GRandGen.RandomValue() * 2 - 1) * _sourceSize, (GRandGen.RandomValue() * 2 - 1) * _sourceSize,
-                       (GRandGen.RandomValue() * 2 - 1) * _sourceSize);
+        Vector3 cSpeed((GFxRandGen.RandomValue() * (1 + _size) - (0.5 + size05)) * 2,
+                       GFxRandGen.RandomValue() * 1 + size2 * 1,
+                       (GFxRandGen.RandomValue() * (1 + _size) - (0.5 + size05)) * 2);
+        Vector3 offset((GFxRandGen.RandomValue() * 2 - 1) * _sourceSize, (GFxRandGen.RandomValue() * 2 - 1) * _sourceSize,
+                       (GFxRandGen.RandomValue() * 2 - 1) * _sourceSize);
         float cSize = floatMax(_size, _size * 3 * density);
-        CloudletSource::SetSize((GRandGen.RandomValue() + 2) * cSize);
+        CloudletSource::SetSize((GFxRandGen.RandomValue() + 2) * cSize);
         // simulate cloudlet source
         Cloudlet* cloudlet = Drop(pos + offset, cSpeed * density * 0.5 + windSpeed + speed);
         cloudlet->SetClimbRate(_cloudletAccY, _cloudletMinYSpeed, _cloudletMaxYSpeed);
@@ -1144,18 +1144,18 @@ void WeaponCloudsSource::Simulate(Vector3Par pos, Vector3Par speed, float densit
         const float size = GetSize();
         const float size2 = 2 * size;
         const float size05 = 0.5 * size;
-        Vector3 cSpeed((GRandGen.RandomValue() * (1 + size) - (0.5 + size05)) * 2,
-                       GRandGen.RandomValue() * 1 + size2 * 1,
-                       (GRandGen.RandomValue() * (1 + size) - (0.5 + size05)) * 2);
+        Vector3 cSpeed((GFxRandGen.RandomValue() * (1 + size) - (0.5 + size05)) * 2,
+                       GFxRandGen.RandomValue() * 1 + size2 * 1,
+                       (GFxRandGen.RandomValue() * (1 + size) - (0.5 + size05)) * 2);
         const float sourceSize = GetSourceSize();
-        Vector3 offset((GRandGen.RandomValue() * 2 - 1) * sourceSize, (GRandGen.RandomValue() * 2 - 1) * sourceSize,
-                       (GRandGen.RandomValue() * 2 - 1) * sourceSize);
+        Vector3 offset((GFxRandGen.RandomValue() * 2 - 1) * sourceSize, (GFxRandGen.RandomValue() * 2 - 1) * sourceSize,
+                       (GFxRandGen.RandomValue() * 2 - 1) * sourceSize);
         float cSize = floatMax(size, size * 3 * density);
-        CloudletSource::SetSize((GRandGen.RandomValue() + 2) * cSize);
+        CloudletSource::SetSize((GFxRandGen.RandomValue() + 2) * cSize);
         // simulate cloudlet source
         Cloudlet* cloudlet = Drop(pos + offset, speed);
 
-        float newSize = GetSize() * _generalize * (0.5 + 1.0 * GRandGen.RandomValue());
+        float newSize = GetSize() * _generalize * (0.5 + 1.0 * GFxRandGen.RandomValue());
         cloudlet->SetGrowUp(_cloudletGrowUp, newSize);
         Vector3 dir = cloudlet->Position() - pos;
         saturateMax(dir[1], 0);
@@ -1226,7 +1226,7 @@ void WeaponLightSource::Simulate(Vector3Par pos, float deltaT)
                 float intensity = _lightIntensity;
                 if (_lightMGun)
                 {
-                    intensity *= GRandGen.PlusMinus(0.8, 0.2);
+                    intensity *= GFxRandGen.PlusMinus(0.8, 0.2);
                 }
                 else
                 {
@@ -1320,7 +1320,7 @@ void Crater::Init(float timeToLive, float size, bool smoke, bool blood, bool wat
         _dustTimeToLive = 0.1;
         _dust.Load(Pars >> "CfgCloudlets" >> "CraterBlood");
 
-        float angle = 2.0 * H_PI * GRandGen.RandomValue();
+        float angle = 2.0 * H_PI * GFxRandGen.RandomValue();
         Vector3 dir(sin(angle), 0, cos(angle));
 
         _dust.SetSpeed(-VUp * 0.5 + dir * 0.5);
@@ -1348,13 +1348,13 @@ void Crater::Init(float timeToLive, float size, bool smoke, bool blood, bool wat
         saturate(cloudletSize, 0.5, 1.2);
         _smoke1.Load(Pars >> "CfgCloudlets" >> "CraterSmoke1");
         _smoke1.SetSize(2.0 * cloudletSize, 1.5 * size);
-        _smoke1.SetColor(_smoke1.GetColor() * GRandGen.RandomValue());
+        _smoke1.SetColor(_smoke1.GetColor() * GFxRandGen.RandomValue());
         _smoke2.Load(Pars >> "CfgCloudlets" >> "CraterSmoke2");
         _smoke2.SetSize(2.0 * cloudletSize, 1.5 * size);
-        _smoke2.SetColor(_smoke2.GetColor() * (0.6 + 0.4 * GRandGen.RandomValue()));
+        _smoke2.SetColor(_smoke2.GetColor() * (0.6 + 0.4 * GFxRandGen.RandomValue()));
         _smoke3.Load(Pars >> "CfgCloudlets" >> "CraterSmoke3");
         _smoke3.SetSize(1.0 * cloudletSize, 1.5 * size);
-        _smoke3.SetColor(_smoke3.GetColor() * (0.6 + 0.4 * GRandGen.RandomValue()));
+        _smoke3.SetColor(_smoke3.GetColor() * (0.6 + 0.4 * GFxRandGen.RandomValue()));
     }
     else
     {
@@ -1391,8 +1391,8 @@ void Crater::Simulate(float deltaT, SimulationImportance prec)
     if (_dustTimeToLive > 0)
     {
         const float scale = 0.8;
-        Vector3 up((GRandGen.RandomValue() * 6 * scale - 3 * scale) * _size, 10 * scale * _size,
-                   (GRandGen.RandomValue() * 6 * scale - 3 * scale) * _size);
+        Vector3 up((GFxRandGen.RandomValue() * 6 * scale - 3 * scale) * _size, 10 * scale * _size,
+                   (GFxRandGen.RandomValue() * 6 * scale - 3 * scale) * _size);
         float density = floatMax(_size, 0.02);
         _dustTimeToLive -= deltaT;
         if (!_isSmoke)

--- a/engine/Poseidon/UI/DisplayUIMenus.cpp
+++ b/engine/Poseidon/UI/DisplayUIMenus.cpp
@@ -251,7 +251,7 @@ void CHead::Simulate()
     if (oldT < tChange && newT >= tChange)
     {
         int size = (Pars >> "CfgMimics" >> "States").GetEntryCount();
-        int i = toIntFloor(size * GRandGen.RandomValue());
+        int i = toIntFloor(size * GFxRandGen.RandomValue());
         GetHead()->SetMimic((Pars >> "CfgMimics" >> "States").GetEntry(i).GetName());
     }
 
@@ -1478,7 +1478,7 @@ inline bool OnKilled()
 DisplayMissionEnd::DisplayMissionEnd(ControlsContainer* parent /*, bool editor*/) : Display(parent)
 {
     int quotations = (IDS_QUOTE_LAST - IDS_QUOTE_1) / 2 + 1;
-    _quotation = toIntFloor(quotations * GRandGen.RandomValue());
+    _quotation = toIntFloor(quotations * GFxRandGen.RandomValue());
     Load("RscDisplayMissionEnd");
 
     GetCtrl(IDC_ME_LOAD)->ShowCtrl(false);

--- a/engine/Poseidon/UI/InGame/InGameUI.cpp
+++ b/engine/Poseidon/UI/InGame/InGameUI.cpp
@@ -987,7 +987,7 @@ InGameUI::InGameUI() : _mode(UIFire), _modeAuto(UIFire), _groundPointValid(false
     }
     _lastUnitInfoTime = Glob.uiTime;
     _lastMenuTime = Glob.uiTime;
-    _timeToPlay = Glob.uiTime + GRandGen.PlusMinus(60, 30);
+    _timeToPlay = Glob.uiTime + GFxRandGen.PlusMinus(60, 30);
 
     _target = nullptr;
     _lockTarget = nullptr;

--- a/engine/Poseidon/UI/Map/UIMapDisplay.cpp
+++ b/engine/Poseidon/UI/Map/UIMapDisplay.cpp
@@ -455,7 +455,7 @@ bool WeaponsInfo::Import(const ParamEntry& superclass)
                 magazine->_reload = 0;
                 if (type->_modes.Size() > 0)
                 {
-                    float reload = 0.8 + 0.2 * GRandGen.RandomValue();
+                    float reload = 0.8 + 0.2 * GFxRandGen.RandomValue();
                     magazine->_reload = reload * type->_modes[0]->_reloadTime;
                 }
                 _magazinesPool.Add(magazine);

--- a/engine/Poseidon/UI/OptionsUI.cpp
+++ b/engine/Poseidon/UI/OptionsUI.cpp
@@ -1218,7 +1218,7 @@ void CampaignHistory::LoadWeaponPool(WeaponsInfo& pool)
             magazine->_reload = 0;
             if (type->_modes.Size() > 0)
             {
-                float reload = 0.8 + 0.2 * GRandGen.RandomValue();
+                float reload = 0.8 + 0.2 * GFxRandGen.RandomValue();
                 magazine->_reload = reload * type->_modes[0]->_reloadTime;
             }
             pool._magazinesPool.Add(magazine);
@@ -2204,7 +2204,7 @@ void StartRandomCutscene(RString world)
 
     const ParamEntry& cls = Pars >> "CfgWorlds" >> world >> "cutscenes";
     int n = cls.GetSize();
-    int i = toIntFloor(n * GRandGen.RandomValue());
+    int i = toIntFloor(n * GFxRandGen.RandomValue());
 
     RString name = cls[i];
 

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
@@ -433,7 +433,9 @@ void Man::DrawNVOptics()
         LODShapeWithShadow* oShape = muzzle->_opticsModel;
         if (oShape)
         {
-            int phase = toIntFloor(5.0f * GRandGen.RandomValue());
+            // Draw-path (per rendered frame): use the cosmetic FX stream, never the
+            // sim's GRandGen — sharing it would desync sim reproducibility. See GFxRandGen.
+            int phase = toIntFloor(5.0f * GFxRandGen.RandomValue());
             muzzle->_animFire.SetPhase(oShape, 0, phase);
             // 4:3 vignette — preserve 4:3 + pillarbox while bars are on, else stretch.
             const bool preserve4x3 = AspectRatio::ArePillarboxBarsEnabled();

--- a/engine/Random/randomGen.hpp
+++ b/engine/Random/randomGen.hpp
@@ -57,4 +57,22 @@ inline RandomGenerator& GRandGen()
 // Let call sites spell the singleton as `GRandGen.Foo()`; expands to `GRandGen().Foo()`.
 #define GRandGen GRandGen()
 
+// Separate RNG stream for cosmetic render-side effects (smoke/dust/cloudlet particles).
+// These consume a nondeterministic number of random values per frame — particle spawn
+// and lifecycle depend on camera, visibility and frame timing — so sharing the sim's
+// GRandGen desynced the MP-critical simulation RNG stream from the first seconds of a
+// mission.  A fixed seed alone could not keep two rendered runs in lockstep: the sim
+// consumed GRandGen a different number of times each run, which rarely (~10%) shifted an
+// AI soldier's head-look timer by one tick, altering its skinned head collision geometry
+// and hence a collision response — a determinism divergence only ever reproducible in the
+// rendered client (never under --simulate, which spawns no particles).  Effects now draw
+// from this independent stream; the simulation owns GRandGen exclusively.  Never use this
+// for anything that influences simulation state.
+inline RandomGenerator& GFxRandGen()
+{
+    static RandomGenerator instance;
+    return instance;
+}
+#define GFxRandGen GFxRandGen()
+
 #endif


### PR DESCRIPTION
## Problem

Cosmetic particle effects (smoke/dust/cloudlets in `Graphics/Rendering/Effects/Smokes.cpp`) draw the global `GRandGen` ~34× per particle per rendered frame.
The number of draws per frame is nondeterministic, particle spawn/lifecycle depends on camera, visibility and frame timing, and because `RandomGenerator::RandomValue()` returns `_valueTable[_seed++]` (the value depends only on the global draw count), that render-side consumption shifts the same global stream the simulation draws from.

So a rendered client's simulation RNG diverges run-to-run from a few seconds into a mission.
It's invisible to the headless/server sim (no particles are spawned there). I found it as a rare (~10%) divergence in a fixed-seed per-tick transform checksum: the desync occasionally shifts an AI soldier's head-look timer by one tick, which changes that soldier's skinned head collision geometry and hence a collision response.

This is a **local reproducibility / latent-nondeterminism** fix, not a networked-MP sync bug, MP is server-authoritative (clients extrapolate and get corrected by authoritative updates), so client-local RNG drift was always invisible to MP.

 ## Fix

Add a second RNG singleton `GFxRandGen` for cosmetic render/audio/UI effects, so the simulation owns `GRandGen` exclusively. Routed the cosmetic consumers to it:

- **Render:** `Smokes` particles, `Man::DrawNVOptics` (draw path)
- **Audio:** `DynSound`, `Speaker`
- **UI:** in-game HUD, menus, options, map

Sim-path consumers (AI decisions, collision, animation phase, `Head::Simulate`, `MoveInfo` animation-variant selection) keep drawing from `GRandGen`.
The stateless positional `RandomValue(x, z[, y])` (no `_seed++`) is never a desync source and is left untouched. `GFxRandGen` is an independent stream, never reseeded to the sim seed.