### PR TITLE
Expose anti-aliasing, supersampling and multitexturing in Graphics options

### DIFF
--- a/engine/Poseidon/UI/Options/GraphicsPage.cpp
+++ b/engine/Poseidon/UI/Options/GraphicsPage.cpp
@@ -2,6 +2,7 @@
 #include <Poseidon/UI/Options/OptionsShell.hpp>
 
 #include <Poseidon/Core/Global.hpp>
+#include <Poseidon/Graphics/Core/Engine.hpp>
 #include <Poseidon/UI/Settings/GraphicsApply.hpp>
 #include <Poseidon/UI/Locale/Stringtable/Stringtable.hpp>
 #include <Poseidon/Foundation/Common/GamePaths.hpp>
@@ -17,23 +18,46 @@ namespace Poseidon
 
 namespace
 {
+// labelEn / descEn render when the key is missing from the loaded data package.
 struct GraphicsRowText
 {
     const char* label;
     const char* desc;
+    const char* labelEn;
+    const char* descEn;
 };
 const GraphicsRowText kRows[] = {
-    {"STR_DISP_MAIN_OPT_GRAPHICS_QUALITY_PRESET", "STR_DISP_MAIN_OPT_GRAPHICS_QUALITY_PRESET_DESC"},
-    {"STR_DISP_MAIN_OPT_GRAPHICS_TERRAIN_DETAIL", "STR_DISP_MAIN_OPT_GRAPHICS_TERRAIN_DETAIL_DESC"},
-    {"STR_DISP_MAIN_OPT_GRAPHICS_OBJECT_LOD", "STR_DISP_MAIN_OPT_GRAPHICS_OBJECT_LOD_DESC"},
-    {"STR_DISP_MAIN_OPT_GRAPHICS_SHADOW_QUALITY", "STR_DISP_MAIN_OPT_GRAPHICS_SHADOW_QUALITY_DESC"},
-    {"STR_DISP_MAIN_OPT_GRAPHICS_PARTICLES", "STR_DISP_MAIN_OPT_GRAPHICS_PARTICLES_DESC"},
-    {"STR_DISP_MAIN_OPT_GRAPHICS_VSYNC", "STR_DISP_MAIN_OPT_GRAPHICS_VSYNC_DESC"},
-    {"STR_DISP_MAIN_OPT_GRAPHICS_FPS_CAP", "STR_DISP_MAIN_OPT_GRAPHICS_FPS_CAP_DESC"},
-    {"STR_DISP_MAIN_OPT_GRAPHICS_BRIGHTNESS", "STR_DISP_MAIN_OPT_GRAPHICS_BRIGHTNESS_DESC"},
-    {"STR_DISP_MAIN_OPT_GRAPHICS_GAMMA", "STR_DISP_MAIN_OPT_GRAPHICS_GAMMA_DESC"},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_QUALITY_PRESET", "STR_DISP_MAIN_OPT_GRAPHICS_QUALITY_PRESET_DESC", "Quality Preset",
+     "Sets the four quality tiers below to a known bundle. Touching any tier row drops the preset to Custom."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_TERRAIN_DETAIL", "STR_DISP_MAIN_OPT_GRAPHICS_TERRAIN_DETAIL_DESC", "Terrain Detail",
+     "Terrain mesh density. Lower means a coarser ground silhouette but cheaper rendering."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_OBJECT_LOD", "STR_DISP_MAIN_OPT_GRAPHICS_OBJECT_LOD_DESC", "Object LOD",
+     "Bias for entity LOD selection. Higher means finer geometry at the same distance."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_SHADOW_QUALITY", "STR_DISP_MAIN_OPT_GRAPHICS_SHADOW_QUALITY_DESC", "Shadow Quality",
+     "Whether dynamic objects and vehicles cast shadows."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_PARTICLES", "STR_DISP_MAIN_OPT_GRAPHICS_PARTICLES_DESC", "Particles & Volumetrics",
+     "Cloudlets smoke dust and muzzle flashes."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_VSYNC", "STR_DISP_MAIN_OPT_GRAPHICS_VSYNC_DESC", "VSync",
+     "Synchronise frame presentation to the monitor refresh. Adaptive falls back to On when the GPU cannot keep up."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_FPS_CAP", "STR_DISP_MAIN_OPT_GRAPHICS_FPS_CAP_DESC", "FPS Cap",
+     "Limits how fast frames are drawn. Native follows your monitor's refresh rate. Unlimited keeps a 300 FPS "
+     "ceiling."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_BRIGHTNESS", "STR_DISP_MAIN_OPT_GRAPHICS_BRIGHTNESS_DESC", "Brightness",
+     "Uniform multiplier in the post pass."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_GAMMA", "STR_DISP_MAIN_OPT_GRAPHICS_GAMMA_DESC", "Gamma", "Display LUT gamma curve."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_ADVANCED", "", "Advanced", ""},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_ANTIALIASING", "STR_DISP_MAIN_OPT_GRAPHICS_ANTIALIASING_DESC", "Anti-aliasing",
+     "Multisample anti-aliasing on the frame target. Higher sample counts smooth polygon edges at a GPU cost."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_SUPERSAMPLING", "STR_DISP_MAIN_OPT_GRAPHICS_SUPERSAMPLING_DESC", "Supersampling",
+     "Renders the whole frame above window resolution and downsamples it. The strongest cure for sub-pixel shimmer "
+     "and the most expensive."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_MULTITEXTURING", "STR_DISP_MAIN_OPT_GRAPHICS_MULTITEXTURING_DESC", "Multitexturing",
+     "Detail and specular texture stages on terrain and objects. Off falls back to the base texture like the "
+     "original compatibility switch."},
 };
 constexpr int kFpsCapValues[] = {0, 30, 60, 90, 120, 144, 240};
