### PR TITLE
Bound the frame rate to the display instead of leaving it Unlimited

### DIFF
--- a/apps/cwr/Game/GameApplication.cpp
+++ b/apps/cwr/Game/GameApplication.cpp
@@ -368,24 +368,26 @@ std::string GraphicsConfigPath()
 void LoadAndApplyGraphicsConfig()
 {
     const std::string path = GraphicsConfigPath();
+    const int refreshHz = GEngine ? GEngine->RefreshRate() : 0;
     GraphicsConfig cfg;
     if (!cfg.Load(path))
     {
-        // First boot: pick a tier from system RAM and stamp the
-        // four tier rows from that preset's bundle.  Per-user
-        // knobs (vsync / fpsCap / brightness / gamma) keep their
-        // class-default values.
+        // First boot autodetects from hardware.  vsync / brightness / gamma
+        // keep their class-default values.
         cfg.LoadDefaults();
         const int ramMB = SDL_GetSystemRAM();
         cfg.qualityPreset = GraphicsConfig::PickPresetFromRam(ramMB);
         cfg.ApplyPresetToTiers(cfg.qualityPreset);
+        cfg.fpsCap = GraphicsConfig::FpsCapForRefreshRate(refreshHz);
         cfg.Save(path);
-        LOG_INFO(Graphics, "LoadGraphicsConfig: autodetected preset={} (RAM={} MB), wrote '{}'", (int)cfg.qualityPreset,
-                 ramMB, path);
+        LOG_INFO(Graphics,
+                 "LoadGraphicsConfig: autodetected preset={} (RAM={} MB) fpsCap={} (display {} Hz), wrote '{}'",
+                 (int)cfg.qualityPreset, ramMB, cfg.fpsCap, refreshHz, path);
     }
 
-    if (cfg.Migrate() && cfg.Save(path))
-        LOG_INFO(Graphics, "LoadGraphicsConfig: migrated '{}' to version {}", path, GraphicsConfig::kVersion);
+    if (cfg.Migrate(refreshHz) && cfg.Save(path))
+        LOG_INFO(Graphics, "LoadGraphicsConfig: migrated '{}' to version {} (fpsCap={}, display {} Hz)", path,
+                 GraphicsConfig::kVersion, cfg.fpsCap, refreshHz);
 
     LiveGraphicsEnv env;
     if (cfg.Normalize(env))

--- a/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
@@ -57,6 +57,7 @@ namespace Poseidon
 } // namespace Poseidon
 
 using namespace Poseidon::Dev;
+#include <Poseidon/Core/Game/GameLoop.hpp>
 #include <Poseidon/Dev/Debug/DebugCheats.hpp>
 #include <Poseidon/Dev/Debug/DebugCommands.hpp>
 #include <Poseidon/UI/Settings/AspectRatio.hpp>
@@ -448,6 +449,12 @@ GameValue TriGetSwapInterval(const GameState* /*state*/)
     if (!GEngine)
         return GameValue((float)1);
     return GameValue((float)GEngine->GetSwapInterval());
+}
+
+/// triGetFpsCap -> int (the cap RenderFrame paces to, 0 when unlimited).
+GameValue TriGetFpsCap(const GameState* /*state*/)
+{
+    return GameValue((float)Poseidon::gUserFpsCap);
 }
 
 /// triGetObjectLodBias -> float (Scene's current LOD bias).
@@ -3054,6 +3061,7 @@ INIT_MODULE(GameStateExtTest, 3)
     GGameState.NewNularOp(GameNular(GameString, "triListMonitors", TriListMonitors));
     // Graphics screen probes
     GGameState.NewNularOp(GameNular(GameScalar, "triGetSwapInterval", TriGetSwapInterval));
+    GGameState.NewNularOp(GameNular(GameScalar, "triGetFpsCap", TriGetFpsCap));
     GGameState.NewNularOp(GameNular(GameScalar, "triGetObjectLodBias", TriGetObjectLodBias));
     GGameState.NewNularOp(GameNular(GameScalar, "triGetTerrainGrid", TriGetTerrainGrid));
     GGameState.NewNularOp(GameNular(GameScalar, "triGetViewDistance", TriGetViewDistance));

--- a/engine/Poseidon/UI/Settings/GraphicsConfig.cpp
+++ b/engine/Poseidon/UI/Settings/GraphicsConfig.cpp
@@ -84,16 +84,34 @@ void GraphicsConfig::LoadDefaults()
     *this = GraphicsConfig{};
 }
 
