### PR TITLE
Preserve custom profile FOV

### DIFF
--- a/apps/cwr/Game/GameApplication.cpp
+++ b/apps/cwr/Game/GameApplication.cpp
@@ -6,6 +6,7 @@
 #include <Poseidon/Foundation/Platform/FPUSetup.hpp>
 #include <Poseidon/Foundation/Platform/PoseidonInit.hpp>
 #include <Poseidon/Core/Config/Config.hpp>
+#include <Poseidon/Core/Config/UserConfig.hpp>
 #include <Poseidon/Foundation/Platform/AppConfig.hpp>
 #include <Poseidon/Foundation/Platform/GamePaths.hpp>
 #include <Poseidon/Foundation/Platform/StartupError.hpp>
@@ -64,7 +65,8 @@ using namespace Poseidon;
 namespace Poseidon
 {
 void CreateClient(RString, int, RString);
-}
+RString GetUserParams();
+} // namespace Poseidon
 
 namespace Poseidon
 {
@@ -258,6 +260,12 @@ void ApplyAspectPolicy(DisplayConfig& cfg)
 
     const int w = GEngine->Width();
     const int h = GEngine->Height();
+    UserConfig& userConfig = USER_CONFIG;
+    if (Poseidon::Presentation::ConfigureUserFov(userConfig, w, h))
+    {
+        const RString userPath = Poseidon::GetUserParams();
+        userConfig.SaveToFile(userPath);
+    }
     const AspectRatio::Settings settings = Poseidon::Presentation::Apply(w, h);
 
     // Diagnostic — full resolved policy so log inspection makes

--- a/engine/Poseidon/Core/Profile/UserConfig.cpp
+++ b/engine/Poseidon/Core/Profile/UserConfig.cpp
@@ -1,11 +1,29 @@
 #include <Poseidon/Core/Profile/UserConfig.hpp>
+#include <Poseidon/Core/SaveVersion.hpp>
 #include <Poseidon/IO/ParamFile/ParamFile.hpp>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <Poseidon/Foundation/Strings/RString.hpp>
 
 namespace Poseidon
 {
+namespace
+{
+constexpr float kDefaultFovLeft = 1.0f;
+constexpr float kDefaultFovTop = 0.75f;
+
+bool ValidFov(float left, float top)
+{
+    return std::isfinite(left) && std::isfinite(top) && left > 0.0f && top > 0.0f;
+}
+
+bool SameFov(float leftA, float topA, float leftB, float topB)
+{
+    constexpr float tolerance = 0.0001f;
+    return std::abs(leftA - leftB) <= tolerance && std::abs(topA - topB) <= tolerance;
+}
+} // namespace
 
 UserConfig::UserConfig()
 {
@@ -22,8 +40,7 @@ void UserConfig::InitDefaults()
     }
     easyMode = true;
     showTitles = true;
-    fovTop = 0.75f;
-    fovLeft = 1.0f;
+    SetAutomaticFov();
 }
 
 void UserConfig::LoadFromFile(const char* filepath)
@@ -74,13 +91,32 @@ void UserConfig::LoadFromParamFile(const ParamFile& cfg)
     if (entry)
         easyMode = *entry;
 
-    entry = cfg.FindEntry("fovTop");
+    _loadedVersion = 0;
+    entry = cfg.FindEntry("version");
     if (entry)
-        fovTop = (float)*entry;
+        _loadedVersion = (int)*entry;
 
-    entry = cfg.FindEntry("fovLeft");
-    if (entry)
-        fovLeft = (float)*entry;
+    const ParamEntry* topEntry = cfg.FindEntry("fovTop");
+    const ParamEntry* leftEntry = cfg.FindEntry("fovLeft");
+    const bool hasBoth = topEntry && leftEntry;
+    const float loadedTop = topEntry ? (float)*topEntry : 0.0f;
+    const float loadedLeft = leftEntry ? (float)*leftEntry : 0.0f;
+    const bool validPair = hasBoth && ValidFov(loadedLeft, loadedTop);
+    if (validPair)
+    {
+        fovTop = loadedTop;
+        fovLeft = loadedLeft;
+    }
+    _customFov = validPair;
+
+    if (_loadedVersion >= UserInfoVersion)
+    {
+        _fovMigrationPending = (topEntry || leftEntry) && !validPair;
+    }
+    else
+    {
+        _fovMigrationPending = true;
+    }
 }
 
 void UserConfig::SaveToParamFile(ParamFile& cfg) const