+constexpr int kMsaaValues[] = {0, 2, 4, 8};
+constexpr float kRenderScaleValues[] = {1.0f, 1.25f, 1.5f, 1.75f, 2.0f};
 
 // Brightness 0.4 .. 1.8 → slider 0..100; Gamma 0.5 .. 2.3 → slider 0..100.
 int FloatToSlider(float v, float lo, float hi)
@@ -107,6 +131,44 @@ int GraphicsPage::FpsCapValueToIndex(int fps)
     return FpsValueToIndex(fps);
 }
 
+int GraphicsPage::MsaaSamplesToIndex(int samples)
+{
+    for (int i = 0; i < (int)(sizeof(kMsaaValues) / sizeof(int)); ++i)
+        if (kMsaaValues[i] == samples)
+            return i;
+    return 0;
+}
+
+int GraphicsPage::MsaaIndexToSamples(int index)
+{
+    if (index < 0 || index >= (int)(sizeof(kMsaaValues) / sizeof(int)))
+        return 0;
+    return kMsaaValues[index];
+}
+
+int GraphicsPage::RenderScaleToIndex(float scale)
+{
+    int best = 0;
+    float bestDiff = std::fabs(scale - kRenderScaleValues[0]);
+    for (int i = 1; i < (int)(sizeof(kRenderScaleValues) / sizeof(float)); ++i)
+    {
+        const float diff = std::fabs(scale - kRenderScaleValues[i]);
+        if (diff < bestDiff)
+        {
+            best = i;
+            bestDiff = diff;
+        }
+    }
+    return best;
+}
+
+float GraphicsPage::RenderScaleIndexToValue(int index)
+{
+    if (index < 0 || index >= (int)(sizeof(kRenderScaleValues) / sizeof(float)))
+        return 1.0f;
+    return kRenderScaleValues[index];
+}
+
 const char* GraphicsPage::CloseLabel()
 {
     return LocalizeString("STR_DISP_CLOSE");
@@ -120,16 +182,16 @@ const char* GraphicsPage::CloseDescription()
 const char* GraphicsPage::GraphicsProvider::RowLabel(int row) const
 {
     static_assert(sizeof(kRows) / sizeof(kRows[0]) == kRowCount, "GraphicsPage row table out of sync with kRowCount");
-    if (row >= 0 && row < kRowCount)
-        return LocalizeString(kRows[row].label);
-    return "";
+    if (row < 0 || row >= kRowCount)
+        return "";
+    return LocalizeStringWithFallback(kRows[row].label, kRows[row].labelEn);
 }
 
 const char* GraphicsPage::GraphicsProvider::RowDescription(int row) const
 {
-    if (row >= 0 && row < kRowCount)
-        return LocalizeString(kRows[row].desc);
-    return "";
+    if (row < 0 || row >= kRowCount)
+        return "";
+    return LocalizeStringWithFallback(kRows[row].desc, kRows[row].descEn);
 }
 
 OptionsScrollList::RowDef GraphicsPage::GraphicsProvider::RowFor(int row) const
@@ -154,8 +216,25 @@ OptionsScrollList::RowDef GraphicsPage::GraphicsProvider::RowFor(int row) const
             return {572, nullptr, -1}; // slider
         case kRowGamma:
             return {582, nullptr, -1}; // slider
+        case kRowAdvanced:
+            return {592, nullptr, 0};
+        case kRowAntiAliasing:
+            return {602, m_page->m_msaaCStrs.data(), 4};
+        case kRowSupersampling:
+            return {612, m_page->m_renderScaleCStrs.data(), 5};
+        case kRowMultitexturing:
+            return {622, m_page->m_offOnCStrs.data(), 2};
     }
     return {-1, nullptr, 0};
