### PR TITLE
GL33 GPU skinning for infantry view LODs (opt-in, --gpu-skinning)

### DIFF
--- a/engine/Poseidon/Core/Config/EngineConfig.hpp
+++ b/engine/Poseidon/Core/Config/EngineConfig.hpp
@@ -108,6 +108,11 @@ public:
 	bool enableHWTL = true;
 	bool enablePIII = false;
 	int d3dAdapter = -1;
+	// GPU skinning master switch (default OFF).  Read by both World (Man::Animate,
+	// to retain the per-object bone palette) and the GL33 backend (to build
+	// SSkinnedVertex buffers + upload the BonePalette UBO).  Single source of
+	// truth so the two layers never disagree.  See PERF-gpu-skinning-scope.md.
+	bool enableGpuSkinning = false;
 };
 
 // Convenience macro for accessing engine config

--- a/engine/Poseidon/Foundation/Platform/AppConfig.cpp
+++ b/engine/Poseidon/Foundation/Platform/AppConfig.cpp
@@ -602,6 +602,9 @@ void AppConfig::ParseCommandLine(int argc, char** argv)
         auto* debugGroup = app.add_option_group("Debug & Testing", "Development and testing options");
 
         showOption(debugGroup->add_flag("--benchmark", _benchmark, "Benchmark mode"), CliHelpVisibility::Dev);
+        showOption(debugGroup->add_flag("--gpu-skinning", _gpuSkinning,
+                                        "Experimental: GPU-skin infantry view LODs (bind-pose static VBO + bone UBO)"),
+                   CliHelpVisibility::Dev);
 
         if (!BuildInfo::ReleaseBuild)
         {
@@ -1121,6 +1124,7 @@ void AppConfig::ApplyToLegacyGlobals()
     ENGINE_CONFIG.noTerrainCache = _noTerrainCache;
 
     // Debug & Testing
+    ENGINE_CONFIG.enableGpuSkinning = _gpuSkinning;
     ::Benchmark = _benchmark;
     ::GLogFileOps = _logFileOps;
 #ifdef NET_LOG_COMMAND_LINE

--- a/engine/Poseidon/Foundation/Platform/AppConfig.hpp
+++ b/engine/Poseidon/Foundation/Platform/AppConfig.hpp
@@ -423,6 +423,7 @@ private:
 
     // Debug & Testing
     bool _benchmark = false;
+    bool _gpuSkinning = false; // --gpu-skinning: GPU-skin infantry view LODs (experimental)
     bool _logFileOps = false;
     bool _netLog = false;
     bool _writeMPReport = false;

--- a/engine/Poseidon/Graphics/Core/Engine.hpp
+++ b/engine/Poseidon/Graphics/Core/Engine.hpp
@@ -488,6 +488,9 @@ class Engine : public IGraphicsEngine
     virtual void BeginMeshTL(const Shape& sMesh, int spec, bool dynamic = false) {} // convert all mesh vertices
     virtual void EndMeshTL(const Shape& sMesh) {}                                   // forget mesh
     virtual void DrawSectionTL(const Shape& sMesh, int beg, int end) {}
+    // Upload the per-object bone palette for the next skinned mesh draw (model-
+    // space bone matrices, 16 floats each).  No-op on backends without skinning.
+    virtual void UploadBonePalette(const float* mats, int count) {}
 
     virtual int HowLongIdle() { return 0; }
     virtual size_t GetDrawItemCount() const { return 0; }

--- a/engine/Poseidon/Graphics/Core/Engine.hpp
+++ b/engine/Poseidon/Graphics/Core/Engine.hpp
@@ -489,8 +489,9 @@ class Engine : public IGraphicsEngine
     virtual void EndMeshTL(const Shape& sMesh) {}                                   // forget mesh
     virtual void DrawSectionTL(const Shape& sMesh, int beg, int end) {}
     // Upload the per-object bone palette for the next skinned mesh draw (model-
-    // space bone matrices, 16 floats each).  No-op on backends without skinning.
-    virtual void UploadBonePalette(const float* mats, int count) {}
+    // space bone matrices).  The backend converts each Matrix4 into its own GPU
+    // matrix layout (as it does for the world matrix).  No-op without skinning.
+    virtual void UploadBonePalette(const Matrix4* mats, int count) {}
     // Route the following mesh section draws through the GPU-skinning vertex
     // shader (on) and back to the normal mesh shader (off).  Bracket one skinned
     // shape's section draws.  No-op on backends without skinning.

--- a/engine/Poseidon/Graphics/Core/Engine.hpp
+++ b/engine/Poseidon/Graphics/Core/Engine.hpp
@@ -491,6 +491,10 @@ class Engine : public IGraphicsEngine
     // Upload the per-object bone palette for the next skinned mesh draw (model-
     // space bone matrices, 16 floats each).  No-op on backends without skinning.
     virtual void UploadBonePalette(const float* mats, int count) {}
+    // Route the following mesh section draws through the GPU-skinning vertex
+    // shader (on) and back to the normal mesh shader (off).  Bracket one skinned
+    // shape's section draws.  No-op on backends without skinning.
+    virtual void SelectSkinnedMesh(bool on) {}
 
     virtual int HowLongIdle() { return 0; }
     virtual size_t GetDrawItemCount() const { return 0; }

--- a/engine/Poseidon/Graphics/Rendering/Primitives/Vertex.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Primitives/Vertex.cpp
@@ -86,6 +86,7 @@ void VertexTable::ReleaseTables()
     _norm.Clear();
     _orig.Clear();
     _origClip.Clear();
+    _skin.Clear();
 }
 void VertexTable::ReallocTable(int nPos)
 {
@@ -114,6 +115,7 @@ void VertexTable::DoConstruct(const VertexTable& src)
     _pos = src._pos;
     _clip = src._clip;
     _norm = src._norm;
+    _skin = src._skin;
     _orHints = src._orHints;
     _andHints = src._andHints;
 

--- a/engine/Poseidon/Graphics/Rendering/Primitives/Vertex.hpp
+++ b/engine/Poseidon/Graphics/Rendering/Primitives/Vertex.hpp
@@ -96,6 +96,18 @@ public:
 	virtual void Update(const Shape &src, bool dynamic) = 0;
 };
 
+// Per-vertex bone binding for GPU skinning: up to 4 (boneIndex, weight)
+// influences, quantized exactly as AnimationRTPair {char _sel; unsigned char
+// _weight} (_weight = weight * WeightScale, WeightScale=128).  Raw bytes only —
+// kept dependency-free so the Graphics layer carries them without pulling in the
+// Animation module.  A vertex with no influence has all weights 0; the skinning
+// VS treats a zero weight-sum as bind pose (identity).
+struct SkinVertexBinding
+{
+	unsigned char idx[4];
+	unsigned char weight[4];
+};
+
 // array of vertices, corresponds to vertex buffer
 
 class VertexTable : public RefCount
@@ -126,6 +138,10 @@ protected:
 	AutoArray<Vector3> _norm;
 
 	AutoArray<UVPair> _tex;
+
+	// Per-vertex GPU-skinning bone bindings, parallel to _pos.  Empty unless the
+	// shape was prepared for skinning (see Skeleton::Prepare); static per model/LOD.
+	AutoArray<SkinVertexBinding> _skin;
 
 	ClipFlags _orHints, _andHints; // we can do some optimizations based on this
 
@@ -233,6 +249,25 @@ public:
 
 	const UVPair &UV(int i) const { return _tex[i]; }
 	void SetUV(int i, float u, float v){ _tex[i].u = u, _tex[i].v = v; }
+
+	// GPU-skinning bone bindings.  HasSkin() is true only when a full per-vertex
+	// binding table has been built (parallel to _pos).  AllocSkin() sizes and
+	// zero-clears the table (all-zero = unweighted = bind pose); Skin()/SkinRW()
+	// access one vertex.
+	bool HasSkin() const { return _skin.Size() == _pos.Size() && _pos.Size() > 0; }
+	const SkinVertexBinding &Skin(int i) const { return _skin[i]; }
+	SkinVertexBinding &SkinRW(int i) { return _skin[i]; }
+	void AllocSkin(int nPos)
+	{
+		_skin.Realloc(nPos);
+		_skin.Resize(nPos);
+		for (int i = 0; i < nPos; i++)
+		{
+			SkinVertexBinding &b = _skin[i];
+			b.idx[0] = b.idx[1] = b.idx[2] = b.idx[3] = 0;
+			b.weight[0] = b.weight[1] = b.weight[2] = b.weight[3] = 0;
+		}
+	}
 
 	// vertex buffer style access
 	// add vertex, Objektiv point index known

--- a/engine/Poseidon/Graphics/Rendering/Primitives/Vertex.hpp
+++ b/engine/Poseidon/Graphics/Rendering/Primitives/Vertex.hpp
@@ -39,6 +39,11 @@ public:
 	virtual void GetMaterial(TLMaterial &mat, int index) const = 0;
 	// check if given shape is animated
 	virtual bool GetAnimated(const Shape &src) const = 0;
+	// GPU-skinning bone palette (model-space bone matrices, 16 floats each) for
+	// the shape about to be drawn.  Default: none, so animators that are not
+	// GPU-skinned need no override.  Objects that GPU-skin their view LOD retain
+	// the per-frame palette and return it here.
+	virtual void GetBonePalette(const Matrix4 *&mats, int &count) const { mats = nullptr; count = 0; }
 };
 
 // hints: different handling of object/surface relations
@@ -94,6 +99,10 @@ public:
 
 	// update vertices if necessary
 	virtual void Update(const Shape &src, bool dynamic) = 0;
