### PR TITLE
Stabilize admin ban test

### DIFF
--- a/tests/integration/multiplayer/admin_ban.test/admin.sqf
+++ b/tests/integration/multiplayer/admin_ban.test/admin.sqf
@@ -1,13 +1,16 @@
 triAssertNgsClient 14
 triAssertMissionPlayable
 triAssertEq [(triNetCommand "#login tri-admin"), "1"]
+triAssertEq [(triGetAdminLoggedIn), "1"]
 triAssertEq [format["%1", banneeReady], "1"]
 triAssertEq [(triMpPlayerNames), "admin|bannee"]
 triAssertEq [(triNetCommand "#ban bannee"), "1"]
 triAssertEq [(triMpPlayerNames), "admin"]
 triScreenshot "admin_after_ban"
-triAssertEq [format["%1", unbanReady], "1"]
-triAssertEq [(triNetCommand format["#unban %1", banId]), "1"]
+triAssertIncludes [format["%1", unbanCommand], "#unban "]
+triAssertEq [(triNetCommand unbanCommand), "1"]
 triScreenshot "admin_after_unban"
-triWait 3000
+triAssertEq [format["%1", unbanDone], "1"]
+unbanAck = 1
+publicVariable "unbanAck"
 triEndTest

--- a/tests/integration/multiplayer/admin_ban.test/server.sqf
+++ b/tests/integration/multiplayer/admin_ban.test/server.sqf
@@ -1,8 +1,9 @@
 triAssertEq [(triServerBanCount), 0]
 triAssertEq [(triServerBanCount), 1]
-banId = (triServerBanFirstId)
-unbanReady = 1
-publicVariable "banId"
-publicVariable "unbanReady"
+unbanCommand = format["#unban %1", (triServerBanFirstId)]
+publicVariable "unbanCommand"
 triAssertEq [(triServerBanCount), 0]
+unbanDone = 1
+publicVariable "unbanDone"
+triAssertEq [format["%1", unbanAck], "1"]
 triEndTest


### PR DESCRIPTION
Wait for admin authorization before issuing ban commands. Replicate the complete unban command and keep both peers alive until the server and client acknowledge removal.

The failed main run exhausted all three attempts with the server ban count stuck at 0 or 1. `admin_ban` passes 10 standalone runs and 3 two-job runs with retries disabled.