### PR TITLE
Retain commander during attack estimation

### DIFF
--- a/engine/Poseidon/World/Detection/TargetFire.cpp
+++ b/engine/Poseidon/World/Detection/TargetFire.cpp
@@ -96,11 +96,12 @@ int EntityAI::EstimateAttack(const Vector3& hPos, float height, const EntityAI* 
     Matrix4 transform; // predict what position will the vehicle have
 
     Vector3 hePos = hPos;
-    AIUnit* unit = CommanderUnit();
-    if (unit)
+    Ref<AIUnit> unit = CommanderUnit();
+    if (!unit)
     {
-        unit->FindNearestEmpty(hePos);
+        return 0;
     }
+    unit->FindNearestEmpty(hePos);
 
     float dx, dz;
     float posY = GLandscape->RoadSurfaceYAboveWater(hePos.X(), hePos.Z(), &dx, &dz);

--- a/tests/unit/engine/Poseidon/AI/test_ai_subgroup.cpp
+++ b/tests/unit/engine/Poseidon/AI/test_ai_subgroup.cpp
@@ -90,3 +90,16 @@ TEST_CASE("remote command deletion resolves the subgroup task by network id", "[
     CHECK(deleteCommandCase.find("dc.subgrp->DeleteCommand(dc.object)") != std::string::npos);
     CHECK(deleteCommandCase.find("dynamic_cast<Command*>") == std::string::npos);
 }
+
+TEST_CASE("attack estimation retains its commander", "[ai][attack]")
+{
+    const std::string source = ReadTextFile(SourcePath("engine/Poseidon/World/Detection/TargetFire.cpp"));
+    const size_t estimate = source.find("int EntityAI::EstimateAttack(");
+    REQUIRE(estimate != std::string::npos);
+    const size_t overload =
+        source.find("int EntityAI::EstimateAttack(const Vector3& hPos, float height) const", estimate);
+    REQUIRE(overload != std::string::npos);
+    const std::string function = source.substr(estimate, overload - estimate);
+
+    CHECK(function.find("Ref<AIUnit> unit = CommanderUnit();") != std::string::npos);
+}


### PR DESCRIPTION
Attack estimation kept a raw commander pointer across visibility and weapon work, allowing it to disappear before the later group lookup. Hold a reference for the calculation and stop when no commander exists.

- fixes user reported crash in Retaliation campaign, mission Zachistka