+}
+
+OptionsScrollList::Kind GraphicsPage::GraphicsProvider::RowKind(int row) const
+{
+    if (row == kRowAdvanced)
+        return OptionsScrollList::KindHeader;
+    if (row == kRowMultitexturing)
+        return OptionsScrollList::KindBoolean;
+    return OptionsScrollList::Provider::RowKind(row);
 }
 
 int GraphicsPage::GraphicsProvider::RowValue(int row) const
@@ -192,6 +271,12 @@ int GraphicsPage::GraphicsProvider::RowValue(int row) const
                     return 2;
             }
         }
+        case kRowAntiAliasing:
+            return GraphicsPage::MsaaSamplesToIndex(c.msaaSamples);
+        case kRowSupersampling:
+            return GraphicsPage::RenderScaleToIndex(c.renderScale);
+        case kRowMultitexturing:
+            return c.multitexturing ? 1 : 0;
         case kRowVsync:
             return (int)c.vsync;
         case kRowFpsCap:
@@ -276,6 +361,15 @@ void GraphicsPage::GraphicsProvider::SetRowValue(int row, int v)
                     break;
             }
             break;
+        case kRowAntiAliasing:
+            c.msaaSamples = GraphicsPage::MsaaIndexToSamples(v);
+            break;
+        case kRowSupersampling:
+            c.renderScale = GraphicsPage::RenderScaleIndexToValue(v);
+            break;
+        case kRowMultitexturing:
+            c.multitexturing = v != 0;
+            break;
         case kRowVsync:
             if (v >= 0 && v <= 2)
                 c.vsync = static_cast<GraphicsConfig::VsyncMode>(v);
@@ -356,6 +450,26 @@ void GraphicsPage::RefreshLocalizedChoices()
     for (size_t i = 0; i < m_particlesLabels.size(); ++i)
         m_particlesCStrs[i] = m_particlesLabels[i].c_str();
 
