### PR TITLE
Add local HTTP test fixtures

### DIFF
--- a/apps/cwr/Game/GameApplication.cpp
+++ b/apps/cwr/Game/GameApplication.cpp
@@ -562,6 +562,7 @@ static std::unique_ptr<HarnessServer> CreateGameHarness()
 
     HarnessBuiltins::RegisterScreenshot(*hs);
     HarnessBuiltins::RegisterSqf(*hs);
+    HarnessBuiltins::RegisterHttpFixtures(*hs);
     // Multiplayer PTT tests (triHoldKey / triReleaseKey) drive VoN
     // transmission via these commands.
     HarnessBuiltins::RegisterKeyInjection(*hs);

--- a/apps/cwr/Server/ServerApplication.cpp
+++ b/apps/cwr/Server/ServerApplication.cpp
@@ -447,6 +447,7 @@ void ServerApplication::DedicatedServerLoop()
             // SQF eval/exec — the dedicated server has a world + GameState, so server-side test
             // verbs (triAssertNgs, triEndTest) run here just as on the client.
             HarnessBuiltins::RegisterSqf(*harnessServer);
+            HarnessBuiltins::RegisterHttpFixtures(*harnessServer);
 
             harnessServer->RegisterEvent({"player_joined", "Player connected", {{"dpid", "int"}, {"name", "string"}}});
             harnessServer->RegisterEvent({"player_left", "Player disconnected", {{"dpid", "int"}, {"name", "string"}}});

--- a/engine/Poseidon/Dev/Harness/HarnessBuiltins.cpp
+++ b/engine/Poseidon/Dev/Harness/HarnessBuiltins.cpp
@@ -29,6 +29,7 @@ using namespace Poseidon;
 #include <Poseidon/Network/NetworkConfig.hpp>
 #include <Poseidon/Network/MasterServerServiceClient.hpp>
 #include <Poseidon/Network/MasterServerBrowser.hpp>
+#include <Poseidon/Network/HttpTestRewrite.hpp>
 #include <Poseidon/AI/AIUnit.hpp>
 #include <Poseidon/Core/ModId.hpp>
 #include <Poseidon/Core/ServerModResolve.hpp>
@@ -106,6 +107,24 @@ void RegisterSqf(HarnessServer& hs)
                            gs->BeginContext(&s_evalScope);
                            gs->Execute(code);
                            gs->EndContext();
+                           return HarnessProtocol::OkResponse();
+                       });
+}
+
+void RegisterHttpFixtures(HarnessServer& hs)
+{
+    hs.RegisterCommand({"http_fixture",
+                        "Map an exact HTTP URL to a loopback fixture URL",
+                        {{"url", "string", true}, {"target", "string", true}}},
+                       [](const std::string&, cJSON* root) -> std::string
+                       {
+                           const char* url = HarnessProtocol::GetString(root, "url");
+                           const char* target = HarnessProtocol::GetString(root, "target");
+                           if (!url || !url[0] || !target || !target[0])
+                               return HarnessProtocol::ErrorResponse("http_fixture requires url and target");
+                           if (!RegisterHttpTestRewrite(url, target))
+                               return HarnessProtocol::ErrorResponse(
+                                   "http_fixture requires an HTTP URL and loopback target");
                            return HarnessProtocol::OkResponse();
                        });
 }

--- a/engine/Poseidon/Dev/Harness/HarnessBuiltins.hpp
+++ b/engine/Poseidon/Dev/Harness/HarnessBuiltins.hpp
@@ -25,6 +25,8 @@ void RegisterScreenshot(HarnessServer& hs);
 /// `eval` + `exec` — SQF via GWorld->GetGameState(). Any app with a world.
 void RegisterSqf(HarnessServer& hs);
 
+void RegisterHttpFixtures(HarnessServer& hs);
+
 /// `key` + `key_up` — inject SDL scancodes into the event queue. Any SDL app.
 void RegisterKeyInjection(HarnessServer& hs);
 

--- a/engine/Poseidon/Game/Commands/GameStateExtTestGeneric.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestGeneric.cpp
@@ -1,6 +1,9 @@
 #include <Evaluator/express.hpp>
 using namespace Poseidon;
+#include <Poseidon/Foundation/Common/Win.h>
 #include <Poseidon/Foundation/Modules/Modules.hpp>
+#include <Poseidon/Foundation/platform.hpp>
+#include <Poseidon/Network/XML/Xml.hpp>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -410,6 +413,22 @@ GameValue TriClearRemoteExecLog(const GameState*)
     return GameValue("OK");
 }
 
