### PR TITLE
Preserve difficulty settings at startup

### DIFF
--- a/engine/Poseidon/Core/Config/ConfigFunctions.cpp
+++ b/engine/Poseidon/Core/Config/ConfigFunctions.cpp
@@ -54,7 +54,6 @@ void Config::InitDifficulties()
     diffDesc[10].stringId = IDS_DIFF_TRACERS;
     diffDesc[11].stringId = IDS_ULTRA_AI;
 
-    USER_CONFIG.InitDifficulties();
     GChatList.Enable(true);
 }
 

--- a/engine/Poseidon/Game/Commands/GameStateExtTestGetters.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestGetters.cpp
@@ -10,6 +10,7 @@ using namespace Poseidon;
 #include <Poseidon/UI/Controls/UIControls.hpp>
 #include <Poseidon/Dev/Debug/DebugOverlay.hpp>
 #include <Poseidon/Core/ModSystem.hpp>
+#include <Poseidon/Core/Config/UserConfig.hpp>
 #include <Poseidon/Core/resincl.hpp>
 #include <Poseidon/UI/DisplayUI.hpp>
 #include <Poseidon/Game/Chat.hpp>
@@ -42,6 +43,14 @@ GameValue TriGetGLErrorCount(const GameState*);
 // ============================================================================
 // Window getters
 // ============================================================================
+
+GameValue TriGetDifficultyEnabled(const GameState* /*state*/, GameValuePar arg)
+{
+    const int type = toInt(static_cast<GameScalarType>(arg));
+    if (type < 0 || type >= DTN)
+        return GameValue(static_cast<float>(-1));
+    return GameValue(USER_CONFIG.IsEnabled(static_cast<DifficultyType>(type)) ? 1.0f : 0.0f);
+}
 
 GameValue TriGetResizable(const GameState* /*state*/)
 {
@@ -504,6 +513,8 @@ void EnsureGameStateExtTestGettersLinked() {}
 
 INIT_MODULE(GameStateExtTestGetters, 3)
 {
+    GGameState.NewFunction(GameFunction(GameScalar, "triGetDifficultyEnabled", TriGetDifficultyEnabled, GameScalar));
+
     // Window
     GGameState.NewNularOp(GameNular(GameString, "triGetResizable", TriGetResizable));
     GGameState.NewNularOp(GameNular(GameScalar, "triGetBackBufferNonBlackCount", TriGetBackBufferNonBlackCount));

--- a/tests/integration/flows/difficulty_reload.seq/01_enable_enemy_tag.test.sqf
+++ b/tests/integration/flows/difficulty_reload.seq/01_enable_enemy_tag.test.sqf
@@ -1,0 +1,43 @@
+triSetLanguage "English"
+triClickText "OPTIONS"
+triClickText "Difficulty"
+triAssertEq [(triDisplay), 9099]
+
+if ((triControlText 501) != "Cadet") then { format ["FAIL: expected active mode Cadet, got '%1'", triControlText 501] } else { "OK" }
+if ((triControlText 531) != "Disabled") then { format ["FAIL: expected Enemy Tag disabled before toggle, got '%1'", triControlText 531] } else { "OK" }
+
+triSendKey 81
+triSimFrames 2
+triSendKey 81
+triSimFrames 2
+triSendKey 81
+triSimFrames 2
+triSendKey 40
+triSimFrames 2
+
+if ((triControlText 531) != "Enabled") then { format ["FAIL: expected Enemy Tag enabled after toggle, got '%1'", triControlText 531] } else { "OK" }
+triAssertEq [(triGetDifficultyEnabled 2), 1]
+
+triSendKey 81
+triSimFrames 2
+triSendKey 81
+triSimFrames 2
+triSendKey 81
+triSimFrames 2
+triSendKey 81
+triSimFrames 2
+triSendKey 81
+triSimFrames 2
+triSendKey 81
+triSimFrames 2
+triSendKey 81
+triSimFrames 2
+triSendKey 81
+triSimFrames 2
+triSendKey 81
+triSimFrames 2
+triSendKey 40
+triSimFrames 2
+triAssertEq [(triGetDifficultyEnabled 11), 1]
+
+triEndTest

--- a/tests/integration/flows/difficulty_reload.seq/02_verify_effective_flag.test.sqf
+++ b/tests/integration/flows/difficulty_reload.seq/02_verify_effective_flag.test.sqf
@@ -1,0 +1,10 @@
+triSetLanguage "English"
+triAssertEq [(triGetDifficultyEnabled 11), 1]
+triAssertEq [(triGetDifficultyEnabled 2), 1]
+
+triClickText "OPTIONS"
+triClickText "Difficulty"
+triAssertEq [(triDisplay), 9099]
+if ((triControlText 531) != "Enabled") then { format ["FAIL: expected Enemy Tag enabled after reload, got '%1'", triControlText 531] } else { "OK" }
+
+triEndTest


### PR DESCRIPTION
The startup application hook reset every effective difficulty flag after `difficulty.cfg` had already been loaded. Keep the loaded flags when localized difficulty labels are initialized so the values displayed in Options match gameplay from the first mission.

The two-boot `difficulty_reload` sequence enables Enemy Tag and Ultra AI, starts a fresh process against the same profile, and verifies both effective flags before opening the Difficulty page. With the reset restored, Ultra AI reads 0 instead of the saved value 1.

fixes https://github.com/BohemiaInteractive/CWR/issues/13