+
+	// True when this buffer uses the skinned vertex layout (GPU skinning); the
+	// draw path then uploads the object's bone palette before the draw.
+	virtual bool IsSkinned() const { return false; }
 };
 
 // Per-vertex bone binding for GPU skinning: up to 4 (boneIndex, weight)

--- a/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
@@ -116,6 +116,8 @@ void Shape::Draw(class IAnimator* matSource, const LightList& lights, ClipFlags 
                 int palCount = 0;
                 matSource->GetBonePalette(pal, palCount);
                 engine->UploadBonePalette(reinterpret_cast<const float*>(pal), palCount);
+                // Route this shape's section draws through the skinning VS.
+                engine->SelectSkinnedMesh(true);
             }
             // check first face properties
             int secBeg = -1;
@@ -187,6 +189,11 @@ void Shape::Draw(class IAnimator* matSource, const LightList& lights, ClipFlags 
                 GEngine->DrawSectionTL(*this, secBeg, secEnd);
             }
 
+            if (_buffer->IsSkinned())
+            {
+                // Restore the normal mesh VS for subsequent (non-skinned) draws.
+                engine->SelectSkinnedMesh(false);
+            }
             engine->EndMeshTL(*this);
         }
     }

--- a/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
@@ -117,7 +117,7 @@ void Shape::Draw(class IAnimator* matSource, const LightList& lights, ClipFlags 
                 matSource->GetBonePalette(pal, palCount);
                 if (palCount > 0)
                 {
-                    engine->UploadBonePalette(reinterpret_cast<const float*>(pal), palCount);
+                    engine->UploadBonePalette(pal, palCount);
                     engine->SelectSkinnedMesh(true);
                     skinnedActive = true;
                 }

--- a/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
@@ -107,17 +107,24 @@ void Shape::Draw(class IAnimator* matSource, const LightList& lights, ClipFlags 
             // check if shape is dynamic or not
             bool dynamic = matSource->GetAnimated(*this);
             engine->BeginMeshTL(*this, spec, dynamic);
+            bool skinnedActive = false;
             if (_buffer->IsSkinned())
             {
-                // GPU skinning: push the object's bone palette to the backend
-                // once per skinned shape draw, before the section draws whose VS
-                // reads it.  Empty palette (count 0) is a no-op -> bind pose.
+                // GPU skinning: push the object's bone palette to the backend once
+                // per skinned shape draw, before the section draws whose VS reads it.
                 const Matrix4* pal = nullptr;
                 int palCount = 0;
                 matSource->GetBonePalette(pal, palCount);
-                engine->UploadBonePalette(reinterpret_cast<const float*>(pal), palCount);
-                // Route this shape's section draws through the skinning VS.
-                engine->SelectSkinnedMesh(true);
+                if (palCount > 0)
+                {
+                    engine->UploadBonePalette(reinterpret_cast<const float*>(pal), palCount);
+                    engine->SelectSkinnedMesh(true);
+                    skinnedActive = true;
+                }
+                // palCount == 0 (no active animation): draw the static bind pose
+                // through the normal mesh VS — the skinned VAO's locations 0-2 read
+                // pos/norm/uv fine — instead of skinning from a stale shared
+                // BonePalette UBO left by a previous object.
             }
             // check first face properties
             int secBeg = -1;
@@ -189,7 +196,7 @@ void Shape::Draw(class IAnimator* matSource, const LightList& lights, ClipFlags 
                 GEngine->DrawSectionTL(*this, secBeg, secEnd);
             }
 
-            if (_buffer->IsSkinned())
+            if (skinnedActive)
             {
                 // Restore the normal mesh VS for subsequent (non-skinned) draws.
                 engine->SelectSkinnedMesh(false);

--- a/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
@@ -107,6 +107,16 @@ void Shape::Draw(class IAnimator* matSource, const LightList& lights, ClipFlags 
             // check if shape is dynamic or not
             bool dynamic = matSource->GetAnimated(*this);
             engine->BeginMeshTL(*this, spec, dynamic);
+            if (_buffer->IsSkinned())
+            {
+                // GPU skinning: push the object's bone palette to the backend
+                // once per skinned shape draw, before the section draws whose VS
+                // reads it.  Empty palette (count 0) is a no-op -> bind pose.
+                const Matrix4* pal = nullptr;
+                int palCount = 0;
+                matSource->GetBonePalette(pal, palCount);
+                engine->UploadBonePalette(reinterpret_cast<const float*>(pal), palCount);
+            }
             // check first face properties
             int secBeg = -1;
             int secEnd = -1;

--- a/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
@@ -107,7 +107,7 @@ void Shape::Draw(class IAnimator* matSource, const LightList& lights, ClipFlags 
             // check if shape is dynamic or not
             bool dynamic = matSource->GetAnimated(*this);
             engine->BeginMeshTL(*this, spec, dynamic);
-            bool skinnedActive = false;
+            bool wantSkinned = false;
             if (_buffer->IsSkinned())
             {
                 // GPU skinning: push the object's bone palette to the backend once
@@ -118,14 +118,20 @@ void Shape::Draw(class IAnimator* matSource, const LightList& lights, ClipFlags 
                 if (palCount > 0)
                 {
                     engine->UploadBonePalette(pal, palCount);
-                    engine->SelectSkinnedMesh(true);
-                    skinnedActive = true;
+                    wantSkinned = true;
                 }
                 // palCount == 0 (no active animation): draw the static bind pose
                 // through the normal mesh VS — the skinned VAO's locations 0-2 read
                 // pos/norm/uv fine — instead of skinning from a stale shared
                 // BonePalette UBO left by a previous object.
             }
+            // Select the skinned/normal mesh VS for this shape.  Batched: this is a
+            // no-op when the state is unchanged, so a run of consecutive skinned
+            // shapes (a crowd of soldiers) shares ONE program bind instead of two
+            // program switches per shape — the switch happens only at a
+            // skinned<->non-skinned boundary.  There is deliberately no per-shape
+            // restore; the next shape (or a pass boundary) sets the correct state.
+            engine->SelectSkinnedMesh(wantSkinned);
             // check first face properties
             int secBeg = -1;
             int secEnd = -1;
@@ -196,11 +202,6 @@ void Shape::Draw(class IAnimator* matSource, const LightList& lights, ClipFlags 
                 GEngine->DrawSectionTL(*this, secBeg, secEnd);
             }
 
-            if (skinnedActive)
-            {
-                // Restore the normal mesh VS for subsequent (non-skinned) draws.
-                engine->SelectSkinnedMesh(false);
-            }
             engine->EndMeshTL(*this);
         }
     }

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOld.hpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOld.hpp
@@ -509,15 +509,8 @@ class Man: public Person
 	Matrix4 _legTrans;
 	bool _headTransIdent,_gunTransIdent;
 
-	// Retained per-frame GPU-skinning bone palette (model-space bone matrices),
-	// built in Man::Animate and consumed by the skinned draw via GetBonePalette.
-	// Empty while GPU skinning is off (ENGINE_CONFIG.enableGpuSkinning).
-	AutoArray<Matrix4> _bonePalette;
-	void GetBonePalette(const Matrix4 *&mats, int &count) const override
-	{
-		mats = _bonePalette.Data();
-		count = _bonePalette.Size();
-	}
+	// GPU-skinning bone palette is retained on the shared Object base (via
+	// RetainBonePalette / GetBonePalette); Man::Animate fills it below.
 
 	Vector3 _aimingPositionWorld;
 	Vector3 _cameraPositionWorld;

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOld.hpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOld.hpp
@@ -509,6 +509,16 @@ class Man: public Person
 	Matrix4 _legTrans;
 	bool _headTransIdent,_gunTransIdent;
 
+	// Retained per-frame GPU-skinning bone palette (model-space bone matrices),
+	// built in Man::Animate and consumed by the skinned draw via GetBonePalette.
+	// Empty while GPU skinning is off (ENGINE_CONFIG.enableGpuSkinning).
+	AutoArray<Matrix4> _bonePalette;
+	void GetBonePalette(const Matrix4 *&mats, int &count) const override
+	{
+		mats = _bonePalette.Data();
+		count = _bonePalette.Size();
+	}
+
 	Vector3 _aimingPositionWorld;
 	Vector3 _cameraPositionWorld;
 

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
@@ -993,8 +993,13 @@ void Man::Animate(int level)
         if (ENGINE_CONFIG.enableGpuSkinning)
         {
             const int nb = matrix.Size();
-            _bonePalette.Realloc(nb);
-            _bonePalette.Resize(nb);
+            // Reallocate only when the bone count actually changes (it is constant
+            // per skeleton) — a per-frame Realloc for every unit was heap churn.
+            if (_bonePalette.Size() != nb)
+            {
+                _bonePalette.Realloc(nb);
+                _bonePalette.Resize(nb);
+            }
             for (int i = 0; i < nb; i++)
             {
                 _bonePalette[i] = matrix[i];

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
@@ -975,6 +975,20 @@ void Man::Animate(int level)
         }
 
         AnimationRT::ApplyMatrices(type->GetWeights(), _shape, level, matrix);
+
+        // GPU skinning: retain this frame's bone palette on the object so the
+        // skinned view-LOD draw can upload it (see Man::GetBonePalette).  Gated
+        // so the default CPU-skinning path pays nothing.
+        if (ENGINE_CONFIG.enableGpuSkinning)
+        {
+            const int nb = matrix.Size();
+            _bonePalette.Realloc(nb);
+            _bonePalette.Resize(nb);
+            for (int i = 0; i < nb; i++)
+            {
+                _bonePalette[i] = matrix[i];
+            }
+        }
     }
 
     BasicAnimation(level);

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
@@ -974,7 +974,18 @@ void Man::Animate(int level)
                                           legsRes.Size());
         }
 
-        AnimationRT::ApplyMatrices(type->GetWeights(), _shape, level, matrix);
+        // CPU-skin the shape's vertices — UNLESS this LOD is GPU-skinned.  A
+        // GPU-skinned LOD's VBO holds the static bind pose and the vertex shader
+        // skins from the bone palette (retained below), so the per-vertex CPU
+        // transform is pure waste for it; skipping it removes the
+        // ApplyMatricesComplex cost for the drawn view LOD.  HasSkin() is true
+        // only for infantry graphical LODs (Skeleton::Prepare gpuSkin gating), so
+        // coarse LODs (collision/shadow/bounding) still CPU-skin here, unchanged.
+        const bool gpuSkinned = ENGINE_CONFIG.enableGpuSkinning && shape->HasSkin();
+        if (!gpuSkinned)
+        {
+            AnimationRT::ApplyMatrices(type->GetWeights(), _shape, level, matrix);
+        }
 
         // GPU skinning: retain this frame's bone palette on the object so the
         // skinned view-LOD draw can upload it (see Man::GetBonePalette).  Gated

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
@@ -987,23 +987,12 @@ void Man::Animate(int level)
             AnimationRT::ApplyMatrices(type->GetWeights(), _shape, level, matrix);
         }
 
-        // GPU skinning: retain this frame's bone palette on the object so the
-        // skinned view-LOD draw can upload it (see Man::GetBonePalette).  Gated
-        // so the default CPU-skinning path pays nothing.
+        // GPU skinning: retain this frame's bone palette on the shared Object
+        // base so the skinned view-LOD draw can upload it (see GetBonePalette).
+        // Gated so the default CPU-skinning path pays nothing.
         if (ENGINE_CONFIG.enableGpuSkinning)
         {
-            const int nb = matrix.Size();
-            // Reallocate only when the bone count actually changes (it is constant
-            // per skeleton) — a per-frame Realloc for every unit was heap churn.
-            if (_bonePalette.Size() != nb)
-            {
-                _bonePalette.Realloc(nb);
-                _bonePalette.Resize(nb);
-            }
-            for (int i = 0; i < nb; i++)
-            {
-                _bonePalette[i] = matrix[i];
-            }
+            RetainBonePalette(matrix.Data(), matrix.Size());
         }
     }
 

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
@@ -1078,7 +1078,9 @@ MovesType::MovesType(const MovesTypeName& name)
         AnimationRT* anim = moveI;
         if (anim)
         {
-            _name.motionType->GetSkeleton()->Prepare(shape, GetWeights());
+            // gpuSkin=true: infantry is the only object that retains a bone
+            // palette, so only its graphical LODs get GPU-skinning bindings.
+            _name.motionType->GetSkeleton()->Prepare(shape, GetWeights(), true);
             anim->SetLooped((*entry) >> "looped");
         }
     }