@@ -96,8 +132,60 @@ void UserConfig::SaveToParamFile(ParamFile& cfg) const
     }
     cfg.Add("showTitles", showTitles);
     cfg.Add("easyMode", easyMode);
-    cfg.Add("fovTop", fovTop);
-    cfg.Add("fovLeft", fovLeft);
+    cfg.Add("version", _fovMigrationPending ? _loadedVersion : UserInfoVersion);
+    if (_customFov)
+    {
+        cfg.Add("fovTop", fovTop);
+        cfg.Add("fovLeft", fovLeft);
+    }
+    else
+    {
+        cfg.Delete("fovTop");
+        cfg.Delete("fovLeft");
+    }
+}
+
+bool UserConfig::MigrateFov(float automaticLeft, float automaticTop)
+{
+    if (!_fovMigrationPending)
+        return false;
+
+    if (_loadedVersion < UserInfoVersion && _customFov)
+    {
+        _customFov = !SameFov(fovLeft, fovTop, kDefaultFovLeft, kDefaultFovTop) &&
+                     !SameFov(fovLeft, fovTop, automaticLeft, automaticTop);
+    }
+    if (!_customFov)
+    {
+        SetAutomaticFov();
+        return true;
+    }
+    _fovMigrationPending = false;
+    _loadedVersion = UserInfoVersion;
+    return true;
+}
+
+void UserConfig::SetCustomFov(float left, float top)
+{
+    if (!ValidFov(left, top))
+    {
+        SetAutomaticFov();
+        return;
+    }
+    fovLeft = left;
+    fovTop = top;
+    _customFov = true;
+    _fovMigrationPending = false;
+    _loadedVersion = UserInfoVersion;
+}
+
+void UserConfig::SetAutomaticFov()
+{
+    fovLeft = kDefaultFovLeft;
+    fovTop = kDefaultFovTop;
+    _customFov = false;
+    _fovMigrationPending = false;
+    _loadedVersion = UserInfoVersion;
 }
 
 void UserConfig::InitDifficulties()

--- a/engine/Poseidon/Core/Profile/UserConfig.hpp
+++ b/engine/Poseidon/Core/Profile/UserConfig.hpp
@@ -24,6 +24,11 @@ class UserConfig
     void InitDefaults();
     void InitDifficulties();
 
+    bool HasCustomFov() const { return _customFov; }
+    bool MigrateFov(float automaticLeft, float automaticTop);
+    void SetCustomFov(float left, float top);
+    void SetAutomaticFov();
+
     /// Whether the toggle is enabled in the current difficulty mode. A server
     /// override (set in multiplayer) takes precedence over the local profile.
     bool IsEnabled(DifficultyType type) const;
@@ -43,12 +48,16 @@ class UserConfig
     bool easyMode = true;  // true = cadet, false = veteran
 
     // --- Aspect / FOV ---
-    float fovTop = 0.75f; // Vertical FOV multiplier (default 4:3)
-    float fovLeft = 1.0f; // Horizontal FOV multiplier (widescreen = higher)
+    float fovTop;  // Vertical FOV multiplier (default 4:3)
+    float fovLeft; // Horizontal FOV multiplier (widescreen = higher)
 
   private:
     void LoadFromParamFile(const ParamFile& cfg);
     void SaveToParamFile(ParamFile& cfg) const;
+
+    bool _customFov = false;
+    bool _fovMigrationPending = false;
+    int _loadedVersion = 0;
 
     // Server difficulty pushed by the host in multiplayer (session-local, not persisted).
     bool _serverDifficultyActive = false;