+GameValue TriHttpGet(const GameState*, GameValuePar arg)
+{
+    const std::string url = TriValStr(arg);
+    size_t size = 0;
+    char* payload = DownloadFile(url.c_str(), size, nullptr, 64 * 1024);
+    if (!payload)
+        return GameValue("FAIL:download failed");
+    const std::string result(payload, size);
+#ifdef _WIN32
+    GlobalFree(payload);
+#else
+    free(payload);
+#endif
+    return GameValue(result.c_str());
+}
+
 // Called from GameStateExtTestAudio.cpp's INIT_MODULE to force this TU into
 // the link when building PoseidonGame (where no other game code references
 // the TriAssert* family directly).
@@ -433,4 +452,5 @@ INIT_MODULE(GameStateExtTestGeneric, 3)
     GGameState.NewFunction(GameFunction(GameString, "triRecordRemoteExec", TriRecordRemoteExec, GameArray));
     GGameState.NewNularOp(GameNular(GameString, "triRemoteExecLog", TriRemoteExecLog));
     GGameState.NewNularOp(GameNular(GameString, "triClearRemoteExecLog", TriClearRemoteExecLog));
+    GGameState.NewFunction(GameFunction(GameString, "triHttpGet", TriHttpGet, GameString));
 };

--- a/engine/Poseidon/Network/HttpTestRewrite.cpp
+++ b/engine/Poseidon/Network/HttpTestRewrite.cpp
@@ -1,0 +1,63 @@
+#include <Poseidon/Network/HttpTestRewrite.hpp>
+
+#include <mutex>
+#include <utility>
+
+namespace Poseidon
+{
+namespace
+{
+
+std::mutex GHttpTestRewritesMutex;
+std::vector<HttpTestRewrite> GHttpTestRewrites;
+
+bool StartsWith(std::string_view value, std::string_view prefix)
+{
+    return value.size() >= prefix.size() && value.substr(0, prefix.size()) == prefix;
+}
+
+} // namespace
+
+bool IsHttpTestRewriteValid(std::string_view source, std::string_view target)
+{
+    const bool sourceIsHttp = StartsWith(source, "http://") || StartsWith(source, "https://");
+    const bool targetIsLoopback = StartsWith(target, "http://127.0.0.1:") || StartsWith(target, "http://localhost:") ||
+                                  StartsWith(target, "http://[::1]:");
+    return sourceIsHttp && targetIsLoopback;
+}
+
+std::string ResolveHttpTestUrl(std::string_view url, const std::vector<HttpTestRewrite>& rewrites)
+{
+    for (const HttpTestRewrite& rewrite : rewrites)
+    {
+        if (url == rewrite.source)
+            return rewrite.target;
+    }
+    return std::string(url);
+}
+
+bool RegisterHttpTestRewrite(std::string source, std::string target)
+{
+    if (!IsHttpTestRewriteValid(source, target))
+        return false;
+
+    std::lock_guard<std::mutex> lock(GHttpTestRewritesMutex);
+    for (HttpTestRewrite& rewrite : GHttpTestRewrites)
+    {
+        if (rewrite.source == source)
+        {
+            rewrite.target = std::move(target);
+            return true;
+        }
+    }
+    GHttpTestRewrites.push_back({std::move(source), std::move(target)});
+    return true;
+}
+
+std::string ResolveHttpTestUrl(std::string_view url)
+{
+    std::lock_guard<std::mutex> lock(GHttpTestRewritesMutex);
+    return ResolveHttpTestUrl(url, GHttpTestRewrites);
+}
+
+} // namespace Poseidon

--- a/engine/Poseidon/Network/HttpTestRewrite.hpp
+++ b/engine/Poseidon/Network/HttpTestRewrite.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Poseidon
+{
+
+struct HttpTestRewrite
+{
+    std::string source;
+    std::string target;
+};
+
+bool IsHttpTestRewriteValid(std::string_view source, std::string_view target);
+
+std::string ResolveHttpTestUrl(std::string_view url, const std::vector<HttpTestRewrite>& rewrites);
+
+bool RegisterHttpTestRewrite(std::string source, std::string target);
+
+std::string ResolveHttpTestUrl(std::string_view url);
+
+} // namespace Poseidon