+    m_msaaLabels[0] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_OFF");
+    m_msaaLabels[1] = "2x";
+    m_msaaLabels[2] = "4x";
+    m_msaaLabels[3] = "8x";
+    for (size_t i = 0; i < m_msaaLabels.size(); ++i)
+        m_msaaCStrs[i] = m_msaaLabels[i].c_str();
+
+    m_renderScaleLabels[0] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_OFF");
+    m_renderScaleLabels[1] = "125%";
+    m_renderScaleLabels[2] = "150%";
+    m_renderScaleLabels[3] = "175%";
+    m_renderScaleLabels[4] = "200%";
+    for (size_t i = 0; i < m_renderScaleLabels.size(); ++i)
+        m_renderScaleCStrs[i] = m_renderScaleLabels[i].c_str();
+
+    m_offOnLabels[0] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_OFF");
+    m_offOnLabels[1] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_ON");
+    for (size_t i = 0; i < m_offOnLabels.size(); ++i)
+        m_offOnCStrs[i] = m_offOnLabels[i].c_str();
+
     m_vsyncLabels[0] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_OFF");
     m_vsyncLabels[1] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_ON");
     m_vsyncLabels[2] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_ADAPTIVE");
@@ -381,6 +495,11 @@ void GraphicsPage::Unmount(OptionsShell& shell)
     // committed since the user explicitly visited the screen.
     if (!m_cfg.Save(GraphicsCfgPath()))
         LOG_WARN(Graphics, "GraphicsPage::Unmount: failed to write graphics.cfg");
+
+    // Multitexturing also lives in the per-profile user params that
+    // Engine::LoadConfig replays on a profile switch; both stores must agree.
+    if (GEngine)
+        GEngine->SaveConfig();
 
     ScrollListPage::Unmount(shell);
 }

--- a/engine/Poseidon/UI/Options/GraphicsPage.hpp
+++ b/engine/Poseidon/UI/Options/GraphicsPage.hpp
@@ -7,24 +7,14 @@
 // pattern with ConfirmRevert).  Persistence on Unmount mirrors
 // AudioPage: the user's session-end state writes to graphics.cfg.
 //
-// Row layout (9 + Close):
-//   0 Quality Preset       Stepper Low/Med/High/Ultra/Custom
-//   1 Terrain Detail       Stepper Low/Med/High/Ultra
-//   2 Object LOD           Stepper Low/Med/High/Ultra
-//   3 Shadow Quality       Stepper Off/Low/Med/High
-//   4 Particles & Volum.   Stepper Off/Low/High
-//   5 VSync                Stepper Off/On/Adaptive
-//   6 FPS Cap              Stepper Unlimited/30/60/90/120/144/240
-//   7 Brightness           Slider  0..100  (mapped 0.4..1.8, shown as the value)
-//   8 Gamma                Slider  0..100  (mapped 0.5..2.3, shown as the value)
-// + Close                  Action  (added by WithCloseRow)
+// WithCloseRow appends a Close action after the last kRow* entry.
 //
 // Quality Preset row is meta-state: selecting Low/Med/High/Ultra
 // stamps the four tier rows from that preset's bundle (write-through).
 // Touching any tier row re-derives the preset to "Custom" without
-// snapping back.  Per-user knobs (VSync / FPS Cap / Brightness /
-// Gamma) are NOT preset-driven — they keep their value across preset
-// changes.
+// snapping back.  Per-user knobs (Anti-aliasing / Supersampling /
+// Multitexturing / VSync / FPS Cap / Brightness / Gamma) are NOT
+// preset-driven; they keep their value across preset changes.
 
 #include <Poseidon/UI/Settings/GraphicsConfig.hpp>
 #include <Poseidon/UI/Options/ScrollListPage.hpp>
@@ -47,6 +37,10 @@ public:
 	static int GammaToSlider(float value);
 	static float SliderToGamma(int slider);
 	static int FpsCapValueToIndex(int fps);
+	static int MsaaSamplesToIndex(int samples);
+	static int MsaaIndexToSamples(int index);
+	static int RenderScaleToIndex(float scale);
+	static float RenderScaleIndexToValue(int index);
 
 	void Mount(OptionsShell& shell) override;
 	void OnReshown(OptionsShell& shell) override;