--- a/engine/Poseidon/Core/SaveVersion.hpp
+++ b/engine/Poseidon/Core/SaveVersion.hpp
@@ -9,7 +9,7 @@ const int WorldSerializeVersion = 13;
 const int MissionsVersion = 11;
 
 // UserInfo.cfg file
-const int UserInfoVersion = 1;
+const int UserInfoVersion = 2;
 
 // Campaign history
 const int CampaignVersion = 3;

--- a/engine/Poseidon/Graphics/Core/Engine.cpp
+++ b/engine/Poseidon/Graphics/Core/Engine.cpp
@@ -272,9 +272,6 @@ void Engine::SaveConfig()
     cfg.Add("brightness", _usrBrightness);
     cfg.Add("multitexturing", _multitexturing);
     cfg.Add("useWBuffer", IsWBuffer());
-    cfg.Add("fovTop", _aspectSettings.topFOV);
-    cfg.Add("fovLeft", _aspectSettings.leftFOV);
-
     cfg.Add("uiTopLeftX", _aspectSettings.uiTopLeftX);
     cfg.Add("uiTopLeftY", _aspectSettings.uiTopLeftY);
     cfg.Add("uiBottomRightX", _aspectSettings.uiBottomRightX);
@@ -293,9 +290,6 @@ void Engine::LoadConfig()
     {
         SetMultitexturing(cfg >> "multitexturing");
     }
-    _aspectSettings.topFOV = cfg.ReadValue("fovTop", 0.75f);
-    _aspectSettings.leftFOV = cfg.ReadValue("fovLeft", 1.0f);
-
     _aspectSettings.uiTopLeftX = cfg.ReadValue("uiTopLeftX", 0.0f);
     _aspectSettings.uiTopLeftY = cfg.ReadValue("uiTopLeftY", 0.0f);
     _aspectSettings.uiBottomRightX = cfg.ReadValue("uiBottomRightX", 1.0f);

