### PR TITLE
Retry smaller Windows minidumps

### DIFF
--- a/engine/Poseidon/Foundation/Platform/CrashHandler.cpp
+++ b/engine/Poseidon/Foundation/Platform/CrashHandler.cpp
@@ -45,9 +45,37 @@ LONG WINAPI CrashFilter(EXCEPTION_POINTERS* ep)
     if (f != INVALID_HANDLE_VALUE)
     {
         MINIDUMP_EXCEPTION_INFORMATION mei = {GetCurrentThreadId(), ep, FALSE};
-        MiniDumpWriteDump(proc, GetCurrentProcessId(), f, MiniDumpWithDataSegs, &mei, nullptr, nullptr);
+        BOOL written = MiniDumpWriteDump(proc, GetCurrentProcessId(), f, MiniDumpWithDataSegs, &mei, nullptr, nullptr);
+        DWORD error = written ? ERROR_SUCCESS : GetLastError();
+        bool normalDump = false;
+        if (!written)
+        {
+            LARGE_INTEGER start = {};
+            if (SetFilePointerEx(f, start, nullptr, FILE_BEGIN) && SetEndOfFile(f))
+            {
+                written = MiniDumpWriteDump(proc, GetCurrentProcessId(), f, MiniDumpNormal, &mei, nullptr, nullptr);
+                error = written ? ERROR_SUCCESS : GetLastError();
+                normalDump = written;
+            }
+            else
+            {
+                error = GetLastError();
+            }
+        }
         CloseHandle(f);
-        fprintf(stderr, "  minidump: %s\n", dmp);
+        if (written)
+        {
+            fprintf(stderr, "  minidump: %s%s\n", dmp, normalDump ? " (without data segments)" : "");
+        }
+        else
+        {
+            DeleteFileA(dmp);
+            fprintf(stderr, "  minidump failed: %s (error 0x%08lX)\n", dmp, error);
+        }
+    }
+    else
+    {
+        fprintf(stderr, "  minidump failed: %s (error 0x%08lX)\n", dmp, GetLastError());
     }
 
     DWORD code = ep->ExceptionRecord->ExceptionCode;


### PR DESCRIPTION
Retry with `MiniDumpNormal` after truncating a partial `MiniDumpWithDataSegs` file. Report the Windows error and remove the corrupt file when both writes fail.

The crash-context test returned 0 from `MiniDumpReadDumpStream` on two CI attempts. With the first write forced to fail, the fallback produced a readable exception stream in 20 consecutive runs.