-bool GraphicsConfig::Migrate()
+int GraphicsConfig::FpsCapForRefreshRate(int refreshHz)
+{
+    // Above any common refresh rate: with no display to pace to, this only has
+    // to stop runaway submission.
+    constexpr int kUnknownRefreshCap = 144;
+    constexpr std::array kAllowed{30, 60, 90, 120, 144, 240};
+
+    if (refreshHz <= 0)
+        return kUnknownRefreshCap;
+    for (int allowed : kAllowed)
+        if (allowed >= refreshHz)
+            return allowed;
+    return kAllowed.back();
+}
+
+bool GraphicsConfig::Migrate(int refreshHz)
 {
     if (version >= kVersion)
         return false;
 
-    // Only a file older than the version stamp reaches here, and its gamma is
-    // whatever first boot wrote.  1.0 is that stamped default and disables
-    // correction entirely; any other value was chosen, so it stays.
-    if (gamma == 1.0f)
+    // 1.0 is the pre-v1 stamped default; any other value was chosen and stays.
+    if (version < 1 && gamma == 1.0f)
         gamma = 1.2f;
+
+    // A cap of 0 below v2 is indistinguishable from the old default, so it is
+    // taken as never set.  From v2 on it is the user's Unlimited and survives.
+    if (fpsCap == 0)
+        fpsCap = FpsCapForRefreshRate(refreshHz);
 
     version = kVersion;
     return true;

--- a/engine/Poseidon/UI/Settings/GraphicsConfig.hpp
+++ b/engine/Poseidon/UI/Settings/GraphicsConfig.hpp
@@ -83,12 +83,15 @@ public:
 
 	// Schema version of the persisted file.  Load resets this to 0 first, so a
 	// file written before versioning reads back as 0 and Migrate can act on it.
-	static constexpr int kVersion = 1;
+	static constexpr int kVersion = 2;
 	int       version          = kVersion;
 
 	// Bring a loaded config up to kVersion.  Returns true when the caller needs
-	// to persist the result.
-	bool Migrate();
+	// to persist the result.  `refreshHz` is 0 when it cannot be read.
+	bool Migrate(int refreshHz);
+
+	// Rounds up to an allowed value, so the cap never sits below the monitor.
+	static int FpsCapForRefreshRate(int refreshHz);
 
 	// Reset every field to factory defaults.
 	void LoadDefaults();

--- a/tests/integration/rendering/frame_rate_bounded.test.sqf
+++ b/tests/integration/rendering/frame_rate_bounded.test.sqf
@@ -1,0 +1,28 @@
+// A default install carries an FPS cap, and with vsync off that cap is the only
+// thing pacing the loop. Asserted against the cap this machine stamped, so the
+// test holds on any display.
+
+triResetGLErrorBaseline
+
+private _cap = triGetFpsCap;
+triAssertGt [_cap, 0]
+
+triSetVsync 0
+
+// triWaitFrames is a render-only pump that never reaches the cap in RenderFrame.
+triSimFrames 200
+
+private _peak = 0;
+for "_i" from 0 to 4 do {
+    triSimFrames 40;
+    private _sample = triFps;
+    if (_sample > _peak) then { _peak = _sample };
+};
+
+// Whole-millisecond sleeps let a cap of N reach 1000/floor(1000/N), ~16% at 144.
+triAssertLt [_peak, _cap * 1.5]
+
+triAssertGt [(triGetBackBufferNonBlackCount), 0]
+triAssertEq [(triGetGLErrorCount), 0]
+
+triEndTest

--- a/tests/integration/rendering/frame_rate_bounded.test.toml
+++ b/tests/integration/rendering/frame_rate_bounded.test.toml
@@ -1,0 +1,3 @@
+timeout = 120
+extra_args = ["--focus"]
+tags = ["headful"]

--- a/tests/smoke/graphics_config.tests.ps1
+++ b/tests/smoke/graphics_config.tests.ps1
@@ -56,7 +56,7 @@ Describe "graphics.cfg boot dance" {
             $preset | Should -BeIn 0,1,2,3 -Because "autodetect picks Low/Med/High/Ultra, never Custom"
             # Per-user knobs must be at the unconditional defaults.
             $kv['vsync']      | Should -Be '1' -Because "VSync defaults On"
-            $kv['fpsCap']     | Should -Be '0' -Because "FPS Cap defaults Unlimited"
+            $kv['fpsCap']     | Should -BeIn '30','60','90','120','144','240' -Because "FPS Cap is stamped from the display rate (GraphicsConfig::FpsCapForRefreshRate)"
             $kv['brightness'] | Should -Match '^1\.20*$' -Because "Brightness defaults 1.2 (original CWA default, GraphicsConfig.hpp)"
             $kv['gamma']      | Should -Match '^1\.0+$' -Because "Gamma defaults 1.0"
         } finally {

--- a/tests/unit/engine/Poseidon/UI/Settings/test_graphicsConfig.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_graphicsConfig.cpp
@@ -59,11 +59,11 @@ TEST_CASE("GraphicsConfig: Migrate lifts an untouched gamma once", "[Settings][G
     c.version = 0;
     c.gamma = 1.0f;
 
-    REQUIRE(c.Migrate());
+    REQUIRE(c.Migrate(60));
     CHECK(c.gamma == 1.2f);
     CHECK(c.version == GraphicsConfig::kVersion);
 
-    CHECK_FALSE(c.Migrate());
+    CHECK_FALSE(c.Migrate(60));
     CHECK(c.gamma == 1.2f);
 }
 
@@ -75,7 +75,7 @@ TEST_CASE("GraphicsConfig: Migrate keeps a gamma the user chose", "[Settings][Gr
         c.version = 0;
         c.gamma = chosen;
 
-        CHECK(c.Migrate());
+        CHECK(c.Migrate(60));
         CHECK(c.gamma == chosen);
         CHECK(c.version == GraphicsConfig::kVersion);
     }
@@ -87,8 +87,78 @@ TEST_CASE("GraphicsConfig: a versioned file is never migrated", "[Settings][Grap
     c.version = GraphicsConfig::kVersion;
     c.gamma = 1.0f;
 
-    CHECK_FALSE(c.Migrate());
+    CHECK_FALSE(c.Migrate(60));
     CHECK(c.gamma == 1.0f);
+}
+
+TEST_CASE("GraphicsConfig: a v1 gamma of 1.0 is the user's own", "[Settings][GraphicsConfig]")
+{
+    GraphicsConfig c;
+    c.version = 1;
+    c.gamma = 1.0f;
+
+    REQUIRE(c.Migrate(60));
+    CHECK(c.gamma == 1.0f);
+    CHECK(c.version == GraphicsConfig::kVersion);
+}
+
+TEST_CASE("GraphicsConfig: the FPS cap rounds up to an allowed rate", "[Settings][GraphicsConfig]")
+{
+    CHECK(GraphicsConfig::FpsCapForRefreshRate(30) == 30);
+    CHECK(GraphicsConfig::FpsCapForRefreshRate(60) == 60);
+    CHECK(GraphicsConfig::FpsCapForRefreshRate(144) == 144);
+
+    SECTION("a rate between two rows takes the higher one")
+    {
+        CHECK(GraphicsConfig::FpsCapForRefreshRate(75) == 90);
+        CHECK(GraphicsConfig::FpsCapForRefreshRate(165) == 240);
+        CHECK(GraphicsConfig::FpsCapForRefreshRate(50) == 60);
+    }
+
+    SECTION("an unreadable or very fast display still gets a bound")
+    {
+        CHECK(GraphicsConfig::FpsCapForRefreshRate(0) == 144);
+        CHECK(GraphicsConfig::FpsCapForRefreshRate(-1) == 144);
+        CHECK(GraphicsConfig::FpsCapForRefreshRate(360) == 240);
+    }
+}
+
+TEST_CASE("GraphicsConfig: Migrate bounds a cap that was left Unlimited", "[Settings][GraphicsConfig]")
+{
+    for (int version : {0, 1})
+    {
+        INFO("from version " << version);
+        GraphicsConfig c;
+        c.version = version;
+        c.fpsCap = 0;
+
+        REQUIRE(c.Migrate(144));
+        CHECK(c.fpsCap == 144);
+        CHECK(c.version == GraphicsConfig::kVersion);
+    }
+}
+
+TEST_CASE("GraphicsConfig: Migrate keeps an FPS cap the user chose", "[Settings][GraphicsConfig]")
+{
+    for (int chosen : {30, 60, 90, 120, 144, 240})
+    {
+        GraphicsConfig c;
+        c.version = 0;
+        c.fpsCap = chosen;
+
+        REQUIRE(c.Migrate(60));
+        CHECK(c.fpsCap == chosen);
+    }
+}
+
+TEST_CASE("GraphicsConfig: Unlimited survives once the file is current", "[Settings][GraphicsConfig]")
+{
+    GraphicsConfig c;
+    c.version = GraphicsConfig::kVersion;
+    c.fpsCap = 0;
+
+    CHECK_FALSE(c.Migrate(144));
+    CHECK(c.fpsCap == 0);
 }
 
 TEST_CASE("GraphicsConfig: a file without a version reloads as version 0", "[Settings][GraphicsConfig]")


### PR DESCRIPTION
The FPS cap shipped as Unlimited, so nothing bounded the loop when the swap did not block. First boot now stamps the cap from the display's refresh rate, and a one-off migration gives existing files the same value where it was 0.