@@ -63,16 +57,20 @@ private:
 	{
 	public:
 		enum : int {
-			kRowPreset     = 0,
-			kRowTerrain    = 1,
-			kRowObjectLod  = 2,
-			kRowShadow     = 3,
-			kRowParticles  = 4,
-			kRowVsync      = 5,
-			kRowFpsCap     = 6,
-			kRowBrightness = 7,
-			kRowGamma      = 8,
-			kRowCount      = 9,
+			kRowPreset         = 0,
+			kRowTerrain        = 1,
+			kRowObjectLod      = 2,
+			kRowShadow         = 3,
+			kRowParticles      = 4,
+			kRowVsync          = 5,
+			kRowFpsCap         = 6,
+			kRowBrightness     = 7,
+			kRowGamma          = 8,
+			kRowAdvanced       = 9,
+			kRowAntiAliasing   = 10,
+			kRowSupersampling  = 11,
+			kRowMultitexturing = 12,
+			kRowCount          = 13,
 		};
 
 		void SetPage(class GraphicsPage* page) { m_page = page; }
@@ -84,6 +82,7 @@ private:
 		int  RowValue(int row) const override;
 		void SetRowValue(int row, int v) override;
 		const char* SliderValueText(int row) const override;
+		OptionsScrollList::Kind RowKind(int row) const override;
 
 	private:
 		GraphicsPage* m_page = nullptr;
@@ -102,6 +101,12 @@ private:
 	std::array<const char*, 4>      m_shadowCStrs{};
 	std::array<std::string, 3>      m_particlesLabels;
 	std::array<const char*, 3>      m_particlesCStrs{};
+	std::array<std::string, 4>      m_msaaLabels;
+	std::array<const char*, 4>      m_msaaCStrs{};
+	std::array<std::string, 5>      m_renderScaleLabels;
+	std::array<const char*, 5>      m_renderScaleCStrs{};
+	std::array<std::string, 2>      m_offOnLabels;
+	std::array<const char*, 2>      m_offOnCStrs{};
 	std::array<std::string, 3>      m_vsyncLabels;
 	std::array<const char*, 3>      m_vsyncCStrs{};
 	std::array<std::string, 7>      m_fpsCapLabels;

--- a/engine/Poseidon/UI/Settings/GraphicsApply.cpp
+++ b/engine/Poseidon/UI/Settings/GraphicsApply.cpp
@@ -94,6 +94,7 @@ void ApplyGraphicsConfigToEngine(const GraphicsConfig& cfg)
         GEngine->SetAlphaToCoverage(cfg.alphaToCoverage);
         GEngine->SetRenderScale(cfg.renderScale);
         GEngine->SetMsaaSamples(cfg.msaaSamples);
+        GEngine->SetMultitexturing(cfg.multitexturing);
     }
     gUserFpsCap = cfg.fpsCap;
 }

--- a/engine/Poseidon/UI/Settings/GraphicsConfig.cpp
+++ b/engine/Poseidon/UI/Settings/GraphicsConfig.cpp
@@ -236,6 +236,8 @@ bool GraphicsConfig::Load(const std::string& path)
         renderScale = (float)*e;
     if (auto* e = cfg.FindEntry("msaaSamples"))
         msaaSamples = (int)*e;
+    if (auto* e = cfg.FindEntry("multitexturing"))
+        multitexturing = (int)*e != 0;
     if (auto* e = cfg.FindEntry("brightness"))
         brightness = (float)*e;
     if (auto* e = cfg.FindEntry("gamma"))
@@ -257,6 +259,7 @@ bool GraphicsConfig::Save(const std::string& path) const
     cfg.Add("alphaToCoverage", alphaToCoverage ? 1 : 0);
     cfg.Add("renderScale", renderScale);
     cfg.Add("msaaSamples", msaaSamples);
