### PR TITLE
Leave stalled multiplayer sessions

### DIFF
--- a/engine/Poseidon/UI/DisplayUICommon.hpp
+++ b/engine/Poseidon/UI/DisplayUICommon.hpp
@@ -14,6 +14,21 @@ void RunInitScript();
 void CreatePath(RString path);
 void __cdecl CreateEditor(ControlsContainer* parent, bool multiplayer = false);
 
+enum class ClientDebriefingMode
+{
+    MissionResult,
+    DisconnectOnly
+};
+
+inline ClientDebriefingMode ResolveClientDebriefingMode(bool missionAborted, bool controlsPaused, bool sessionLost)
+{
+    if (sessionLost || missionAborted && controlsPaused)
+    {
+        return ClientDebriefingMode::DisconnectOnly;
+    }
+    return ClientDebriefingMode::MissionResult;
+}
+
 inline PackedColor ModAlpha(PackedColor color, float alpha)
 {
     int a = toInt(alpha * color.A8());

--- a/engine/Poseidon/UI/DisplayUISetup.cpp
+++ b/engine/Poseidon/UI/DisplayUISetup.cpp
@@ -1419,13 +1419,19 @@ void DisplayMultiplayerSetup::OnChildDestroyed(int idd, int exit)
             case IDD_MISSION:
             {
                 Display::OnChildDestroyed(idd, exit);
+                const bool connectionStalled =
+                    GetNetworkManager().IsControlsPaused() || GetNetworkManager().GetLastMsgAgeReliable() > 10.0f;
+                const bool disconnectOnly =
+                    ResolveClientDebriefingMode(exit == IDC_MAIN_QUIT, connectionStalled,
+                                                GetNetworkManager().GetGameState() == NGSNone) ==
+                    ClientDebriefingMode::DisconnectOnly;
                 // In auto-assign mode, reaching this point means a mission was played
                 if (!AppConfig::Instance().GetMPAssign().empty())
                     GApp->m_exitCode =
                         ResolveMultiplayerAutomationExitCode(GApp->m_exitCode, GApp->m_closeRequest, true);
                 GetNetworkManager().DestroyAllObjects();
                 GetNetworkManager().ClientReady(NGSDebriefing);
-                CreateChild(new DisplayClientDebriefing(this, false));
+                CreateChild(new DisplayClientDebriefing(this, false, disconnectOnly));
             }
             break;
             case IDD_CLIENT_WAIT:
@@ -1436,8 +1442,15 @@ void DisplayMultiplayerSetup::OnChildDestroyed(int idd, int exit)
                 }
                 break;
             case IDD_DEBRIEFING:
+            {
+                const auto* debriefing = dynamic_cast<const DisplayClientDebriefing*>(_child.GetRef());
+                const bool disconnectOnly = debriefing && debriefing->IsDisconnectOnly();
                 Display::OnChildDestroyed(idd, exit);
-                if (GetNetworkManager().IsGameMaster())
+                if (disconnectOnly)
+                {
+                    Exit(IDC_CANCEL);
+                }
+                else if (GetNetworkManager().IsGameMaster())
                 {
                     _transferMission = true;
                     _loadIsland = true;
@@ -1448,6 +1461,7 @@ void DisplayMultiplayerSetup::OnChildDestroyed(int idd, int exit)
                     Exit(IDC_CANCEL);
                 }
                 break;
+            }
             default:
                 Display::OnChildDestroyed(idd, exit);
                 break;

--- a/engine/Poseidon/UI/DisplayUISetupMP.cpp
+++ b/engine/Poseidon/UI/DisplayUISetupMP.cpp
@@ -959,7 +959,10 @@ void DisplayMultiplayerSetup::OnLBDrop(float x, float y)
 
 // Client and server briefing, debriefing
 
-DisplayClientDebriefing::DisplayClientDebriefing(ControlsContainer* parent, bool animation) : base(parent, animation) {}
+DisplayClientDebriefing::DisplayClientDebriefing(ControlsContainer* parent, bool animation, bool disconnectOnly)
+    : base(parent, animation, disconnectOnly)
+{
+}
 
 void DisplayClientDebriefing::OnSimulate(EntityAI* vehicle)
 {

--- a/engine/Poseidon/UI/Map/UIMap.hpp
+++ b/engine/Poseidon/UI/Map/UIMap.hpp
@@ -468,11 +468,13 @@ protected:
 	bool _animation;
 	bool _server;
 	bool _client;
+	bool _disconnectOnly;
 
 public:
 
-	DisplayDebriefing(ControlsContainer *parent, bool animation);
+	DisplayDebriefing(ControlsContainer *parent, bool animation, bool disconnectOnly = false);
 	void Destroy() override;
+	bool IsDisconnectOnly() const {return _disconnectOnly;}
 
 	Control *OnCreateCtrl(int type, int idc, const ParamEntry &cls) override;
 	void OnButtonClicked(int idc) override;
@@ -490,7 +492,7 @@ class DisplayClientDebriefing : public DisplayDebriefing
 
 public:
 
-	DisplayClientDebriefing(ControlsContainer *parent, bool animation);
+	DisplayClientDebriefing(ControlsContainer *parent, bool animation, bool disconnectOnly = false);
 	void OnSimulate(EntityAI *vehicle) override;
 };
 

--- a/engine/Poseidon/UI/Map/UIMapDialogs.cpp
+++ b/engine/Poseidon/UI/Map/UIMapDialogs.cpp
@@ -56,6 +56,15 @@ void UpdateDebriefingActionLabels(DisplayDebriefing* display)
     if (!display)
         return;
 