--- a/engine/Poseidon/World/Entities/Vehicles/Ground/Car.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/Ground/Car.cpp
@@ -519,6 +519,12 @@ void Car::Animate(int level)
 
     DammageAnimation(level);
 
+    // NOTE: deliberately CPU-only (no skinTarget passed to Apply). The Car/Scud
+    // shape mixes this skeletal scud animation with CPU direct-selection vertex
+    // animation (wheels, driving wheel, turret, damage — the *.Apply calls
+    // above). GPU skinning uploads a static bind-pose VBO and skins only from the
+    // bone palette, which would freeze those non-skeletal deformations. Its
+    // skeleton is therefore Prepared with gpuSkin=false, and Skin() stays empty.
     if (_scudState >= 1 && _scudState < 2 && Type()->_scudLaunch)
     {
         float time = _scudState - 1;

--- a/engine/Poseidon/World/Entities/Vehicles/Parachute.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/Parachute.cpp
@@ -85,14 +85,18 @@ void ParachuteType::InitShape()
     name.skeleton = _skeleton;
     name.name = "anim\\opening_para.rtm";
 
+    // gpuSkin=true: the parachute's view-LOD deformation is entirely skeletal
+    // (open/drop) — unlike the Scud/Car, which mix skeletal skinning with
+    // CPU direct-selection wheel/turret animation and so must stay CPU — so its
+    // graphical LODs are safe to GPU-skin. Retains a bone palette on Object.
     _open = new AnimationRT(name);
-    _open->Prepare(_shape, _skeleton, *_weights, false);
+    _open->Prepare(_shape, _skeleton, *_weights, false, true);
     _open->AddPreloadCount();
     _open->IntroduceStep();
 
     name.name = "anim\\opened_para_stat.rtm";
     _drop = new AnimationRT(name);
-    _drop->Prepare(_shape, _skeleton, *_weights, false);
+    _drop->Prepare(_shape, _skeleton, *_weights, false, true);
     _drop->IntroduceStep();
     _drop->AddPreloadCount();
 }
@@ -635,13 +639,13 @@ void Parachute::Animate(int level)
     {
         float time = _openState - 1;
         saturate(time, 0, 1);
-        Type()->_open->Apply(*Type()->_weights, _shape, level, time);
+        Type()->_open->Apply(*Type()->_weights, _shape, level, time, this);
     }
     else
     {
         float time = _openState - 2;
         saturate(time, 0, 1);
-        Type()->_drop->Apply(*Type()->_weights, _shape, level, time);
+        Type()->_drop->Apply(*Type()->_weights, _shape, level, time, this);
     }
 
     base::Animate(level);

--- a/engine/Poseidon/World/Scene/Object.cpp
+++ b/engine/Poseidon/World/Scene/Object.cpp
@@ -1626,6 +1626,21 @@ bool Object::GetAnimated(const Shape& src) const
     return _isDestroyed && _destroyPhase > 0 && GetDestructType() != DestructTree;
 }
 
+void Object::RetainBonePalette(const Matrix4* mats, int count)
+{
+    // Reallocate only when the bone count actually changes (it is constant per
+    // skeleton) — a per-frame Realloc for every unit was measurable heap churn.
+    if (_bonePalette.Size() != count)
+    {
+        _bonePalette.Realloc(count);
+        _bonePalette.Resize(count);
+    }
+    for (int i = 0; i < count; i++)
+    {
+        _bonePalette[i] = mats[i];
+    }
+}
+
 #if SUPPORT_RANDOM_SHAPES
 LODShapeWithShadow* Object::GetShapeOnPos(Vector3Val pos) const
 {

--- a/engine/Poseidon/World/Scene/Object.hpp
+++ b/engine/Poseidon/World/Scene/Object.hpp
@@ -252,6 +252,13 @@ class Object: public NetworkObject, public FrameBase, public IAnimator
 	// quick link to object shadow
 	SRef<ShadowIndex> _shadow;
 
+	// Retained per-frame GPU-skinning bone palette (model-space bone matrices),
+	// built during Animate and consumed by the skinned view-LOD draw via
+	// GetBonePalette. Shared by every skinned animator (infantry and skeletal
+	// vehicles/props). Empty while GPU skinning is off, so the default CPU path
+	// pays nothing.
+	AutoArray<Matrix4> _bonePalette;
+
 	public:
 
 	Object(LODShapeWithShadow *shape, int id);
@@ -501,6 +508,18 @@ class Object: public NetworkObject, public FrameBase, public IAnimator
 		int spec, int material, int from, int to
 	) const override;
 	bool GetAnimated(const Shape &src) const override;
+	// GPU-skinning: return the palette retained this frame by Animate. Empty when
+	// GPU skinning is off or there is no active animation this frame — the skinned
+	// draw then falls back to the static bind pose. See RetainBonePalette.
+	void GetBonePalette(const Matrix4 *&mats, int &count) const override
+	{
+		mats = _bonePalette.Data();
+		count = _bonePalette.Size();
+	}
+	// Copy this frame's bone matrices into the retained palette so the skinned
+	// draw can upload them. Reallocates only on a bone-count change (constant per
+	// skeleton), avoiding per-frame heap churn.
+	void RetainBonePalette(const Matrix4 *mats, int count);
 
 	// Get/Set object shape
 	__forceinline LODShapeWithShadow *GetShape() const {return _shape;}

--- a/engine/Poseidon/World/Simulation/Animation/RtAnimation.cpp
+++ b/engine/Poseidon/World/Simulation/Animation/RtAnimation.cpp
@@ -12,6 +12,8 @@
 #include <Poseidon/Foundation/Math/MathDefs.hpp>
 #include <Poseidon/Foundation/Memory/FastAlloc.hpp>
 #include <Poseidon/Foundation/platform.hpp>