+    cfg.Add("multitexturing", multitexturing ? 1 : 0);
     cfg.Add("brightness", brightness);
     cfg.Add("gamma", gamma);
     cfg.Add("version", version);

--- a/engine/Poseidon/UI/Settings/GraphicsConfig.hpp
+++ b/engine/Poseidon/UI/Settings/GraphicsConfig.hpp
@@ -19,7 +19,9 @@
 //
 //   Per-user knobs      — independent of preset, keep value across
 //                         preset changes:
-//                           vsync, fpsCap, brightness, gamma
+//                           msaaSamples, renderScale, alphaToCoverage,
+//                           multitexturing, vsync, fpsCap, brightness,
+//                           gamma
 //
 // Autodetect on first boot: GraphicsConfig::PickPresetFromRam()
 // returns a tier from SDL_GetSystemRAM(); ApplyPresetToTiers fills the
@@ -75,9 +77,9 @@ public:
 	float     renderScale      = 1.0f;          // SSAA: render at scale x window and downsample.
 	                                             // 1.0 = off; up to 2.0.  The only general cure for
 	                                             // sub-pixel OPAQUE geometry sparkle (fence bars)
-	int       msaaSamples      = 0;             // MSAA on the frame target: 0 (off) / 2 / 4 / 8.
-	                                             // Default off — AA is being tuned via the dev panel
-	                                             // Render tab before a shipped default is picked
+	int       msaaSamples      = 0;             // MSAA on the frame target: 0 (off) / 2 / 4 / 8
+	bool      multitexturing   = true;          // Detail-texture / specular second stage on terrain and
+	                                             // objects.  Off drops those draws to the base texture
 	float     brightness       = 1.6f;          // 0.4..1.8
 	float     gamma            = 1.2f;          // 0.5..2.3
 

--- a/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
+++ b/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
@@ -530,12 +530,21 @@ void EngineGL33::CaptureScreenshotIfPending()
     RString path = _pendingScreenshotPath;
     _pendingScreenshotPath = "";
 
-    // With SSAA the final image lives in the default framebuffer after the
-    // resolve (BackToFront resolves before calling this); read window-sized.
-    GLint viewport[4];
-    glGetIntegerv(GL_VIEWPORT, viewport);
-    const int w = viewport[2];
-    const int h = viewport[3];
+    // glReadPixels rejects a multisampled read buffer, so the scaled frame
+    // target is never the source.  BackToFront resolves into the default
+    // framebuffer and draws gamma + overlay on top before calling this, and
+    // resolving a second time would overwrite that composite; only a mid-frame
+    // flush still has the scaled target bound.
+    GLint drawFbo = 0;
+    glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &drawFbo);
+    const bool onScaledTarget = SSAAActive() && drawFbo != 0;
+    if (onScaledTarget)
+        ResolveSSAAToDefault();
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+
+    int w = _w, h = _h;
+    if (_sdlWindow)
+        SDL_GetWindowSizeInPixels(_sdlWindow, &w, &h);
     if (w <= 0 || h <= 0)
         return;
 
@@ -557,6 +566,10 @@ void EngineGL33::CaptureScreenshotIfPending()
         }
     }
     ScreenshotWriter::WriteRGB(path, w, h, rgb.data());
+
+    // Hand the scaled target back so the rest of the frame keeps drawing into it.
+    if (onScaledTarget)
+        BindFrameRenderTarget();
 }
 
 void EngineGL33::BackToFront()

--- a/tests/integration/rendering/screenshot_with_msaa.test.sqf
+++ b/tests/integration/rendering/screenshot_with_msaa.test.sqf
@@ -1,0 +1,15 @@
+// Pins that a screenshot taken while MSAA is on reads the resolved window
+// image. triScreenshot flushes mid-frame, while the multisampled scaled target
+// is still bound, and a GL error there is fatal under strict mode.
+//
+// A render scale above 1 also makes the frame target larger than the window,
+// so the capture has to size the image from the window.
+
+triSimFrames 5;
+triSetMsaa 8;
+triSetRenderScale 1.5;
+triSimFrames 5;
+
+triScreenshot "msaa_8x_supersampled";
+
+triEndTest;