--- a/engine/Poseidon/Network/XML/Xml.cpp
+++ b/engine/Poseidon/Network/XML/Xml.cpp
@@ -23,6 +23,7 @@
 #include <Poseidon/Foundation/Framework/Log.hpp>
 #include <Poseidon/Foundation/Strings/RString.hpp>
 #include <Poseidon/Foundation/platform.hpp>
+#include <Poseidon/Network/HttpTestRewrite.hpp>
 #include <curl/curl.h>
 #include <mutex>
 #include <vector>
@@ -93,7 +94,8 @@ CurlDownloadStatus DownloadFileWithCurl(const char* url, const char* proxyServer
         return CurlDownloadStatus::Failed;
     }
 
-    curl_easy_setopt(curl, CURLOPT_URL, url);
+    const std::string effectiveUrl = Poseidon::ResolveHttpTestUrl(url);
+    curl_easy_setopt(curl, CURLOPT_URL, effectiveUrl.c_str());
     curl_easy_setopt(curl, CURLOPT_USERAGENT, AGENT_NAME);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);

--- a/engine/Trident/protocol/harness.schema.json
+++ b/engine/Trident/protocol/harness.schema.json
@@ -82,6 +82,14 @@
       },
       "response": { "ok": "bool" }
     },
+    "http_fixture": {
+      "description": "Map an exact HTTP URL to a loopback fixture URL",
+      "params": {
+        "url": { "type": "string", "required": true },
+        "target": { "type": "string", "required": true }
+      },
+      "response": { "ok": "bool" }
+    },
     "exit": {
       "description": "Request clean game shutdown",
       "params": {},

--- a/engine/Trident/src/client/connection.rs
+++ b/engine/Trident/src/client/connection.rs
@@ -208,6 +208,23 @@ impl HarnessClient {
         .await
     }
 
+    pub async fn set_http_fixture(&mut self, url: &str, target: &str) -> Result<()> {
+        let response = self
+            .send(&Command::HttpFixture {
+                url: url.to_string(),
+                target: target.to_string(),
+            })
+            .await?;
+        if response.ok {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "http_fixture failed: {}",
+                response.error.as_deref().unwrap_or("unknown error")
+            );
+        }
+    }
+
     // ── Convenience methods ────────────────────────────────────────────────
 
     /// Wait for the "ready" event (first display shown after launch).

--- a/engine/Trident/src/protocol/types.rs
+++ b/engine/Trident/src/protocol/types.rs
@@ -62,6 +62,9 @@ pub enum Command {
     #[serde(rename = "exec")]
     Exec { code: String },
 
+    #[serde(rename = "http_fixture")]
+    HttpFixture { url: String, target: String },
+
     #[serde(rename = "exit")]
     Exit,
 }