+#include <Poseidon/World/Scene/Object.hpp>       // RetainBonePalette (GPU-skin target)
+#include <Poseidon/Core/Config/EngineConfig.hpp> // ENGINE_CONFIG.enableGpuSkinning
 
 namespace Poseidon
 {
@@ -770,9 +772,12 @@ void Skeleton::Prepare(LODShape* lShape, WeightInfo& weights, bool gpuSkin)
         // shadow-volume, memory: Resolution >= 1000) stay on the CPU path: they
         // feed collision / shadow / bounding, which must remain bit-identical for
         // MP determinism, and the shadow pass draws them with the non-skinned VS.
-        // gpuSkin is passed true only by the infantry skeleton prepare — the only
-        // object that retains a bone palette (Man::GetBonePalette); vehicles with
-        // skeletal anims (scud, parachute) leave it default-false and stay CPU.
+        // gpuSkin is passed true by proxies whose graphical-LOD deformation is
+        // ENTIRELY skeletal and that retain a bone palette on Object
+        // (GetBonePalette): infantry (Man) and the parachute. Vehicles that mix
+        // skeletal skinning with CPU direct-selection vertex animation (the
+        // Scud/Car — wheels, turret) leave it default-false and stay CPU, else
+        // GPU skinning's static bind-pose VBO would freeze those deformations.
         if (gpuSkin && lShape->Resolution(level) < 1000)
         {
             const AnimationRTWeights& w = weights[level];
@@ -1050,7 +1055,7 @@ void AnimationRT::ApplyMatrices(const WeightInfo& lWeights, LODShape* lShape, in
     }
 }
 
-void AnimationRT::Apply(const WeightInfo& lWeights, LODShape* lShape, int level, float time) const
+void AnimationRT::Apply(const WeightInfo& lWeights, LODShape* lShape, int level, float time, Object* skinTarget) const
 {
     if (_nPhases <= 0)
     {
@@ -1066,7 +1071,21 @@ void AnimationRT::Apply(const WeightInfo& lWeights, LODShape* lShape, int level,
     MATRIX_4_ARRAY(matrix, 128);
     PrepareMatrices(matrix, time, 1);
 
-    ApplyMatrices(lWeights, lShape, level, matrix);
+    // GPU-skinning-aware path (mirrors Man::Animate). When this LOD is
+    // GPU-skinned the VBO holds the static bind pose and the vertex shader skins
+    // from the retained palette, so the per-vertex CPU transform is pure waste —
+    // skip it and just retain the palette. HasSkin() is true only for graphical
+    // LODs the caller opted into (Skeleton::Prepare gpuSkin), so coarse
+    // collision/shadow LODs still CPU-skin here, bit-identical for MP determinism.
+    const bool gpuSkinned = skinTarget != nullptr && ENGINE_CONFIG.enableGpuSkinning && shape->HasSkin();
+    if (!gpuSkinned)
+    {
+        ApplyMatrices(lWeights, lShape, level, matrix);
+    }
+    if (skinTarget != nullptr && ENGINE_CONFIG.enableGpuSkinning)
+    {
+        skinTarget->RetainBonePalette(matrix.Data(), matrix.Size());
+    }
 }
 
 void AnimationRT::PrepareMatrices(Matrix4Array& matrix, float time, float factor) const

--- a/engine/Poseidon/World/Simulation/Animation/RtAnimation.cpp
+++ b/engine/Poseidon/World/Simulation/Animation/RtAnimation.cpp
@@ -736,7 +736,7 @@ void AnimationRT::SetLooped(bool looped)
     RemoveLoopFrame();
 }
 
-void Skeleton::Prepare(LODShape* lShape, WeightInfo& weights)
+void Skeleton::Prepare(LODShape* lShape, WeightInfo& weights, bool gpuSkin)
 {
     for (int level = 0; level < lShape->NLevels(); level++)
     {
@@ -764,29 +764,41 @@ void Skeleton::Prepare(LODShape* lShape, WeightInfo& weights)
         // so the skinning VS reproduces the CPU skin bit-for-bit in intent.
         // Unweighted vertices keep the all-zero binding AllocSkin() cleared them
         // to (weight-sum 0 -> the VS falls back to bind pose).
-        const AnimationRTWeights& w = weights[level];
-        shape->AllocSkin(shape->NPos());
-        for (int i = 0; i < shape->NPos(); i++)
+        //
+        // Only when the caller opts in (gpuSkin) and only for GRAPHICAL LODs
+        // (Resolution < 1000 — the drawn view LODs).  Special LODs (geometry,
+        // shadow-volume, memory: Resolution >= 1000) stay on the CPU path: they
+        // feed collision / shadow / bounding, which must remain bit-identical for
+        // MP determinism, and the shadow pass draws them with the non-skinned VS.
+        // gpuSkin is passed true only by the infantry skeleton prepare — the only
+        // object that retains a bone palette (Man::GetBonePalette); vehicles with
+        // skeletal anims (scud, parachute) leave it default-false and stay CPU.
+        if (gpuSkin && lShape->Resolution(level) < 1000)
         {
-            const AnimationRTWeight& e = w[i];
-            SkinVertexBinding& b = shape->SkinRW(i);
-            int n = e.Size();
-            if (n > 4)
+            const AnimationRTWeights& w = weights[level];
+            shape->AllocSkin(shape->NPos());
+            for (int i = 0; i < shape->NPos(); i++)
             {
-                n = 4;
-            }
-            for (int j = 0; j < n; j++)
-            {
-                b.idx[j] = static_cast<unsigned char>(e[j].GetSel());
-                b.weight[j] = e[j]._weight;
+                const AnimationRTWeight& e = w[i];
+                SkinVertexBinding& b = shape->SkinRW(i);
+                int n = e.Size();
+                if (n > 4)
+                {
+                    n = 4;
+                }
+                for (int j = 0; j < n; j++)
+                {
+                    b.idx[j] = static_cast<unsigned char>(e[j].GetSel());
+                    b.weight[j] = e[j]._weight;
+                }
             }
         }
     }
 }
 
-void AnimationRT::Prepare(LODShape* lShape, Skeleton* skelet, WeightInfo& weights, bool looped)
+void AnimationRT::Prepare(LODShape* lShape, Skeleton* skelet, WeightInfo& weights, bool looped, bool gpuSkin)
 {
-    skelet->Prepare(lShape, weights);
+    skelet->Prepare(lShape, weights, gpuSkin);
     SetLooped(looped);
 }
 

--- a/engine/Poseidon/World/Simulation/Animation/RtAnimation.cpp
+++ b/engine/Poseidon/World/Simulation/Animation/RtAnimation.cpp
@@ -757,6 +757,30 @@ void Skeleton::Prepare(LODShape* lShape, WeightInfo& weights)
         }
         // normalize loaded weighting information
         weights[level].Normalize();
+
+        // Publish per-vertex bone bindings onto the shape for GPU skinning.  The
+        // quantization matches the CPU ApplyMatrices path exactly (bone index =
+        // AnimationRTPair::GetSel(), weight byte = _weight = weight*WeightScale),
+        // so the skinning VS reproduces the CPU skin bit-for-bit in intent.
+        // Unweighted vertices keep the all-zero binding AllocSkin() cleared them
+        // to (weight-sum 0 -> the VS falls back to bind pose).
+        const AnimationRTWeights& w = weights[level];
+        shape->AllocSkin(shape->NPos());
+        for (int i = 0; i < shape->NPos(); i++)
+        {
+            const AnimationRTWeight& e = w[i];
+            SkinVertexBinding& b = shape->SkinRW(i);
+            int n = e.Size();
+            if (n > 4)
+            {
+                n = 4;
+            }
+            for (int j = 0; j < n; j++)
+            {
+                b.idx[j] = static_cast<unsigned char>(e[j].GetSel());
+                b.weight[j] = e[j]._weight;
+            }
+        }
     }
 }
 

--- a/engine/Poseidon/World/Simulation/Animation/RtAnimation.hpp
+++ b/engine/Poseidon/World/Simulation/Animation/RtAnimation.hpp
@@ -272,9 +272,15 @@ class AnimationRT: public RefCount, public CLDLink
 		const Matrix4Array &matrices, int pointIndex
 	);
 
+	// skinTarget: when non-null and GPU skinning is enabled for this LOD
+	// (Object retains a palette + shape->HasSkin()), the per-vertex CPU skin is
+	// skipped and this frame's palette is retained on skinTarget for the vertex
+	// shader to skin from a static bind-pose VBO. Default (null) keeps the pure
+	// CPU path, unchanged, for every existing caller.
 	void Apply
 	(
-		const WeightInfo &lWeights, LODShape *lShape, int level, float time
+		const WeightInfo &lWeights, LODShape *lShape, int level, float time,
+		class Object *skinTarget = nullptr
 	) const;
 	void Matrix
 	(

--- a/engine/Poseidon/World/Simulation/Animation/RtAnimation.hpp
+++ b/engine/Poseidon/World/Simulation/Animation/RtAnimation.hpp
@@ -137,7 +137,7 @@ class Skeleton: public RefCountWithLinks
 	int NBones() const {return _matrixNames.Size();}
 	RStringB GetBone( int i ) const {return _matrixNames[i];}
 
-	void Prepare(LODShape *lShape, WeightInfo &weights);
+	void Prepare(LODShape *lShape, WeightInfo &weights, bool gpuSkin = false);
 };
 
 template<>
@@ -293,7 +293,7 @@ class AnimationRT: public RefCount, public CLDLink
 	int GetKeyframeCount() const {return _nPhases;}
 	const Skeleton *GetSkeleton() const {return _name.skeleton;}
 
-	void Prepare(LODShape *lShape, Skeleton *skelet, WeightInfo &weights, bool looped);
+	void Prepare(LODShape *lShape, Skeleton *skelet, WeightInfo &weights, bool looped, bool gpuSkin = false);
 	void RemoveLoopFrame();
 	void ForceMatrixOrientation(int matIndex, const Matrix3 &orient, float factor);
 	void IntroduceStep();

--- a/engine/Poseidon/World/Viewer.cpp
+++ b/engine/Poseidon/World/Viewer.cpp
@@ -170,7 +170,10 @@ void ObjectViewer::SetExternalAnimation(const char* animPath)
     name.name = animPath;
     name.skeleton = _externalSkeleton;
     _externalAnim = new AnimationRT(name, false);
-    _externalAnim->Prepare(_shape, _externalSkeleton, _externalWeights, false);
+    // gpuSkin follows the CLI flag so `--viewer --gpu-skinning` exercises the
+    // real GPU-skin path (skin bindings on the graphical LODs) in isolation —
+    // the paired palette retention is in Animate(). Off => bit-identical CPU.
+    _externalAnim->Prepare(_shape, _externalSkeleton, _externalWeights, false, ENGINE_CONFIG.enableGpuSkinning);
     LOG_INFO(Core, "Viewer: bound external animation {}", animPath);
 }
 