--- a/tests/integration/rendering/screenshot_with_msaa.test.toml
+++ b/tests/integration/rendering/screenshot_with_msaa.test.toml
@@ -1,0 +1,4 @@
+binary = "PoseidonGame"
+no_menu = false
+timeout = 60
+tags = ["headless"]

--- a/tests/integration/ui/options/graphics/new_graphics_multitexturing_persist.test.sqf
+++ b/tests/integration/ui/options/graphics/new_graphics_multitexturing_persist.test.sqf
@@ -1,0 +1,30 @@
+// Pins that the Multitexturing row reaches graphics.cfg on unmount.
+// Scancodes: 81 Down, 79 Right, 40 Enter, 41 Esc.
+
+triSimFrames 5;
+triSetLanguage "English";
+triSimFrames 5;
+triClickText "OPTIONS";
+triSimFrames 5;
+
+// Index focus starts on Audio; two rows down is Graphics.
+triSendKey 81;
+triSimFrames 1;
+triSendKey 81;
+triSimFrames 1;
+triSendKey 40;
+triSimFrames 5;
+
+// Page focus starts on Quality Preset; Multitexturing is eleven focus steps
+// down, the Advanced header being skipped rather than focused.
+for "_i" from 1 to 11 do {
+    triSendKey 81;
+    triSimFrames 1;
+};
+triSendKey 79;
+triSimFrames 2;
+
+triSendKey 41;
+triSimFrames 3;
+
+triEndTest;

--- a/tests/integration/ui/options/graphics/new_graphics_multitexturing_persist.test.toml
+++ b/tests/integration/ui/options/graphics/new_graphics_multitexturing_persist.test.toml
@@ -1,0 +1,4 @@
+binary = "PoseidonGame"
+no_menu = false
+timeout = 30
+tags = ["headless"]