--- a/engine/Poseidon/Graphics/Core/Engine.hpp
+++ b/engine/Poseidon/Graphics/Core/Engine.hpp
@@ -154,12 +154,12 @@ struct Char3DContext
 struct AspectSettings
 {
     //@{ wide screen settings (ratio world to screen)
-    float leftFOV;
-    float topFOV;
+    float leftFOV = 1.0f;
+    float topFOV = 0.75f;
     //}@
     //@{ 2D UI region settings (0..1 range)
-    float uiTopLeftX, uiTopLeftY;
-    float uiBottomRightX, uiBottomRightY;
+    float uiTopLeftX = 0.0f, uiTopLeftY = 0.0f;
+    float uiBottomRightX = 1.0f, uiBottomRightY = 1.0f;
     //@}
     //@{ 3D world render rect as fractions of the full window.  Default
     // (0,0,1,1) = full window.  A centered sub-rect crops the world

--- a/engine/Poseidon/UI/OptionsUIApp.cpp
+++ b/engine/Poseidon/UI/OptionsUIApp.cpp
@@ -13,6 +13,7 @@ using namespace Poseidon;
 
 #include <Poseidon/Input/InputSubsystem.hpp>
 #include <Poseidon/UI/Settings/GameSettingsConfig.hpp>
+#include <Poseidon/UI/Settings/Presentation.hpp>
 
 #include <Poseidon/World/Scene/Camera/Camera.hpp>
 #include <Poseidon/Core/Progress.hpp>
@@ -383,10 +384,17 @@ void StartCampaign(RString campaign, Display* disp)
 
 static void UpdateUserProfile()
 {
+    const RString userPath = GetUserParams();
+    USER_CONFIG.LoadFromFile(userPath);
     InputSubsystem::Instance().LoadKeys();
     UserConfig_LoadDifficulties(USER_CONFIG);
 
     GEngine->LoadConfig();
+    const int width = GEngine->Width();
+    const int height = GEngine->Height();
+    if (Poseidon::Presentation::ConfigureUserFov(USER_CONFIG, width, height))
+        USER_CONFIG.SaveToFile(userPath);
+    Poseidon::Presentation::Apply(GEngine->Width(), GEngine->Height());
     GScene->LoadConfig();
     if (GSoundsys)
     {

--- a/engine/Poseidon/UI/Settings/Presentation.cpp
+++ b/engine/Poseidon/UI/Settings/Presentation.cpp
@@ -1,5 +1,8 @@
 #include <Poseidon/UI/Settings/Presentation.hpp>
 
+#include <optional>
+
+#include <Poseidon/Core/Profile/UserConfig.hpp>
 #include <Poseidon/Graphics/Core/Engine.hpp>
 
 namespace Poseidon
@@ -10,6 +13,12 @@ namespace
 {
 AspectRatio::DisplayStyle s_style = AspectRatio::Modern;
 AspectRatio::UltrawideClamp s_clamp = AspectRatio::Clamp21x9;
+struct UserFov
+{
+    float left;
+    float top;
+};
+std::optional<UserFov> s_userFov;
 } // namespace
 
 void SetPolicy(AspectRatio::DisplayStyle style, AspectRatio::UltrawideClamp clamp)
@@ -19,6 +28,8 @@ void SetPolicy(AspectRatio::DisplayStyle style, AspectRatio::UltrawideClamp clam
     AspectRatio::SetPillarboxBarsEnabled(style == AspectRatio::Modern);
 }
 
+namespace
+{
 AspectRatio::PolicyInput CurrentPolicy(int viewportWidth, int viewportHeight)
 {
     AspectRatio::PolicyInput input;
@@ -29,11 +40,36 @@ AspectRatio::PolicyInput CurrentPolicy(int viewportWidth, int viewportHeight)
     return input;
 }
 
+AspectRatio::Settings ResolveAutomatic(int viewportWidth, int viewportHeight)
+{
+    return AspectRatio::ResolvePolicy(CurrentPolicy(viewportWidth, viewportHeight)).settings;
+}
+} // namespace
+
+bool ConfigureUserFov(UserConfig& config, int viewportWidth, int viewportHeight)
+{
+    const AspectRatio::Settings automatic = ResolveAutomatic(viewportWidth, viewportHeight);
+    const bool migrated = config.MigrateFov(automatic.leftFOV, automatic.topFOV);
+    if (!config.HasCustomFov())
+    {
+        s_userFov.reset();
+        return migrated;
+    }
+    s_userFov = UserFov{config.fovLeft, config.fovTop};
+    return migrated;
+}
+
 AspectRatio::Settings Resolve(int viewportWidth, int viewportHeight)
 {
     if (AspectRatio::Live().overrideEnabled)
         return AspectRatio::ResolveLive(AspectRatio::Live(), viewportWidth, viewportHeight);
-    return AspectRatio::ResolvePolicy(CurrentPolicy(viewportWidth, viewportHeight)).settings;
+    AspectRatio::Settings settings = ResolveAutomatic(viewportWidth, viewportHeight);
+    if (s_userFov)
+    {
+        settings.leftFOV = s_userFov->left;
+        settings.topFOV = s_userFov->top;
+    }
+    return settings;
 }
 
 AspectRatio::Settings Apply(int viewportWidth, int viewportHeight)

--- a/engine/Poseidon/UI/Settings/Presentation.hpp
+++ b/engine/Poseidon/UI/Settings/Presentation.hpp
@@ -13,6 +13,8 @@
 
 namespace Poseidon
 {
+class UserConfig;
+
 namespace Presentation
 {
 
@@ -25,7 +27,9 @@ AspectRatio::Settings Resolve(int viewportWidth, int viewportHeight);
 // is active.  The Display options page and boot config loader update this
 // once; resize then reuses the same policy.
 void SetPolicy(AspectRatio::DisplayStyle style, AspectRatio::UltrawideClamp clamp);
-AspectRatio::PolicyInput CurrentPolicy(int viewportWidth, int viewportHeight);
+
+// Returns true when the profile migration needs to be persisted.
+bool ConfigureUserFov(UserConfig& config, int viewportWidth, int viewportHeight);
 
 // Resolve + map + Engine::SetAspectSettings — the one apply site.
 // Returns the resolved settings for the caller's diagnostics.

--- a/tests/integration/rendering/userinfo_fov.test/UserInfo.cfg
+++ b/tests/integration/rendering/userinfo_fov.test/UserInfo.cfg
@@ -1,0 +1,3 @@
+version = 2;
+fovTop = 0.8;
+fovLeft = 1.5;

--- a/tests/integration/rendering/userinfo_fov.test/client.sqf
+++ b/tests/integration/rendering/userinfo_fov.test/client.sqf
@@ -1,0 +1,4 @@
+triAssertEq [triDisplay, 0]
+triWaitFrames 10
+triAssertIncludes [triGetAspectSettings, "1.5000,0.8000,"]
+triEndTest

--- a/tests/integration/rendering/userinfo_fov.test/test.toml
+++ b/tests/integration/rendering/userinfo_fov.test/test.toml
@@ -1,0 +1,15 @@
+data_dir = "packages/Demo"
+timeout = 45
+assert_timeout = 10
+
+tags = ["headful", "exclusive"]
+
+[[instances]]
+name = "client"
+type = "client"
+use_mission = false
+no_autotest = true
+extra_args = ["--no-strict", "--name", "client"]
+copy_files = [
+  { source = "UserInfo.cfg", target = "Users/client/UserInfo.cfg" },
+]

--- a/tests/unit/engine/Poseidon/Core/test_user_config_serialization.cpp
+++ b/tests/unit/engine/Poseidon/Core/test_user_config_serialization.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <Poseidon/Core/Config/UserConfig.hpp>
 #include <Poseidon/Core/Difficulty.hpp>
+#include <Poseidon/IO/ParamFile/ParamFile.hpp>
 #include "../test_fixtures.hpp"
 
 TEST_CASE("UserConfig LoadFromFile", "[core][config][serialization]")
@@ -90,8 +91,7 @@ TEST_CASE("UserConfig SaveToFile", "[core][config][serialization]")
         const char* tempPath = GET_TEMP_FILE("user_config_fov.cfg");
 
         Poseidon::UserConfig original;
-        original.fovTop = 0.75f;
-        original.fovLeft = 1.7778f; // 16:9
+        original.SetCustomFov(1.7778f, 0.75f);
 
         original.SaveToFile(tempPath);
 
@@ -108,11 +108,17 @@ TEST_CASE("UserConfig SaveToFile", "[core][config][serialization]")
     {
         const char* tempPath = GET_TEMP_FILE("user_config_no_fov.cfg");
 
-        // Save a config without FOV (just difficulty)
         Poseidon::UserConfig original;
         original.SaveToFile(tempPath);
 
-        // Now load into a fresh config — should get defaults
+        Poseidon::ParamFile raw;
+        REQUIRE(raw.Parse(tempPath) == LSOK);
+        const Poseidon::ParamEntry* version = raw.FindEntry("version");
+        REQUIRE(version != nullptr);
+        CHECK((int)*version == 2);
+        CHECK(raw.FindEntry("fovTop") == nullptr);
+        CHECK(raw.FindEntry("fovLeft") == nullptr);
+
         Poseidon::UserConfig loaded;
         loaded.LoadFromFile(tempPath);
 
@@ -163,8 +169,7 @@ TEST_CASE("UserConfig profile integration", "[core][config][profile]")
         original.cadetDifficulty[Poseidon::DTArmor] = false;
         original.cadetDifficulty[Poseidon::DTAutoSpot] = false;
         original.veteranDifficulty[Poseidon::DTWeaponCursor] = false;
-        original.fovTop = 0.75f;
-        original.fovLeft = 2.3704f; // 21:9
+        original.SetCustomFov(2.3704f, 0.75f);
 
         original.SaveToFile(tempPath);
 
@@ -194,7 +199,7 @@ TEST_CASE("UserConfig profile integration", "[core][config][profile]")
 
         // Modify and save again
         Poseidon::UserConfig modified;
-        modified.fovLeft = 3.5556f; // 32:9
+        modified.SetCustomFov(3.5556f, 0.75f);
         modified.cadetDifficulty[Poseidon::DTMap] = false;
         modified.SaveToFile(tempPath);
 
@@ -204,6 +209,78 @@ TEST_CASE("UserConfig profile integration", "[core][config][profile]")
 
         REQUIRE(reloaded.fovLeft == Catch::Approx(3.5556f));
         REQUIRE(reloaded.cadetDifficulty[Poseidon::DTMap] == false);
+    }
+}
+
+TEST_CASE("UserConfig FOV migration", "[core][config][serialization]")
+{
+    SECTION("generated version-1 values become automatic")
+    {
+        const char* tempPath = GET_TEMP_FILE("user_config_fov_v1_auto.cfg");
+        Poseidon::ParamFile raw;
+        raw.Add("version", 1);
+        raw.Add("fovLeft", 4.0f / 3.0f);
+        raw.Add("fovTop", 0.75f);
+        REQUIRE(raw.Save(tempPath) == LSOK);
+
+        Poseidon::UserConfig config;
+        config.LoadFromFile(tempPath);
+        REQUIRE(config.MigrateFov(4.0f / 3.0f, 0.75f));
+        CHECK_FALSE(config.HasCustomFov());
+        config.SaveToFile(tempPath);
+
+        REQUIRE(raw.Parse(tempPath) == LSOK);
+        REQUIRE(raw.FindEntry("version") != nullptr);
+        CHECK((int)*raw.FindEntry("version") == 2);
+        CHECK(raw.FindEntry("fovLeft") == nullptr);
+        CHECK(raw.FindEntry("fovTop") == nullptr);
+        TestFixtures::CleanupTempFile(tempPath);
+    }
+
+    SECTION("custom version-1 values remain custom")
+    {
+        const char* tempPath = GET_TEMP_FILE("user_config_fov_v1_custom.cfg");
+        Poseidon::ParamFile raw;
+        raw.Add("version", 1);
+        raw.Add("fovLeft", 1.5f);
+        raw.Add("fovTop", 0.8f);
+        REQUIRE(raw.Save(tempPath) == LSOK);
+
+        Poseidon::UserConfig config;
+        config.LoadFromFile(tempPath);
+        REQUIRE(config.MigrateFov(4.0f / 3.0f, 0.75f));
+        CHECK(config.HasCustomFov());
+        CHECK(config.fovLeft == Catch::Approx(1.5f));
+        CHECK(config.fovTop == Catch::Approx(0.8f));
+        config.SaveToFile(tempPath);
+
+        Poseidon::UserConfig reloaded;
+        reloaded.LoadFromFile(tempPath);
+        CHECK_FALSE(reloaded.MigrateFov(4.0f / 3.0f, 0.75f));
+        CHECK(reloaded.HasCustomFov());
+        CHECK(reloaded.fovLeft == Catch::Approx(1.5f));
+        CHECK(reloaded.fovTop == Catch::Approx(0.8f));
+        TestFixtures::CleanupTempFile(tempPath);
+    }
+
+    SECTION("invalid version-2 values become automatic")
+    {
+        const char* tempPath = GET_TEMP_FILE("user_config_fov_v2_invalid.cfg");
+        Poseidon::ParamFile raw;
+        raw.Add("version", 2);
+        raw.Add("fovLeft", 1.5f);
+        REQUIRE(raw.Save(tempPath) == LSOK);
+
+        Poseidon::UserConfig config;
+        config.LoadFromFile(tempPath);
+        REQUIRE(config.MigrateFov(4.0f / 3.0f, 0.75f));
+        CHECK_FALSE(config.HasCustomFov());
+        config.SaveToFile(tempPath);
+
+        REQUIRE(raw.Parse(tempPath) == LSOK);
+        CHECK(raw.FindEntry("fovLeft") == nullptr);
+        CHECK(raw.FindEntry("fovTop") == nullptr);
+        TestFixtures::CleanupTempFile(tempPath);
     }
 }
 

--- a/tests/unit/engine/Poseidon/UI/Settings/test_presentation.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_presentation.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "Poseidon/Core/Profile/UserConfig.hpp"
 #include "Poseidon/UI/Settings/Presentation.hpp"
 
 // Presentation::Resolve — the single aspect decision point's rule table,
@@ -98,4 +99,34 @@ TEST_CASE("Presentation: live dev override drives the resolve", "[Settings][Pres
     const Poseidon::AspectRatio::Settings p = Poseidon::Presentation::Resolve(1920, 1080);
     CHECK(p.worldLeft == Catch::Approx(0.0f));
     CHECK(p.worldRight == Catch::Approx(1.0f));
+}
+
+TEST_CASE("Presentation: custom profile FOV survives viewport changes", "[Settings][Presentation]")
+{
+    Poseidon::Presentation::SetPolicy(Poseidon::AspectRatio::Modern, Poseidon::AspectRatio::Clamp21x9);
+    Poseidon::UserConfig config;
+    config.SetCustomFov(1.5f, 0.8f);
+    CHECK_FALSE(Poseidon::Presentation::ConfigureUserFov(config, 1920, 1080));
+
+    const Poseidon::AspectRatio::Settings initial = Poseidon::Presentation::Resolve(1920, 1080);
+    CHECK(initial.leftFOV == Catch::Approx(1.5f));
+    CHECK(initial.topFOV == Catch::Approx(0.8f));
+
+    const Poseidon::AspectRatio::Settings resized = Poseidon::Presentation::Resolve(2560, 1080);
+    CHECK(resized.leftFOV == Catch::Approx(1.5f));
+    CHECK(resized.topFOV == Catch::Approx(0.8f));
+
+    config.SetAutomaticFov();
+    CHECK_FALSE(Poseidon::Presentation::ConfigureUserFov(config, 2560, 1080));
+}
+
+TEST_CASE("Presentation: generated profile FOV keeps automatic sizing", "[Settings][Presentation]")
+{
+    Poseidon::Presentation::SetPolicy(Poseidon::AspectRatio::Modern, Poseidon::AspectRatio::Clamp21x9);
+    Poseidon::UserConfig config;
+    CHECK_FALSE(Poseidon::Presentation::ConfigureUserFov(config, 2560, 1080));
+
+    const Poseidon::AspectRatio::Settings resized = Poseidon::Presentation::Resolve(2560, 1080);
+    CHECK(resized.leftFOV == Catch::Approx(0.75f * (2560.0f / 1080.0f)));
+    CHECK(resized.topFOV == Catch::Approx(0.75f));
 }

--- a/tests/unit/engine/Poseidon/UI/Settings/test_presentation_single_entry.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_presentation_single_entry.cpp
@@ -105,3 +105,25 @@ TEST_CASE("Presentation: aspect resolvers have no callers outside the module", "
             REQUIRE(IsAllowed(generic, allowed));
         });
 }
+
+TEST_CASE("Presentation: profile FOV migration has one production caller", "[Settings][Presentation][boundary]")
+{
+    const std::vector<std::string> allowed = {
+        "engine/Poseidon/Core/Profile/UserConfig.hpp",
+        "engine/Poseidon/Core/Profile/UserConfig.cpp",
+        "engine/Poseidon/UI/Settings/Presentation.cpp",
+    };
+    int sites = 0;
+    ForEachProductionCpp(
+        [&](const std::filesystem::path& p)
+        {
+            const std::string body = ReadStripped(p);
+            if (body.find("MigrateFov(") == std::string::npos)
+                return;
+            const std::string generic = std::filesystem::relative(p, RepoRoot()).generic_string();
+            INFO(generic << " calls UserConfig::MigrateFov");
+            REQUIRE(IsAllowed(generic, allowed));
+            ++sites;
+        });
+    REQUIRE(sites == 3);
+}


### PR DESCRIPTION
Keep custom UserInfo `fovLeft` and `fovTop` values across display policy application and viewport changes. Policy-generated values remain automatic.

Without the fix, the focused test reads 1.33333/0.75 at 1920x1080 and 1.77778/0.75 after resize instead of 1.5/0.8. The live test verifies the loaded renderer values.