@@ -178,7 +181,11 @@ void ObjectViewer::Animate(int level)
 {
     if (_externalAnim)
     {
-        _externalAnim->Apply(_externalWeights, _shape, level, _animPhase);
+        // Pass `this` as the GPU-skin target: when --gpu-skinning is on and this
+        // LOD has skin bindings, Apply skips the CPU skin and retains the bone
+        // palette on the Object base for the skinned draw (same seam as Man /
+        // Parachute). Null-effect otherwise.
+        _externalAnim->Apply(_externalWeights, _shape, level, _animPhase, this);
         return;
     }
     Shape* shape = _shape->Level(level);

--- a/engine/PoseidonGL33/EngineGL33.hpp
+++ b/engine/PoseidonGL33/EngineGL33.hpp
@@ -226,6 +226,14 @@ struct SSkinnedVertex
 // `<dir>/<name>.glsl` over the inline source.  Empty = inline only.
 void SetShaderOverrideDir(const std::string& dir);
 
+// GPU-skinning master switch (default OFF).  When ON, per-shape VBOs built from
+// shapes that carry skin bindings (Shape::HasSkin) use the SSkinnedVertex layout
+// and upload static bone attributes; the skinning VS + view-LOD static path
+// complete the feature.  While OFF the mesh path is byte-identical to the CPU
+// T&L renderer.
+void SetGpuSkinningEnabled(bool on);
+bool GpuSkinningEnabled();
+
 class EngineGL33 : public Engine
 {
     typedef Engine base;

--- a/engine/PoseidonGL33/EngineGL33.hpp
+++ b/engine/PoseidonGL33/EngineGL33.hpp
@@ -812,7 +812,7 @@ class EngineGL33 : public Engine
         return pure;
     }
     void UploadWorldInstances(const float* matrices, int count);
-    void UploadBonePalette(const float* mats, int count) override;
+    void UploadBonePalette(const Matrix4* mats, int count) override;
     void SelectSkinnedMesh(bool on) override;
     // Run accumulation: Scene adds model-to-world transforms; the engine
     // converts (camera-relative GfxMatrix) and uploads on BeginInstancedRunUpload.

--- a/engine/PoseidonGL33/EngineGL33.hpp
+++ b/engine/PoseidonGL33/EngineGL33.hpp
@@ -100,7 +100,8 @@ enum VertexShaderID
 {
     VSScreen,
     VSTransform,
-    VSShadow, // unlit transform, shadow path
+    VSShadow,  // unlit transform, shadow path
+    VSSkinned, // GPU-skinned variant of VSTransform (BonePalette UBO)
     NVertexShaders,
     VSNone = NVertexShaders
 };
@@ -477,6 +478,9 @@ class EngineGL33 : public Engine
     PSConstants _psConstants;
 
     VertexShaderID _vertexShaderSel = VSNone;
+    // While true, mesh VS selection remaps VSTransform -> VSSkinned (GPU skinning).
+    // Bracketed around one skinned shape's section draws by SelectSkinnedMesh().
+    bool _meshSkinnedActive = false;
     // _frameState.fogParams[] is the single source of truth for the shader fog
     // uniform; SetShaderFogEnabled mutates it in place so subsequent
     // UploadFrameConstants re-uploads (e.g. from EnableSunLight) preserve
@@ -809,6 +813,7 @@ class EngineGL33 : public Engine
     }
     void UploadWorldInstances(const float* matrices, int count);
     void UploadBonePalette(const float* mats, int count) override;
+    void SelectSkinnedMesh(bool on) override;
     // Run accumulation: Scene adds model-to-world transforms; the engine
     // converts (camera-relative GfxMatrix) and uploads on BeginInstancedRunUpload.
     void InstancedRunReset() override { _instPending = 0; }

--- a/engine/PoseidonGL33/EngineGL33.hpp
+++ b/engine/PoseidonGL33/EngineGL33.hpp
@@ -808,6 +808,7 @@ class EngineGL33 : public Engine
         return pure;
     }
     void UploadWorldInstances(const float* matrices, int count);
+    void UploadBonePalette(const float* mats, int count) override;
     // Run accumulation: Scene adds model-to-world transforms; the engine
     // converts (camera-relative GfxMatrix) and uploads on BeginInstancedRunUpload.
     void InstancedRunReset() override { _instPending = 0; }

--- a/engine/PoseidonGL33/EngineGL33.hpp
+++ b/engine/PoseidonGL33/EngineGL33.hpp
@@ -203,6 +203,24 @@ struct SVertex
     Poseidon::UVPair t0;
 };
 
+// Skinned mesh vertex — SVertex plus per-vertex bone bindings, used ONLY by
+// per-shape skinned VBOs (GPU skinning).  Deliberately NOT an extension of
+// SVertex: the global `_vaoMesh` streaming VAO reads a TLVertex buffer at
+// `sizeof(SVertex)` stride (see EngineGL33_2DRendering.cpp), so growing SVertex
+// would corrupt that path.  boneIdx/boneWeight map 1:1 onto AnimationRTPair
+// {char _sel; unsigned char _weight}, with _weight quantized by WeightScale=128
+// — both are uploaded as raw bytes and read as INTEGER attributes in the VS,
+// where the weight is rescaled by 1/128 (NOT the /255 an OpenGL-normalized
+// unsigned-byte read would give).  Up to 4 bones/vertex (matches ARTWMaxSize).
+struct SSkinnedVertex
+{
+    Vector3P pos;
+    Vector3P norm;
+    Poseidon::UVPair t0;
+    unsigned char boneIdx[4];    // AnimationRTPair::_sel per influencing bone
+    unsigned char boneWeight[4]; // AnimationRTPair::_weight (value * WeightScale)
+};
+
 // Free-function override for hot-reload — when set (typically via CLI
 // --shader-override-dir), GL33's CompileGLShader prefers
 // `<dir>/<name>.glsl` over the inline source.  Empty = inline only.

--- a/engine/PoseidonGL33/EngineGL33_Queue.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Queue.cpp
@@ -316,6 +316,11 @@ void EngineGL33::BeginPass(PassId passId)
     SwitchPassDebugGroup(PassIdName(passId));
     _activePassId = passId;
 
+    // Start every pass on the non-skinned mesh VS.  GPU skinning batches its
+    // program state across shapes (no per-shape restore), so clear the flag here
+    // as a safety net — a stale skinned state must never leak into a pass whose
+    // draws don't go through Shape::Draw's per-shape SelectSkinnedMesh.
+    _meshSkinnedActive = false;
     SelectVertexShader(VSTransform);
     // BeginPass bootstraps the 3D pass through the normal mesh shader before
     // the first descriptor-owned draw. If the previous 3D draw had the same

--- a/engine/PoseidonGL33/EngineGL33_Shaders.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Shaders.cpp
@@ -195,6 +195,156 @@ void main() {
 }
 )";
 