--- a/tests/unit/engine/Poseidon/UI/Settings/test_graphicsConfig.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_graphicsConfig.cpp
@@ -129,6 +129,10 @@ TEST_CASE("GraphicsConfig: Save then Load round-trips every field", "[Settings][
     src.particlesQuality = GraphicsConfig::TierLow;
     src.vsync = GraphicsConfig::VsyncAdaptive;
     src.fpsCap = 144;
+    src.msaaSamples = 4;
+    src.renderScale = 1.5f;
+    src.alphaToCoverage = false;
+    src.multitexturing = false;
     src.brightness = 1.2f;
     src.gamma = 0.9f;
     REQUIRE(src.Save(path));
@@ -142,6 +146,10 @@ TEST_CASE("GraphicsConfig: Save then Load round-trips every field", "[Settings][
     CHECK(dst.particlesQuality == src.particlesQuality);
     CHECK(dst.vsync == src.vsync);
     CHECK(dst.fpsCap == src.fpsCap);
+    CHECK(dst.msaaSamples == src.msaaSamples);
+    CHECK(dst.renderScale == src.renderScale);
+    CHECK(dst.alphaToCoverage == src.alphaToCoverage);
+    CHECK(dst.multitexturing == src.multitexturing);
     CHECK(dst.brightness == src.brightness);
     CHECK(dst.gamma == src.gamma);
 }

--- a/tests/unit/engine/Poseidon/UI/test_graphics_page.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_graphics_page.cpp
@@ -82,3 +82,72 @@ TEST_CASE("GraphicsPage fps-cap index mapping falls back to unlimited for unknow
     CHECK(GraphicsPage::FpsCapValueToIndex(240) == 6);
     CHECK(GraphicsPage::FpsCapValueToIndex(165) == 0);
 }
+
+TEST_CASE("GraphicsPage MSAA index mapping falls back to off for unknown counts", "[UI][GraphicsPage]")
+{
+    CHECK(GraphicsPage::MsaaSamplesToIndex(0) == 0);
+    CHECK(GraphicsPage::MsaaSamplesToIndex(2) == 1);
+    CHECK(GraphicsPage::MsaaSamplesToIndex(4) == 2);
+    CHECK(GraphicsPage::MsaaSamplesToIndex(8) == 3);
+    CHECK(GraphicsPage::MsaaSamplesToIndex(16) == 0);
+
+    for (int i = 0; i < 4; ++i)
+        CHECK(GraphicsPage::MsaaSamplesToIndex(GraphicsPage::MsaaIndexToSamples(i)) == i);
+    CHECK(GraphicsPage::MsaaIndexToSamples(4) == 0);
+    CHECK(GraphicsPage::MsaaIndexToSamples(-1) == 0);
+}
+
+TEST_CASE("GraphicsPage render-scale index mapping picks the nearest step", "[UI][GraphicsPage]")
+{
+    CHECK(GraphicsPage::RenderScaleToIndex(1.0f) == 0);
+    CHECK(GraphicsPage::RenderScaleToIndex(1.25f) == 1);
+    CHECK(GraphicsPage::RenderScaleToIndex(1.5f) == 2);
+    CHECK(GraphicsPage::RenderScaleToIndex(1.75f) == 3);
+    CHECK(GraphicsPage::RenderScaleToIndex(2.0f) == 4);
+
+    CHECK(GraphicsPage::RenderScaleToIndex(1.6f) == 2);
+    CHECK(GraphicsPage::RenderScaleToIndex(1.05f) == 0);
+
+    for (int i = 0; i < 5; ++i)
+        CHECK(GraphicsPage::RenderScaleToIndex(GraphicsPage::RenderScaleIndexToValue(i)) == i);
+    CHECK(GraphicsPage::RenderScaleIndexToValue(5) == Catch::Approx(1.0f));
+    CHECK(GraphicsPage::RenderScaleIndexToValue(-1) == Catch::Approx(1.0f));
+}
+
+TEST_CASE("GraphicsPage anti-aliasing rows round-trip through the provider", "[UI][GraphicsPage]")
+{
+    TestableGraphicsPage page;
+    auto& p = page.Provider();
+
+    CHECK(p.RowValue(10) == 0);
+    CHECK(p.RowValue(11) == 0);
+
+    p.SetRowValue(10, 2);
+    CHECK(p.RowValue(10) == 2);
+    p.SetRowValue(11, 4);
+    CHECK(p.RowValue(11) == 4);
+}
+
+TEST_CASE("GraphicsPage multitexturing row is a boolean defaulting to on", "[UI][GraphicsPage]")
+{
+    TestableGraphicsPage page;
+    auto& p = page.Provider();
+
+    CHECK(p.RowKind(12) == OptionsScrollList::KindBoolean);
+    CHECK(p.RowValue(12) == 1);
+
+    p.SetRowValue(12, 0);
+    CHECK(p.RowValue(12) == 0);
+    p.SetRowValue(12, 1);
+    CHECK(p.RowValue(12) == 1);
+}
+
+// A focusable divider would strand keyboard nav on a row with no value to change.
+TEST_CASE("GraphicsPage advanced divider is an unfocusable header", "[UI][GraphicsPage]")
+{
+    TestableGraphicsPage page;
+    auto& p = page.Provider();
+
+    CHECK(p.RowKind(9) == OptionsScrollList::KindHeader);
+    CHECK_FALSE(OptionsScrollList::CanRowReceiveFocus(p.RowKind(9)));
+}


### PR DESCRIPTION
MSAA and the SSAA render scale were reachable only from the dev panel, and multitexturing was stranded on the legacy video screen OptionsShell replaced. All three become Graphics rows, and screenshot capture now resolves first.

<img width="799" height="620" alt="image" src="https://github.com/user-attachments/assets/f0c7f627-95b4-4cab-a147-d2ea085a1763" />
