### PR TITLE
Fix uninitialised per-entity heap fields read during simulation

### DIFF
--- a/engine/Poseidon/World/Entities/Infantry/Head.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/Head.cpp
@@ -243,6 +243,18 @@ Head::Head(const HeadType& type, LODShape* lShape)
     SetGlasses(type, lShape, "None");
     SetMimic("Default");
 
+    // Random-lip state MUST be initialised: Head::Simulate reads all four fields
+    // every tick (the _wanted/_actual lerp and the `Glob.time >= _nextChangeRandomLip`
+    // trigger) unconditionally, not gated on _randomLip. Left uninitialised (the
+    // entity is heap-allocated with non-zeroing operator new), the trigger can fire
+    // spuriously and call NextRandomLip() -> GRandGen.RandomValue(), advancing the
+    // shared RNG stream by a run-dependent amount and desyncing MP / replays. The
+    // far-future _nextChangeRandomLip keeps the block a deterministic no-op until
+    // SetRandomLip() enables the feature (which re-initialises all four).
+    _actualRandomLip = 0;
+    _wantedRandomLip = 0;
+    _speedRandomLip = 0;
+    _nextChangeRandomLip = Glob.time + 1e10f;
     _randomLip = false;
 }
 

--- a/engine/Poseidon/World/Entities/Vehicles/Ground/Tank.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/Ground/Tank.cpp
@@ -50,6 +50,11 @@ Tank::Tank(VehicleType* name, Person* driver)
       _backwardUsedAsBrake(false), _forwardUsedAsBrake(false), _parkingBrake(false)
 {
     _rpm = 0.1f, _rpmWanted = 0.1f;
+    // Tank::Sound reads _doGearSound every simulation tick (`if (_doGearSound &&
+    // !_gearSound)`); the entity is heap-allocated with non-zeroing operator new
+    // and the ctor never set this bitfield, so it was read uninitialised. It is
+    // only meant to be raised on a gear change (see Simulate), so default false.
+    _doGearSound = false;
     // init gear box
     AutoArray<float> gears;
     gears.Add(0);


### PR DESCRIPTION
Heap-aware Valgrind memcheck (mimalloc built MI_TRACK_VALGRIND, so the heap is no longer hidden) found entity objects allocated via non-zeroing operator new whose fields are read every simulation tick before being set:

1. Head (soldier face),  _actualRandomLip / _wantedRandomLip / _speedRandomLip / _nextChangeRandomLip were never initialised by the ctor, only by SetRandomLip(). Head::Simulate reads all four every tick unconditionally, and `if (Glob.time >= _nextChangeRandomLip) NextRandomLip()` can fire on garbage and call GRandGen.RandomValue(), advancing the SHARED RNG stream by a run-dependent amount. That desyncs MP clients / replays, a real determinism bug, and a strong candidate for the rare (~few-%) sim-checksum divergence the determinism gate has been chasing. Initialise to a deterministic no-op state (far-future _nextChangeRandomLip) until SetRandomLip() enables the feature.

2. Tank::_doGearSound, bitfield read every tick in Tank::Sound (`if (_doGearSound && !_gearSound)`), never set by the ctor. Sound-only (not determinism-critical) but a genuine uninitialised read. Default it false.

Found via: PoseidonServer --render dummy --simulate <mission-dir> under memcheck --track-origins. Other flagged uninitialised reads were triaged as benign (fixed-buffer BString over-reads in config/bank loading, master-server network string building, and dummy-backend / boot-time config reads).