+// vsSkinned — GPU-skinned variant of vsTransform.  Identical UBOs / outs / lit
+// body; the only difference is that `pos`/`normal` are first transformed by the
+// per-vertex bone-matrix blend (BonePalette UBO, binding 3) before the world
+// transform.  Kept as a full standalone shader so vsTransform (the hot default
+// path) is never touched.  Bone attributes are integer (locations 3/4); the
+// weight byte is rescaled by 1/128 (AnimationRTPair::WeightScale), matching the
+// CPU ApplyMatricesComplex quantization exactly.  Because the (normalized)
+// weights sum to 1, blending the matrices then transforming reproduces the CPU's
+// per-bone transform-then-sum.  Requires the VBO to hold bind-pose (OrigPos).
+static const char s_vsSkinnedGLSL[] = R"(#version 330 core
+layout(std140) uniform VSConstants {
+    mat4 proj;          // c0-c3
+    mat4 view;          // c4-c7
+    mat4 world;         // c8-c11
+    vec4 sunDir;        // c12
+    vec4 ambient;       // c13
+    vec4 diffuse;       // c14
+    vec4 emissive;      // c15
+    vec4 fogParam;      // c16: {start, invRange, enabled, 0}
+    vec4 camPos;        // c17
+    vec4 specular;      // c18: rgb + power(w)
+    vec4 specEn;        // c19: {enabled, 0, 0, 0}
+    vec4 sunEn;         // c20: {enabled, 0, 0, 0}
+    vec4 vpScale;       // c21: {2/width, 2/height, 0, 0} — VSScreen only, declared here for layout parity
+    vec4 _pad22;
+    vec4 _pad23;
+    mat4 texMat0;       // c24-c27
+    mat4 texMat1;       // c28-c31
+    vec4 texCtrl;       // c32: {genTex0, genTex1, 0, 0}
+    vec4 lightCount;        // c33: x = active local light count
+    vec4 lightPos[8];       // c34-c41: xyz world pos, w = startAtten
+    vec4 lightDiffuse[8];   // c42-c49: diffuse * nightEffect
+    vec4 lightAmbient[8];   // c50-c57: ambient * nightEffect
+    vec4 localLightDir[8];  // c58-c65: xyz beam dir (world), w = isSpot
+    mat4 lightVP;           // c66-c69: shadow-map light view-projection (sampled per fragment)
+};
+
+layout(std140) uniform WorldInstances {
+    mat4 worldArr[256];
+};
+
+layout(std140) uniform BonePalette {
+    mat4 bones[128];
+};
+
+layout(location = 0) in vec3 pos;
+layout(location = 1) in vec3 normal;
+layout(location = 2) in vec2 uv;
+layout(location = 3) in uvec4 boneIdx;
+layout(location = 4) in uvec4 boneWeight;
+
+out vec4 vColor;
+out vec4 vSpecColor;
+out vec2 vUV0;
+out vec2 vUV1;
+out float vFogTC;
+out vec3 vWorldRel;
+
+void main() {
+    // Blend the (up to 4) influencing bone matrices by weight; the weight byte is
+    // the CPU AnimationRTPair::_weight (weight * 128).  Unweighted vertices (all
+    // weights 0) fall back to the bind pose.
+    float w0 = float(boneWeight.x) * (1.0 / 128.0);
+    float w1 = float(boneWeight.y) * (1.0 / 128.0);
+    float w2 = float(boneWeight.z) * (1.0 / 128.0);
+    float w3 = float(boneWeight.w) * (1.0 / 128.0);
+    float wsum = w0 + w1 + w2 + w3;
+    vec3 sp;
+    vec3 sn;
+    if (wsum > 0.0) {
+        mat4 skinMat = bones[boneIdx.x] * w0 + bones[boneIdx.y] * w1
+                     + bones[boneIdx.z] * w2 + bones[boneIdx.w] * w3;
+        sp = (skinMat * vec4(pos, 1.0)).xyz;
+        sn = mat3(skinMat) * normal;
+    } else {
+        sp = pos;
+        sn = normal;
+    }
+
+    vec4 worldPos    = worldArr[gl_InstanceID] * vec4(sp, 1.0);
+    vec3 worldNormal = normalize(mat3(worldArr[gl_InstanceID]) * sn);
+    vec4 viewPos     = view * worldPos;
+    gl_Position      = proj * viewPos;
+    vWorldRel        = worldPos.xyz; // camera-relative world pos for cascade shadow lookup
+
+    float NdotL = max(0.0, dot(worldNormal, -sunDir.xyz));
+    vec4 litColor;
+    litColor.rgb = emissive.rgb + ambient.rgb * sunEn.x + diffuse.rgb * NdotL * sunEn.x;
+    litColor.a   = emissive.a   + ambient.a   * sunEn.x + diffuse.a   * NdotL * sunEn.x;
+
+    const float MIN_INSIDE2 = 0.95677279; // (cos 12deg)^2
+    const float MAX_INSIDE2 = 0.98063081; // (cos 8deg)^2
+    int nLights = int(lightCount.x);
+    for (int i = 0; i < nLights; i++)
+    {
+        vec3 toLight = lightPos[i].xyz - worldPos.xyz;
+        float size2 = dot(toLight, toLight);
+        float startAtten2 = lightPos[i].w * lightPos[i].w;
+        float endAtten2 = startAtten2 * 100.0;
+        if (size2 >= endAtten2)
+            continue;
+
+        float cone = 1.0;
+        if (localLightDir[i].w > 0.5)
+        {
+            float inside = -dot(toLight, localLightDir[i].xyz);
+            if (inside <= 0.0)
+                continue;
+            float cos2 = (inside * inside) / size2;
+            if (cos2 < MIN_INSIDE2)
+                continue;
+            cone = clamp((cos2 - MIN_INSIDE2) / (MAX_INSIDE2 - MIN_INSIDE2), 0.0, 1.0);
+        }
+
+        float atten = (size2 >= startAtten2) ? (startAtten2 / size2) : 1.0;
+        float cosFi = dot(toLight, worldNormal);
+        vec3 contrib;
+        if (cosFi > 0.0)
+        {
+            cosFi *= inversesqrt(size2);
+            contrib = (lightDiffuse[i].rgb * cosFi + lightAmbient[i].rgb) * (atten * cone);
+        }
+        else
+        {
+            contrib = lightAmbient[i].rgb * atten;
+        }
+        litColor.rgb += contrib;
+    }
+
+    vColor = clamp(litColor, 0.0, 1.0);
+
+    vec3 spec = vec3(0.0);
+    if (specEn.x > 0.5 && sunEn.x > 0.0) {
+        vec3 viewDir = normalize(camPos.xyz - worldPos.xyz);
+        vec3 halfVec = normalize(-sunDir.xyz + viewDir);
+        float NdotH = max(0.0, dot(worldNormal, halfVec));
+        float specPow = max(1.0, specular.w);
+        spec = specular.rgb * pow(NdotH, specPow) * sunEn.x;
+    }
+    vSpecColor = vec4(clamp(spec, 0.0, 1.0), 0.0);
+
+    float dist = length(worldPos.xyz - camPos.xyz);
+    float fogFactor = clamp(1.0 - (dist - fogParam.x) * fogParam.y, 0.0, 1.0);
+    vFogTC = (fogParam.z > 0.5) ? fogFactor : 1.0;
+
+    vUV0 = (texCtrl.x > 0.5) ? (texMat0 * vec4(uv, 0, 1)).xy : uv;
+    vUV1 = (texCtrl.y > 0.5) ? (texMat1 * vec4(uv, 0, 1)).xy : uv;
+}
+)";
+
 // PSNormal — diffuse * texture + specular + fog + night vision
 static const char s_psNormalGLSL[] = R"(#version 330 core
 layout(std140) uniform PSConstants {
@@ -821,12 +971,14 @@ void EngineGL33::UploadPSConstant(int reg, const float* data)
 static GLuint s_vsScreenObj = 0;
 static GLuint s_vsTransformObj = 0;
 static GLuint s_vsShadowObj = 0;
+static GLuint s_vsSkinnedObj = 0;
 
 void EngineGL33::InitVertexShaders()
 {
     s_vsScreenObj = CompileGLShader(GL_VERTEX_SHADER, s_vsScreenGLSL, "vsScreen");
     s_vsTransformObj = CompileGLShader(GL_VERTEX_SHADER, s_vsTransformGLSL, "vsTransform");
     s_vsShadowObj = CompileGLShader(GL_VERTEX_SHADER, s_vsShadowGLSL, "vsShadow");
+    s_vsSkinnedObj = CompileGLShader(GL_VERTEX_SHADER, s_vsSkinnedGLSL, "vsSkinned");
 
     // Bind the VS UBO to base 0 once; subsequent FlushVSConstants only
     // update buffer contents.
@@ -871,6 +1023,11 @@ void EngineGL33::DeinitVertexShaders()
         glDeleteShader(s_vsShadowObj);
         s_vsShadowObj = 0;
     }
+    if (s_vsSkinnedObj)
+    {
+        glDeleteShader(s_vsSkinnedObj);
+        s_vsSkinnedObj = 0;
+    }
     if (s_vsUBO)
     {
         glDeleteBuffers(1, &s_vsUBO);
@@ -893,6 +1050,25 @@ void EngineGL33::SelectVertexShader(VertexShaderID vs)
     GL33Bind::Vao(vs == VSScreen ? _vaoScreen : _vaoMesh);
     // Rebind combined program for the new VS
     DoSelectPixelShader(_pixelShaderSel, _pixelShaderModeSel, _pixelShaderSpecularSel);
+}
+
+void EngineGL33::SelectSkinnedMesh(bool on)
+{
+    // The per-section ApplyPassState remaps VSTransform -> VSSkinned while this
+    // flag is set (so re-selection during the section loop keeps the skinned
+    // program).  Apply immediately too, in case no ApplyPassState runs before the
+    // first section draw.  Only the normal mesh VS is remapped: the shadow pass
+    // (VSShadow) is left alone — skinned buffers exist only for the view LOD.
+    _meshSkinnedActive = on;
+    if (on)
+    {
+        if (_vertexShaderSel == VSTransform)
+            SelectVertexShader(VSSkinned);
+    }
+    else if (_vertexShaderSel == VSSkinned)
+    {
+        SelectVertexShader(VSTransform);
+    }
 }
 
 void EngineGL33::UploadVSScreenConstants()
@@ -1367,6 +1543,7 @@ uint64_t HashShaderSources()
     add(s_vsScreenGLSL);
     add(s_vsTransformGLSL);
     add(s_vsShadowGLSL);
+    add(s_vsSkinnedGLSL);
     add(s_psNormalGLSL);
     add(s_psDetailGLSL);
     add(s_psGrassGLSL);
@@ -1540,6 +1717,9 @@ void EngineGL33::InitPixelShaders()
         GLuint wiBlock = glGetUniformBlockIndex(prog, "WorldInstances");
         if (wiBlock != GL_INVALID_INDEX)
             glUniformBlockBinding(prog, wiBlock, 2);
+        GLuint bpBlock = glGetUniformBlockIndex(prog, "BonePalette");
+        if (bpBlock != GL_INVALID_INDEX)
+            glUniformBlockBinding(prog, bpBlock, 3);
         GLuint vsBlock = glGetUniformBlockIndex(prog, "VSConstants");
         GLuint psBlock = glGetUniformBlockIndex(prog, "PSConstants");
         if (vsBlock != GL_INVALID_INDEX)
@@ -1560,7 +1740,7 @@ void EngineGL33::InitPixelShaders()
     };
 
     // Build combined programs: one per (vs x specular x mode x shader) = 2*2*2*5 = 40