@@ -352,5 +355,18 @@ mod tests {
         let json = serde_json::to_string(&cmd).unwrap();
         assert!(json.contains(r#""cmd":"exec""#));
         assert!(json.contains(r#""code":"hint 'hello'""#));
+    }
+
+    #[test]
+    fn serialize_http_fixture() {
+        let cmd = Command::HttpFixture {
+            url: "https://fixtures.test/value.txt".into(),
+            target: "http://127.0.0.1:43127/fixture/0".into(),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert_eq!(
+            json,
+            r#"{"cmd":"http_fixture","url":"https://fixtures.test/value.txt","target":"http://127.0.0.1:43127/fixture/0"}"#
+        );
     }
 }

--- a/engine/Trident/src/scenarios/multi.rs
+++ b/engine/Trident/src/scenarios/multi.rs
@@ -21,7 +21,11 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 use tokio::process::{Child, Command as ProcessCommand};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 
 /// Parsed multi-instance test configuration from `test.toml`.
 #[derive(serde::Deserialize)]
@@ -58,8 +62,19 @@ pub struct MultiTestConfig {
     #[serde(default)]
     pub services: Vec<ServiceConfig>,
 
+    #[serde(default)]
+    pub http_fixtures: Vec<HttpFixtureConfig>,
+
     /// Instance definitions — started in array order
     pub instances: Vec<InstanceConfig>,
+}
+
+#[derive(Clone, serde::Deserialize)]
+pub struct HttpFixtureConfig {
+    pub url: String,
+    pub file: String,
+    #[serde(default)]
+    pub min_requests: usize,
 }
 
 const fn default_game_port() -> u16 {
@@ -483,6 +498,177 @@ impl RunningService {
         let _ = self.child.start_kill();
         let _ = tokio::time::timeout(timeout, self.child.wait()).await;
     }
+}
+
+struct HttpFixtureRoute {
+    source_url: String,
+    path: String,
+    body: Arc<Vec<u8>>,
+    min_requests: usize,
+    requests: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+struct RunningHttpFixtures {
+    rewrites: Vec<(String, String)>,
+    routes: Arc<Vec<HttpFixtureRoute>>,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: JoinHandle<Result<()>>,
+}
+
+impl RunningHttpFixtures {
+    fn validate(&self) -> Result<()> {
+        use std::sync::atomic::Ordering;
+
+        for route in self.routes.iter() {
+            let requests = route.requests.load(Ordering::Relaxed);
+            if requests < route.min_requests {
+                anyhow::bail!(
+                    "HTTP fixture '{}' received {requests} request(s), expected at least {}",
+                    route.source_url,
+                    route.min_requests
+                );
+            }
+        }
+        Ok(())
+    }
+
+    async fn stop(mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        let _ = self.task.await;
+    }
+}
+
+async fn serve_http_fixture_connection(
+    mut stream: TcpStream,
+    routes: Arc<Vec<HttpFixtureRoute>>,
+    request_log: Arc<Mutex<File>>,
+) -> Result<()> {
+    use std::sync::atomic::Ordering;
+
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    while request.len() < 16 * 1024 {
+        let read = stream.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        request.extend_from_slice(&chunk[..read]);
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let request_text = String::from_utf8_lossy(&request);
+    let mut parts = request_text
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .split_whitespace();
+    let method = parts.next().unwrap_or_default();
+    let path = parts.next().unwrap_or_default();
+    let route = (method == "GET")
+        .then(|| routes.iter().find(|route| route.path == path))
+        .flatten();
+
+    if let Ok(mut log) = request_log.lock() {
+        let _ = writeln!(log, "{method} {path}");
+    }
+
+    let (status, body): (&str, &[u8]) = route.map_or(("404 Not Found", b"not found"), |route| {
+        route.requests.fetch_add(1, Ordering::Relaxed);
+        ("200 OK", route.body.as_slice())
+    });
+    let header = format!(
+        "HTTP/1.1 {status}\r\nContent-Length: {}\r\nContent-Type: application/octet-stream\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(header.as_bytes()).await?;
+    stream.write_all(body).await?;
+    stream.shutdown().await?;
+    Ok(())
+}
+
+async fn start_http_fixtures(
+    fixtures: &[HttpFixtureConfig],
+    test_dir: &Path,
+    output_dir: &Path,
+) -> Result<Option<RunningHttpFixtures>> {
+    use std::sync::atomic::AtomicUsize;
+
+    if fixtures.is_empty() {
+        return Ok(None);
+    }
+
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .context("failed to start HTTP fixture server")?;
+    let port = listener.local_addr()?.port();
+    let mut source_urls = HashSet::new();
+    let mut routes = Vec::with_capacity(fixtures.len());
+    let mut rewrites = Vec::with_capacity(fixtures.len());
+    for (index, fixture) in fixtures.iter().enumerate() {
+        let url = reqwest::Url::parse(&fixture.url)
+            .with_context(|| format!("invalid HTTP fixture URL '{}'", fixture.url))?;
+        if !matches!(url.scheme(), "http" | "https") {
+            anyhow::bail!("HTTP fixture URL '{}' must use http or https", fixture.url);
+        }
+        if !source_urls.insert(fixture.url.clone()) {
+            anyhow::bail!("duplicate HTTP fixture URL '{}'", fixture.url);
+        }
+
+        let relative = checked_relative_file_path(&fixture.file)?;
+        let file = test_dir.join(relative);
+        let body = std::fs::read(&file)
+            .with_context(|| format!("failed to read HTTP fixture {}", file.display()))?;
+        let path = format!("/__trident_http_fixture/{index}");
+        let target = format!("http://127.0.0.1:{port}{path}");
+        rewrites.push((fixture.url.clone(), target));
+        routes.push(HttpFixtureRoute {
+            source_url: fixture.url.clone(),
+            path,
+            body: Arc::new(body),
+            min_requests: fixture.min_requests,
+            requests: Arc::new(AtomicUsize::new(0)),
+        });
+    }
+
+    let service_output = output_dir.join("services/http-fixtures");
+    std::fs::create_dir_all(&service_output)
+        .with_context(|| format!("failed to create {}", service_output.display()))?;
+    let request_log = Arc::new(Mutex::new(File::create(
+        service_output.join("requests.log"),
+    )?));
+    let routes = Arc::new(routes);
+    let server_routes = Arc::clone(&routes);
+    let server_log = Arc::clone(&request_log);
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => break,
+                accepted = listener.accept() => {
+                    let (stream, _) = accepted?;
+                    let routes = Arc::clone(&server_routes);
+                    let request_log = Arc::clone(&server_log);
+                    tokio::spawn(async move {
+                        if let Err(error) = serve_http_fixture_connection(stream, routes, request_log).await {
+                            tracing::warn!("HTTP fixture request failed: {error:#}");
+                        }
+                    });
+                }
+            }
+        }
+        Ok(())
+    });
+
+    Ok(Some(RunningHttpFixtures {
+        rewrites,
+        routes,
+        shutdown: Some(shutdown_tx),
+        task,
+    }))
 }
 
 fn service_url_from_listen(listen: &str) -> String {
@@ -1928,6 +2114,21 @@ pub async fn run_multi_test(
     replacements.insert("ports.game".to_string(), game_port.to_string());
     replacements.insert("game.port".to_string(), game_port.to_string());
 
+    let http_fixtures =
+        match start_http_fixtures(&config.http_fixtures, test_dir, &test_output_dir).await {
+            Ok(fixtures) => fixtures,
+            Err(e) => {
+                return Ok(ScenarioResult {
+                    passed: false,
+                    message: format!(
+                        "[http-fixture] {e:#} ({:.1}s)",
+                        start.elapsed().as_secs_f64()
+                    ),
+                    duration: start.elapsed(),
+                });
+            }
+        };
+
     let mut services = match start_services(
         name,
         &config.services,
@@ -2161,6 +2362,21 @@ pub async fn run_multi_test(
         .await
         {
             Ok(mut game) => {
+                if let Some(fixtures) = &http_fixtures {
+                    for (url, target) in &fixtures.rewrites {
+                        if let Err(error) = game.client().set_http_fixture(url, target).await {
+                            failed_instance = Some((
+                                inst.name.clone(),
+                                format!("failed to configure HTTP fixture: {error:#}"),
+                            ));
+                            break;
+                        }
+                    }
+                }
+                if failed_instance.is_some() {
+                    instances.push((inst.name.clone(), game));
+                    break;
+                }
                 // A dedicated server has no display, so it emits no `ready` event —
                 // a successful harness connection already means it finished init.
                 if !inst.is_server() {
@@ -2272,6 +2488,14 @@ pub async fn run_multi_test(
     for service in services.iter_mut().rev() {
         service.stop(timeout).await;
     }
+    if let Some(fixtures) = http_fixtures {
+        if failed_instance.is_none() {
+            if let Err(error) = fixtures.validate() {
+                failed_instance = Some(("http-fixture".to_string(), error.to_string()));
+            }
+        }
+        fixtures.stop().await;
+    }
 
     let elapsed = start.elapsed();
 
@@ -2351,6 +2575,50 @@ type = "server"
 
         assert_eq!(config.data_dir.as_deref(), Some("packages/Demo"));
         assert_eq!(config.required_env, ["CWR_MODS_SOURCE_DIR"]);
+    }
+
+    #[tokio::test]
+    async fn http_fixture_maps_exact_url_to_local_file_and_counts_requests() {
+        let test_dir = tempfile::tempdir().unwrap();
+        let output_dir = tempfile::tempdir().unwrap();
+        std::fs::write(test_dir.path().join("squad.xml"), b"<squad />").unwrap();
+        let fixtures = vec![HttpFixtureConfig {
+            url: "https://squad.test/squad.xml".to_string(),
+            file: "squad.xml".to_string(),
+            min_requests: 1,
+        }];
+
+        let running = start_http_fixtures(&fixtures, test_dir.path(), output_dir.path())
+            .await
+            .unwrap()
+            .unwrap();
+        let target = &running.rewrites[0].1;
+        let response = reqwest::get(target.as_str()).await.unwrap();
+
+        assert_eq!(response.bytes().await.unwrap().as_ref(), b"<squad />");
+        assert!(running.validate().is_ok());
+        running.stop().await;
+    }
+
+    #[tokio::test]
+    async fn http_fixture_reports_missing_required_request() {
+        let test_dir = tempfile::tempdir().unwrap();
+        let output_dir = tempfile::tempdir().unwrap();
+        std::fs::write(test_dir.path().join("logo.paa"), b"fixture").unwrap();
+        let fixtures = vec![HttpFixtureConfig {
+            url: "https://squad.test/logo.paa".to_string(),
+            file: "logo.paa".to_string(),
+            min_requests: 1,
+        }];
+
+        let running = start_http_fixtures(&fixtures, test_dir.path(), output_dir.path())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let error = running.validate().unwrap_err();
+        assert!(error.to_string().contains("received 0 request(s)"));
+        running.stop().await;
     }
 
     #[test]

--- a/tests/integration/harness/http_fixture.test/client.sqf
+++ b/tests/integration/harness/http_fixture.test/client.sqf
@@ -1,0 +1,2 @@
+triAssertIncludes [triHttpGet "https://fixtures.test/payload.txt?variant=full", "fixture-through-engine"]
+triEndTest

--- a/tests/integration/harness/http_fixture.test/payload.txt
+++ b/tests/integration/harness/http_fixture.test/payload.txt
@@ -1,0 +1,1 @@
+fixture-through-engine

--- a/tests/integration/harness/http_fixture.test/test.toml
+++ b/tests/integration/harness/http_fixture.test/test.toml
@@ -1,0 +1,12 @@
+data_dir = "packages/Demo"
+timeout = 30
+
+[[http_fixtures]]
+url = "https://fixtures.test/payload.txt?variant=full"
+file = "payload.txt"
+min_requests = 1
+
+[[instances]]
+name = "client"
+type = "client"
+extra_args = ["--no-strict"]

--- a/tests/unit/engine/Poseidon/Network/test_network_predicate_parity.cpp
+++ b/tests/unit/engine/Poseidon/Network/test_network_predicate_parity.cpp
@@ -2,10 +2,35 @@
 #include <catch2/catch_message.hpp>
 
 #include <Poseidon/Foundation/platform.hpp>
+#include <Poseidon/Network/HttpTestRewrite.hpp>
 #include <Poseidon/Network/NetworkCustomAssets.hpp>
 #include <Poseidon/Network/NetworkMissionTransfer.hpp>
 #include <Poseidon/Network/NetworkPlayerRoleAssignment.hpp>
 #include <Poseidon/Network/NetworkServerAuth.hpp>
+
+TEST_CASE("HTTP test rewrites match exact URLs", "[network][http]")
+{
+    const std::vector<Poseidon::HttpTestRewrite> rewrites = {
+        {"https://squad.test/squad.xml?variant=full", "http://127.0.0.1:43127/__trident_http_fixture/0"},
+    };
+
+    REQUIRE(Poseidon::ResolveHttpTestUrl("https://squad.test/squad.xml?variant=full", rewrites) ==
+            "http://127.0.0.1:43127/__trident_http_fixture/0");
+    REQUIRE(Poseidon::ResolveHttpTestUrl("https://squad.test/squad.xml", rewrites) == "https://squad.test/squad.xml");
+}
+
+TEST_CASE("HTTP test rewrites require HTTP sources and loopback targets", "[network][http]")
+{
+    REQUIRE(Poseidon::IsHttpTestRewriteValid("https://squad.test/a", "http://127.0.0.1:1234/a"));
+    REQUIRE_FALSE(Poseidon::IsHttpTestRewriteValid("https://squad.test/a", "https://example.com/a"));
+    REQUIRE_FALSE(Poseidon::IsHttpTestRewriteValid("squad.test/a", "http://127.0.0.1:1234/a"));
+}
+
+TEST_CASE("HTTP test rewrites register process-local mappings", "[network][http]")
+{
+    REQUIRE(Poseidon::RegisterHttpTestRewrite("https://fixtures.test/value.txt", "http://127.0.0.1:43127/value"));
+    REQUIRE(Poseidon::ResolveHttpTestUrl("https://fixtures.test/value.txt") == "http://127.0.0.1:43127/value");
+}
 
 // Behaviour-preservation tests for the server-side network predicates that were
 // extracted out of the legacy inline command / vote / role logic. Each case


### PR DESCRIPTION
Let Trident serve exact HTTP URLs from files and register their loopback mappings through the harness before each process becomes ready. The engine keeps the mappings process-local and applies them only to exact curl download URLs.

The live http_fixture test downloads a fixture through the engine and requires one request. Without the early harness command, the fixture receives zero requests and the original hostname fails to resolve.

This is extracted from upcoming patches testing and fixing various MP assets issues like squad xml, faces, sounds, ...