### PR TITLE
Fix remote command removal

### DIFF
--- a/engine/Poseidon/AI/AISubgroup.cpp
+++ b/engine/Poseidon/AI/AISubgroup.cpp
@@ -1054,20 +1054,25 @@ void AISubgroup::DeleteCommand(NetworkId id)
         Command* task = _stack[i]._task;
         if (task && task->GetNetworkId() == id)
         {
-            _stack.Delete(i);
             if (i == n - 1)
             {
-                if (GetCurrent())
+                for (int j = i - 1; j >= 0; j--)
                 {
-                    AISubgroupContext context(this);
-                    context._task = GetCurrent()->_task;
-                    context._fsm = GetCurrent()->_fsm;
-                    PopTask(&context, false);
+                    if (!_stack[j]._fsm)
+                    {
+                        _stack.Delete(j, 1);
+                    }
                 }
+
+                AISubgroupContext context(this);
+                context._task = GetCurrent()->_task;
+                context._fsm = GetCurrent()->_fsm;
+                PopTask(&context, false);
             }
             else
             {
                 RptF("Warning: Delete out of order");
+                _stack.Delete(i);
             }
             break;
         }

--- a/tests/unit/engine/Poseidon/AI/test_ai_subgroup.cpp
+++ b/tests/unit/engine/Poseidon/AI/test_ai_subgroup.cpp
@@ -22,6 +22,34 @@ std::filesystem::path SourcePath(const std::filesystem::path& path)
 {
     return std::filesystem::path(TESTS_ROOT_DIR).parent_path() / path;
 }
+
+class TestAISubgroup : public AISubgroup
+{
+  public:
+    TestAISubgroup() { SetLocal(false); }
+
+    void SeedRemoteCommandStackWithPlaceholder(NetworkId queuedId, NetworkId currentId)
+    {
+        _stack.Resize(3);
+        _stack[0]._task = CreateCommand(queuedId);
+        _stack[0]._fsm = CreateFSM(Command::NoCommand);
+        _stack[2]._task = CreateCommand(currentId);
+        _stack[2]._fsm = CreateFSM(Command::NoCommand);
+    }
+
+    NetworkId CurrentCommandId() const { return GetCurrent()->_task->GetNetworkId(); }
+
+    void OnTaskDeleted(int, Command&) override {}
+
+  private:
+    static Command* CreateCommand(NetworkId id)
+    {
+        Command* command = new Command();
+        command->SetNetworkId(id);
+        command->SetLocal(false);
+        return command;
+    }
+};
 } // namespace
 
 TEST_CASE("arcadeTemplate compiles", "[ai]")
@@ -102,4 +130,36 @@ TEST_CASE("attack estimation retains its commander", "[ai][attack]")
     const std::string function = source.substr(estimate, overload - estimate);
 
     CHECK(function.find("Ref<AIUnit> unit = CommanderUnit();") != std::string::npos);
+}
+
+TEST_CASE("remote command deletion removes only the matched stack task", "[ai][network]")
+{
+    NetworkId queuedId(7, 11);
+    NetworkId currentId(7, 12);
+    TestAISubgroup subgroup;
+    subgroup.SeedRemoteCommandStackWithPlaceholder(queuedId, currentId);
+
+    SECTION("current command")
+    {
+        subgroup.DeleteCommand(currentId);
+
+        REQUIRE(subgroup.StackSize() == 1);
+        CHECK(subgroup.CurrentCommandId() == queuedId);
+    }
+
+    SECTION("queued command")
+    {
+        subgroup.DeleteCommand(queuedId);
+
+        REQUIRE(subgroup.StackSize() == 2);
+        CHECK(subgroup.CurrentCommandId() == currentId);
+    }
+
+    SECTION("unknown command")
+    {
+        subgroup.DeleteCommand(NetworkId(7, 13));
+
+        REQUIRE(subgroup.StackSize() == 3);
+        CHECK(subgroup.CurrentCommandId() == currentId);
+    }
 }


### PR DESCRIPTION
Keep the current command on the stack until `PopTask` exits and removes it, clearing empty placeholders first. This prevents a null FSM exit and preserves the queued command below it.

- fixes server crash reported