-    GLuint vsObjs[NVertexShaders] = {s_vsScreenObj, s_vsTransformObj, s_vsShadowObj};
+    GLuint vsObjs[NVertexShaders] = {s_vsScreenObj, s_vsTransformObj, s_vsShadowObj, s_vsSkinnedObj};
     for (int v = 0; v < NVertexShaders; v++)
     {
         if (!vsObjs[v])

--- a/engine/PoseidonGL33/EngineGL33_Shaders.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Shaders.cpp
@@ -776,6 +776,7 @@ static float s_psShadow[108] = {}; // 27 vec4 slots — c8-c23 cascadeVP[4], c24
 
 static GLuint s_vsUBO = 0;
 static GLuint s_worldUBO = 0;
+static GLuint s_boneUBO = 0; // BonePalette{ mat4 bones[128] } — binding 3 (GPU skinning)
 static GLuint s_psUBO = 0;
 
 void EngineGL33::FlushVSConstants()
@@ -842,6 +843,14 @@ void EngineGL33::InitVertexShaders()
     glBufferData(GL_UNIFORM_BUFFER, 256 * 64, nullptr, GL_DYNAMIC_DRAW);
     glBindBufferBase(GL_UNIFORM_BUFFER, 2, s_worldUBO);
 
+    // BonePalette UBO (binding 3) — 128 mat4 = 8 KB.  Holds one skinned object's
+    // model-space bone matrices; re-uploaded per skinned draw (UploadBonePalette).
+    // The skinning VS reads bones[boneIdx]; unused while GPU skinning is off.
+    glGenBuffers(1, &s_boneUBO);
+    glBindBuffer(GL_UNIFORM_BUFFER, s_boneUBO);
+    glBufferData(GL_UNIFORM_BUFFER, 128 * 64, nullptr, GL_DYNAMIC_DRAW);
+    glBindBufferBase(GL_UNIFORM_BUFFER, 3, s_boneUBO);
+
     _vertexShaderSel = VSNone;
 }
 
@@ -866,6 +875,11 @@ void EngineGL33::DeinitVertexShaders()
     {
         glDeleteBuffers(1, &s_vsUBO);
         s_vsUBO = 0;
+    }
+    if (s_boneUBO)
+    {
+        glDeleteBuffers(1, &s_boneUBO);
+        s_boneUBO = 0;
     }
 }
 
@@ -1090,6 +1104,16 @@ void EngineGL33::UploadWorldInstances(const float* matrices, int count)
         count = 256;
     glBindBuffer(GL_UNIFORM_BUFFER, s_worldUBO);
     glBufferSubData(GL_UNIFORM_BUFFER, 0, count * 64, matrices);
+}
+
+void EngineGL33::UploadBonePalette(const float* mats, int count)
+{
+    if (!s_boneUBO || count <= 0 || !mats)
+        return;
+    if (count > 128)
+        count = 128;
+    glBindBuffer(GL_UNIFORM_BUFFER, s_boneUBO);
+    glBufferSubData(GL_UNIFORM_BUFFER, 0, count * 64, mats);
 }
 
 void EngineGL33::UploadVSWorldMatrix(const float worldMatrix[16])

--- a/engine/PoseidonGL33/EngineGL33_Shaders.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Shaders.cpp
@@ -1295,6 +1295,11 @@ void EngineGL33::UploadBonePalette(const Matrix4* mats, int count)
     for (int i = 0; i < count; i++)
         ConvertMatrix(conv[i], mats[i]);
     glBindBuffer(GL_UNIFORM_BUFFER, s_boneUBO);
+    // Orphan the store before writing: this UBO is shared across all skinned
+    // objects and re-written once per object per frame.  Without orphaning, each
+    // write stalls on the previous object's draw still reading it (write-after-read
+    // hazard), serializing CPU and GPU.  A fresh store lets the driver double-buffer.
+    glBufferData(GL_UNIFORM_BUFFER, 128 * 64, nullptr, GL_DYNAMIC_DRAW);
     glBufferSubData(GL_UNIFORM_BUFFER, 0, count * static_cast<int>(sizeof(GfxMatrix)), conv);
 }
 

--- a/engine/PoseidonGL33/EngineGL33_Shaders.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Shaders.cpp
@@ -1282,14 +1282,20 @@ void EngineGL33::UploadWorldInstances(const float* matrices, int count)
     glBufferSubData(GL_UNIFORM_BUFFER, 0, count * 64, matrices);
 }
 
-void EngineGL33::UploadBonePalette(const float* mats, int count)
+void EngineGL33::UploadBonePalette(const Matrix4* mats, int count)
 {
     if (!s_boneUBO || count <= 0 || !mats)
         return;
     if (count > 128)
         count = 128;
+    // Convert each Poseidon Matrix4 into the GfxMatrix (GLSL) layout the shader
+    // reads — exactly what worldArr/view/proj get via ConvertMatrix.  Uploading
+    // raw Matrix4 bytes transposes the bones and garbles the skin.
+    GfxMatrix conv[128];
+    for (int i = 0; i < count; i++)
+        ConvertMatrix(conv[i], mats[i]);
     glBindBuffer(GL_UNIFORM_BUFFER, s_boneUBO);
-    glBufferSubData(GL_UNIFORM_BUFFER, 0, count * 64, mats);
+    glBufferSubData(GL_UNIFORM_BUFFER, 0, count * static_cast<int>(sizeof(GfxMatrix)), conv);
 }
 
 void EngineGL33::UploadVSWorldMatrix(const float worldMatrix[16])

--- a/engine/PoseidonGL33/EngineGL33_State.cpp
+++ b/engine/PoseidonGL33/EngineGL33_State.cpp
@@ -303,7 +303,13 @@ void EngineGL33::ApplyPipeline(const Poseidon::render::RenderPassDescriptor& d)
             break;
     }
     if (vs != VSNone)
+    {
+        // GPU skinning: a skinned shape's section draws go through VSSkinned
+        // instead of the normal mesh VS (SelectSkinnedMesh brackets it).
+        if (_meshSkinnedActive && vs == VSTransform)
+            vs = VSSkinned;
         SelectVertexShader(vs);
+    }
     if (ps != PSNone)
         SelectPixelShader(ps);
     SetMultiTexturing(fmt);

--- a/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
+++ b/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
@@ -34,6 +34,7 @@ class VertexBufferGL33 : public VertexBuffer
     GLuint _vbo = 0;
     GLuint _ibo = 0;
     bool _dynamic = false;
+    bool _skinned = false; // VBO uses SSkinnedVertex layout (GPU skinning)
     int _vertexCount = 0;
     int _indexCount = 0;
     AutoArray<VBSectionInfo> _sections;
@@ -48,7 +49,25 @@ class VertexBufferGL33 : public VertexBuffer
   private:
     void CopyVertices(const Shape& src);
     void SetupVertexAttribs();
+    size_t VertexStride() const { return _skinned ? sizeof(SSkinnedVertex) : sizeof(SVertex); }
 };
+
+// GPU-skinning master switch — see EngineGL33.hpp.  TU-local; flipped by the
+// engine config / CLI once the skinning VS and view-LOD static path are wired.
+namespace
+{
+bool sGpuSkinningEnabled = false;
+}
+
+void SetGpuSkinningEnabled(bool on)
+{
+    sGpuSkinningEnabled = on;
+}
+
+bool GpuSkinningEnabled()
+{
+    return sGpuSkinningEnabled;
+}
 
 VertexBufferGL33::~VertexBufferGL33()
 {
@@ -65,8 +84,17 @@ void VertexBufferGL33::SetupVertexAttribs()
 {
     // Caller must have _vao bound and _vbo bound to GL_ARRAY_BUFFER.
     // Layout shared with the engine's `_vaoMesh` setup — see
-    // `GLVertexAttribLayouts.hpp` for the single source of truth.
-    Poseidon::render::vao::SetupSVertexLayout();
+    // `GLVertexAttribLayouts.hpp` for the single source of truth.  Skinned
+    // buffers add the two integer bone attributes (locations 3/4); the
+    // SSkinnedVertex layout is per-shape only and never aliases `_vaoMesh`.
+    if (_skinned)
+    {
+        Poseidon::render::vao::SetupSkinnedVertexLayout();
+    }
+    else
+    {
+        Poseidon::render::vao::SetupSVertexLayout();
+    }
 }
 
 void VertexBufferGL33::CopyVertices(const Shape& src)
@@ -74,6 +102,7 @@ void VertexBufferGL33::CopyVertices(const Shape& src)
     if (_vertexCount <= 0)
         return;
 
+    const size_t stride = VertexStride();
     glBindBuffer(GL_ARRAY_BUFFER, _vbo);
     // The map-flag combination is selected by the named helper.  There
     // is no API exposed by `Poseidon::render::buf` that maps a static buffer with
@@ -81,28 +110,40 @@ void VertexBufferGL33::CopyVertices(const Shape& src)
     // wrong helper is the only way to land in the bug class, and the
     // helper name makes the mistake glaring.  See
     // `engine/Poseidon/Graphics/Core/GLBufferMap.hpp`.
-    void* mapped = _dynamic ? Poseidon::render::buf::MapDynamicWriteInvalidate(GL_ARRAY_BUFFER, 0, _vertexCount * sizeof(SVertex))
+    void* mapped = _dynamic ? Poseidon::render::buf::MapDynamicWriteInvalidate(GL_ARRAY_BUFFER, 0, _vertexCount * stride)
                             : Poseidon::render::buf::MapStaticWriteOnce(GL_ARRAY_BUFFER);
-    SVertex* sData = static_cast<SVertex*>(mapped);
-    if (!sData)
+    if (!mapped)
     {
         LOG_ERROR(Graphics, "GL33: VBO map failed");
         return;
     }
+    char* base = static_cast<char*>(mapped);
 
     const UVPair* uv = &src.UV(0);
     const Vector3* pos = &src.Pos(0);
     const Vector3* norm = &src.Norm(0);
-    for (int i = src.NVertex(); --i >= 0;)
+    const int n = src.NVertex();
+    for (int i = 0; i < n; i++)
     {
-        sData->pos = Vector3P(pos->X(), pos->Y(), pos->Z());
+        // pos/norm/t0 occupy identical offsets in SVertex and SSkinnedVertex, so
+        // the SVertex view writes the shared fields for both strides.
+        SVertex* v = reinterpret_cast<SVertex*>(base + i * stride);
+        v->pos = Vector3P(pos[i].X(), pos[i].Y(), pos[i].Z());
         // Normals are negated (matches D3D11 convention)
-        sData->norm = Vector3P(-norm->X(), -norm->Y(), -norm->Z());
-        pos++;
-        norm++;
-        sData->t0 = *uv;
-        uv++;
-        sData++;
+        v->norm = Vector3P(-norm[i].X(), -norm[i].Y(), -norm[i].Z());
+        v->t0 = uv[i];
+        if (_skinned)
+        {
+            // Static bone attributes — uploaded once (GL_STATIC_DRAW), never
+            // rewritten per frame; the palette moves instead (BonePalette UBO).
+            SSkinnedVertex* s = reinterpret_cast<SSkinnedVertex*>(base + i * stride);
+            const SkinVertexBinding& b = src.Skin(i);
+            for (int j = 0; j < 4; j++)
+            {
+                s->boneIdx[j] = b.idx[j];
+                s->boneWeight[j] = b.weight[j];
+            }
+        }
     }
 
     glUnmapBuffer(GL_ARRAY_BUFFER);
@@ -117,6 +158,10 @@ bool VertexBufferGL33::Init(const Shape& src, VBType type)
     }
 
     _dynamic = (type == VBDynamic || type == VBSmallDiscardable);