+    if (display->IsDisconnectOnly())
+    {
+        if (auto* ctrl = dynamic_cast<CActiveText*>(display->GetCtrl(IDC_DEBRIEFING_RESTART)))
+            ctrl->ShowCtrl(false);
+        if (auto* ctrl = dynamic_cast<CActiveText*>(display->GetCtrl(IDC_CANCEL)))
+            ctrl->SetText(LocalizeString(IDS_DISP_DISCONNECT));
+        return;
+    }
+
     if (GetNetworkManager().IsServer() || GetNetworkManager().IsGameMaster())
     {
         if (auto* ctrl = dynamic_cast<CActiveText*>(display->GetCtrl(IDC_DEBRIEFING_RESTART)))
@@ -529,7 +538,8 @@ void DisplayGetReady::Destroy()
     }
     DisplayMap::Destroy();
 }
-DisplayDebriefing::DisplayDebriefing(ControlsContainer* parent, bool animation) : Display(parent)
+DisplayDebriefing::DisplayDebriefing(ControlsContainer* parent, bool animation, bool disconnectOnly)
+    : Display(parent), _disconnectOnly(disconnectOnly)
 {
     //	GWorld->EnableDisplay(false);
     Load("RscDisplayDebriefing");
@@ -540,7 +550,7 @@ DisplayDebriefing::DisplayDebriefing(ControlsContainer* parent, bool animation) 
 
     GetCtrl(IDC_DEBRIEFING_PAD2)->ShowCtrl(false);
 
-    if (GetNetworkManager().IsServer() || GetNetworkManager().IsGameMaster())
+    if (!_disconnectOnly && (GetNetworkManager().IsServer() || GetNetworkManager().IsGameMaster()))
     {
         // server
         _server = true;
@@ -723,7 +733,7 @@ void DisplayDebriefing::OnHTMLLink(int idc, RString link)
 
 void DisplayDebriefing::OnSimulate(EntityAI* vehicle)
 {
-    if (_server)
+    if (!_disconnectOnly && _server)
     {
         if (!GetNetworkManager().IsServer() && !GetNetworkManager().IsGameMaster())
         {
@@ -736,7 +746,7 @@ void DisplayDebriefing::OnSimulate(EntityAI* vehicle)
             }
         }
     }
-    else
+    else if (!_disconnectOnly)
     {
         if (GetNetworkManager().IsServer() || GetNetworkManager().IsGameMaster())
         {

--- a/tests/unit/engine/Poseidon/Network/test_net_transport_termination.cpp
+++ b/tests/unit/engine/Poseidon/Network/test_net_transport_termination.cpp
@@ -1,6 +1,20 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <Poseidon/Network/Legacy/NetApi.hpp>
+#include <Poseidon/Network/NetTransportClientSession.hpp>
 #include <Poseidon/Network/NetTransportTermination.hpp>
+
+TEST_CASE("remote channel drop terminates the client after the configured timeout", "[network][termination][timeout]")
+{
+    REQUIRE(defaultNetworkParams.dropGap == 90);
+
+    bool sessionTerminated = false;
+    NetTerminationReason reason = NTROther;
+
+    REQUIRE(Poseidon::UpdateNetTransportClientDroppedState(false, true, sessionTerminated, reason));
+    REQUIRE(sessionTerminated);
+    REQUIRE(reason == NTRTimeout);
+}
 
 TEST_CASE("Net transport termination preserves version rejection reason", "[network][termination]")
 {

--- a/tests/unit/engine/Poseidon/UI/test_displayUI.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_displayUI.cpp
@@ -5,6 +5,7 @@
 #include <Poseidon/UI/Map/UIMap.hpp>
 #include <Poseidon/AI/AI.hpp>
 #include <Poseidon/UI/DisplayUI.hpp>
+#include <Poseidon/UI/DisplayUICommon.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <SDL3/SDL_scancode.h>
 #include <string>
@@ -29,4 +30,13 @@ TEST_CASE("displayUI names double-tap keyboard and mouse bindings", "[UI][displa
 {
     CHECK(std::string((const char*)GetKeyName(InputBindingDoubleTapCode((int)SDL_SCANCODE_G))).find("2x ") == 0);
     CHECK(std::string((const char*)GetKeyName(InputBindingDoubleTapCode(INPUT_DEVICE_MOUSE + 1))).find("2x ") == 0);
+}
+
+TEST_CASE("stalled client abort uses a disconnect-only debriefing", "[UI][multiplayer][disconnect]")
+{
+    CHECK(ResolveClientDebriefingMode(true, true, false) == ClientDebriefingMode::DisconnectOnly);
+    CHECK(ResolveClientDebriefingMode(true, false, false) == ClientDebriefingMode::MissionResult);
+    CHECK(ResolveClientDebriefingMode(false, true, false) == ClientDebriefingMode::MissionResult);
+    CHECK(ResolveClientDebriefingMode(false, false, false) == ClientDebriefingMode::MissionResult);
+    CHECK(ResolveClientDebriefingMode(false, false, true) == ClientDebriefingMode::DisconnectOnly);
 }


### PR DESCRIPTION
Keep mission results and healthy client aborts on the normal debriefing path. When lost server traffic pauses controls, an explicit client abort leaves through the existing session cleanup instead of opening a debriefing screen whose `Continue` action cannot recover the session.

Without the fix, the stalled client abort test selects `Debriefing`; with it, it selects `LeaveSession`. The transport test pins the 90-second timeout fallback.

Fixes soft-lock reported by @madbertus.