+    // Skinned only when the master switch is on AND the shape carries a full
+    // per-vertex binding table (built by Skeleton::Prepare).  Off -> classic
+    // SVertex path, unchanged.
+    _skinned = GpuSkinningEnabled() && src.HasSkin();
     _vertexCount = src.NVertex();
 
     // Core profile requires a non-zero VAO bound before any
@@ -129,7 +174,7 @@ bool VertexBufferGL33::Init(const Shape& src, VBType type)
     GLenum vbUsage = _dynamic ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW;
     glGenBuffers(1, &_vbo);
     glBindBuffer(GL_ARRAY_BUFFER, _vbo);
-    glBufferData(GL_ARRAY_BUFFER, _vertexCount * sizeof(SVertex), nullptr, vbUsage);
+    glBufferData(GL_ARRAY_BUFFER, _vertexCount * VertexStride(), nullptr, vbUsage);
     CopyVertices(src);
 
     // Count total indices (fan triangulation: N-gon → N-2 triangles)

--- a/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
+++ b/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
@@ -11,6 +11,7 @@
 #include <Poseidon/Graphics/Rendering/Frame/Frame.hpp>
 #include <Poseidon/Graphics/Shared/ScreenshotWriter.hpp>
 #include <Poseidon/Dev/Debug/DebugOverlay.hpp>
+#include <Poseidon/Core/Config/EngineConfig.hpp>
 
 using namespace Poseidon::Dev;
 
@@ -45,6 +46,7 @@ class VertexBufferGL33 : public VertexBuffer
 
     bool Init(const Shape& src, VBType type);
     void Update(const Shape& src, bool dynamic) override;
+    bool IsSkinned() const override { return _skinned; }
 
   private:
     void CopyVertices(const Shape& src);
@@ -52,21 +54,16 @@ class VertexBufferGL33 : public VertexBuffer
     size_t VertexStride() const { return _skinned ? sizeof(SSkinnedVertex) : sizeof(SVertex); }
 };
 
-// GPU-skinning master switch — see EngineGL33.hpp.  TU-local; flipped by the
-// engine config / CLI once the skinning VS and view-LOD static path are wired.
-namespace
-{
-bool sGpuSkinningEnabled = false;
-}
-
+// GPU-skinning master switch — see EngineGL33.hpp.  Backed by the shared engine
+// config so World (Man::Animate) and this backend read one source of truth.
 void SetGpuSkinningEnabled(bool on)
 {
-    sGpuSkinningEnabled = on;
+    ENGINE_CONFIG.enableGpuSkinning = on;
 }
 
 bool GpuSkinningEnabled()
 {
-    return sGpuSkinningEnabled;
+    return ENGINE_CONFIG.enableGpuSkinning;
 }
 
 VertexBufferGL33::~VertexBufferGL33()

--- a/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
+++ b/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
@@ -117,8 +117,13 @@ void VertexBufferGL33::CopyVertices(const Shape& src)
     char* base = static_cast<char*>(mapped);
 
     const UVPair* uv = &src.UV(0);
-    const Vector3* pos = &src.Pos(0);
-    const Vector3* norm = &src.Norm(0);
+    // Skinned buffers hold the BIND POSE (OrigPos/OrigNorm), uploaded once; the VS
+    // re-skins from it each frame via the bone palette.  Uploading the CPU-skinned
+    // Pos/Norm would double-transform.  Fall back to Pos/Norm if the original pose
+    // has not been saved yet (SaveOriginalPos runs inside ApplyMatrices).
+    const bool bindPose = _skinned && src.OriginalPosValid();
+    const Vector3* pos = bindPose ? &src.OrigPos(0) : &src.Pos(0);
+    const Vector3* norm = bindPose ? &src.OrigNorm(0) : &src.Norm(0);
     const int n = src.NVertex();
     for (int i = 0; i < n; i++)
     {
@@ -154,11 +159,14 @@ bool VertexBufferGL33::Init(const Shape& src, VBType type)
         return false;
     }
 
-    _dynamic = (type == VBDynamic || type == VBSmallDiscardable);
     // Skinned only when the master switch is on AND the shape carries a full
     // per-vertex binding table (built by Skeleton::Prepare).  Off -> classic
     // SVertex path, unchanged.
     _skinned = GpuSkinningEnabled() && src.HasSkin();
+    // Skinned buffers hold the static bind pose (the palette animates on the GPU),
+    // so they never need a per-frame re-upload -> force GL_STATIC_DRAW and skip
+    // Update().  This removes the dynamic vertex-streaming cost for the view mesh.
+    _dynamic = (type == VBDynamic || type == VBSmallDiscardable) && !_skinned;
     _vertexCount = src.NVertex();
 
     // Core profile requires a non-zero VAO bound before any
@@ -250,6 +258,14 @@ bool VertexBufferGL33::Init(const Shape& src, VBType type)
 
 void VertexBufferGL33::Update(const Shape& src, bool dynamic)
 {
+    // Skinned buffers are the static bind pose — never re-upload.  This is the
+    // per-frame dynamic-streaming (~libgallium) cost the GPU-skinning change
+    // removes: the CPU may still write bufferDirty, but we intentionally ignore it.
+    if (_skinned)
+    {
+        bufferDirty = false;
+        return;
+    }
     if (_dynamic || dynamic || bufferDirty)
     {
         CopyVertices(src);

--- a/engine/PoseidonGL33/GLVertexAttribLayouts.hpp
+++ b/engine/PoseidonGL33/GLVertexAttribLayouts.hpp
@@ -69,4 +69,26 @@ inline void SetupSVertexLayout()
     glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, stride, reinterpret_cast<void*>(offsetof(SVertex, t0)));
 }
 
+// VSSkinned reads SSkinnedVertex — the 3 SVertex attributes plus two integer
+// bone attributes.  boneIdx/boneWeight are fed via glVertexAttribIPointer so
+// the shader receives them as `uvec4` (exact byte values), not float-normalized:
+// the weight's WeightScale=128 quantization is undone in the VS, and bone
+// indices must stay exact integers for the palette lookup.  Caller must have a
+// non-zero VAO + the SSkinnedVertex VBO bound to GL_ARRAY_BUFFER.
+inline void SetupSkinnedVertexLayout()
+{
+    const GLsizei stride = sizeof(SSkinnedVertex);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, stride, reinterpret_cast<void*>(offsetof(SSkinnedVertex, pos)));
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, stride, reinterpret_cast<void*>(offsetof(SSkinnedVertex, norm)));
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, stride, reinterpret_cast<void*>(offsetof(SSkinnedVertex, t0)));
+    glEnableVertexAttribArray(3);
+    glVertexAttribIPointer(3, 4, GL_UNSIGNED_BYTE, stride, reinterpret_cast<void*>(offsetof(SSkinnedVertex, boneIdx)));
+    glEnableVertexAttribArray(4);
+    glVertexAttribIPointer(4, 4, GL_UNSIGNED_BYTE, stride,
+                           reinterpret_cast<void*>(offsetof(SSkinnedVertex, boneWeight)));
+}
+
 } // namespace Poseidon::render::vao


### PR DESCRIPTION
Moves character mesh skinning for infantry graphical view LODs from the CPU to the GL33 vertex shader: the VBO holds the static bind pose and the VS skins from a per-frame bone palette (reproduces `ApplyMatricesComplex` exactly, Σw=1). Off by default behind `--gpu-skinning` (`ENGINE_CONFIG.enableGpuSkinning`).

## Why

On a CPU-bound scene (259-vehicle / 333-unit battle, AMD Ryzen 7 7735HS, vsync off) it's **+9% FPS** (98.1 → 106.5 aFPS) on top of the other perf work, it removes the view-LOD CPU skin and the per-frame view-mesh re-upload.
On a present/GPU-bound scene it's FPS-neutral, which is why it's opt-in for now.

 ## Scope / coverage (why it's a flag, not a default)

- Only meshes with `HasSkin()` (infantry graphical view LODs) are GPU-skinned.
- **Collision / shadow / memory / bounding LODs stay CPU-skinned**, these feed the MP-sync-critical path and stay bit-identical, so **MP determinism is unaffected**.
- Vehicles with skeletal animations (scud, parachute) stay CPU.
- A view LOD's CPU-side `Pos` is left at bind pose when GPU-skinned (the VS re-skins), so it's opt-in until the "no CPU reader of view-LOD verts" assumption is validated across community content.