### PR TITLE
Add database, JSON, loadout, and script event commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ or the [Steam demo folder](https://store.steampowered.com/app/4819000/Arma_Cold_
 ## Layout
 
 - [Apps](apps/README.md) - executable targets
+- [Documentation](docs/README.md) - scripting and engine feature notes
 - [Engine](engine/README.md) - engine libraries and Rust Trident tooling
 - [Master server tools](mserver/README.md) - Rust service and CLI crates
 - [Tests](tests/README.md) - test source trees; CI currently compiles them only

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+- [Scripting](scripting/README.md)

--- a/docs/scripting/README.md
+++ b/docs/scripting/README.md
@@ -1,0 +1,15 @@
+# Scripting
+
+- [Database and Cache](database.md)
+- [JSON Commands](json.md)
+- [Scripting Commands](commands.md)
+
+## SQS-Style Scripts
+
+Scripts that use SQS flow control such as labels (`#label`), conditional jumps
+(`? condition : goto "label"`), `exit`, or waits (`~5`) are parsed line by line.
+Keep command expressions on one line in those scripts.
+
+This is especially important for nested array arguments used by `jsonObject`,
+`jsonSelect`, and `cacheSet`. A multi-line expression can be parsed as an
+incomplete line and produce `Any`/type errors.

--- a/docs/scripting/README.md
+++ b/docs/scripting/README.md
@@ -1,8 +1,9 @@
 # Scripting
 
-- [Database and Cache](database.md)
 - [JSON Commands](json.md)
+- [Database and Cache](database.md)
 - [Scripting Commands](commands.md)
+- [Script Event System](event-system.md)
 
 ## SQS-Style Scripts
 
@@ -11,5 +12,5 @@ Scripts that use SQS flow control such as labels (`#label`), conditional jumps
 Keep command expressions on one line in those scripts.
 
 This is especially important for nested array arguments used by `jsonObject`,
-`jsonSelect`, and `cacheSet`. A multi-line expression can be parsed as an
-incomplete line and produce `Any`/type errors.
+`jsonSelect`, `cacheSet`, and `eventOn` inline code blocks. A multi-line
+expression can be parsed as an incomplete line and produce `Any`/type errors.

--- a/docs/scripting/commands.md
+++ b/docs/scripting/commands.md
@@ -59,3 +59,8 @@ lifeState unit
 ```
 
 Returns `"HEALTHY"`, `"INJURED"`, `"UNCONSCIOUS"`, or `"DEAD"`.
+
+## Script Events
+
+See [event-system.md](event-system.md) for `eventOn`, `eventGet`, `eventList`,
+`eventOff`, `eventClear`, and the domain-specific event emitters.

--- a/docs/scripting/commands.md
+++ b/docs/scripting/commands.md
@@ -1,0 +1,61 @@
+# Scripting Commands
+
+This page documents small generic scripting command additions that do not need a
+dedicated topic page.
+
+## Unit Loadout
+
+```sqf
+getUnitLoadout unit
+unit setUnitLoadout loadout
+```
+
+`getUnitLoadout` captures:
+
+- weapons
+- magazines with ammo counts
+- selected weapon or muzzle
+
+The returned value is:
+
+```sqf
+[
+  [weaponClass, ...],
+  [magazineClass, ammoCount, ...],
+  selectedMuzzle
+]
+```
+
+Example:
+
+```sqf
+loadout = getUnitLoadout player
+player setUnitLoadout loadout
+```
+
+The returned structure is suitable for JSON storage:
+
+```sqf
+state = jsonObject [
+  ["position", getPosASL player],
+  ["direction", getDir player],
+  ["loadout", getUnitLoadout player]
+]
+
+dbSave ["actor", uid, state]
+```
+
+In SQS-style scripts, keep the `jsonObject` call on one line:
+
+```sqf
+state = jsonObject [["position", getPosASL player], ["direction", getDir player], ["loadout", getUnitLoadout player]]
+dbSave ["actor", uid, state]
+```
+
+## Unit Life State
+
+```sqf
+lifeState unit
+```
+
+Returns `"HEALTHY"`, `"INJURED"`, `"UNCONSCIOUS"`, or `"DEAD"`.

--- a/docs/scripting/database.md
+++ b/docs/scripting/database.md
@@ -1,0 +1,373 @@
+# Database and Cache
+
+Poseidon exposes a small generic persistence layer to scripts. It is intentionally
+not tied to a specific mod or game mode. Higher-level systems can build on these
+commands for actors, accounts, world state, economy data, mission state, or editor
+tools.
+
+## Storage Layout
+
+Database records are stored under the active profile directory:
+
+```text
+<profileDirectory>/LocalDb/<database>/<key>.json
+```
+
+For example:
+
+```sqf
+dbSave ["actor", "76561198027566824", state]
+```
+
+writes:
+
+```text
+LocalDb/actor/76561198027566824.json
+```
+
+And:
+
+```sqf
+dbSave ["world", "state", world]
+```
+
+writes:
+
+```text
+LocalDb/world/state.json
+```
+
+The `database` and `key` values are safe identifiers, not arbitrary paths. This
+keeps scripts from escaping the database root.
+
+## Sync Versus Async
+
+The database exposes both synchronous and asynchronous commands because scripts
+need both deterministic setup flows and non-blocking gameplay persistence.
+
+Use synchronous commands for mission init, shutdown/save checkpoints, debugging,
+tests, and small one-off operations where the script must immediately receive
+the value before continuing.
+
+Use asynchronous commands for live gameplay, repeated persistence, larger scans,
+or any path where disk I/O could be visible to the player. Async commands enqueue
+work on the local DB worker thread and return a job id that scripts can poll.
+
+The cache commands are usually the best gameplay-facing pattern: keep the latest
+record in memory with `cacheSet`, then write it with `cacheAsyncFlush` or
+`cacheAsyncFlushAll` when immediate disk durability is not required.
+
+## Database Commands
+
+```sqf
+dbRoot
+dbSave ["database", "key", json]
+dbLoad ["database", "key"]
+dbRemove ["database", "key"]
+dbExists ["database", "key"]
+dbList "database"
+dbFind ["database", "field", value]
+dbFindPath ["database", ["nested", "field"], value]
+dbIndex ["database", "field"]
+dbIndexPath ["database", ["nested", "field"]]
+dbUpdate ["database", "key", { jsonSet [_this, "cash", (jsonGet [_this, "cash"]) + 100] }]
+```
+
+`dbSave` writes immediately to disk. `dbLoad` reads the record from disk and
+returns the stored JSON string. These commands are synchronous and should be
+kept out of hot gameplay paths. Prefer the async commands or the cache layer for
+player-facing runtime persistence.
+
+## Async Database Commands
+
+```sqf
+job = dbAsyncSave ["database", "key", json]
+job = dbAsyncLoad ["database", "key"]
+job = dbAsyncRemove ["database", "key"]
+job = dbAsyncExists ["database", "key"]
+job = dbAsyncList "database"
+job = dbAsyncFind ["database", "field", value]
+job = dbAsyncFindPath ["database", ["nested", "field"], value]
+job = dbAsyncIndex ["database", "field"]
+job = dbAsyncIndexPath ["database", ["nested", "field"]]
+dbAsyncDone job
+dbAsyncResult job
+dbAsyncClear job
+dbAsyncJobs
+```
+
+The async commands copy their arguments immediately, enqueue file work on the
+local DB worker thread, and return a numeric job id. They do not wait for disk
+I/O on the script thread. Invalid arguments or unavailable queued data return
+`-1`. Completed async job records should be cleared with `dbAsyncClear`; the
+engine prunes old completed jobs when the async job table reaches its safety cap.
+
+`dbAsyncResult` returns an array:
+
+```sqf
+[jobId, status, ok, result]
+```
+
+`status` is `"queued"`, `"running"`, or `"done"`. `ok` is meaningful once the
+status is `"done"`.
+
+The result field matches the operation:
+
+- `dbAsyncLoad`: stored JSON string, or `""`/nil on failure.
+- `dbAsyncExists`: boolean.
+- `dbAsyncList`, `dbAsyncFind`, `dbAsyncFindPath`: array of keys.
+- `dbAsyncIndex`, `dbAsyncIndexPath`: array of `[fieldValue, [key, ...]]`.
+- `dbAsyncSave`, `dbAsyncRemove`: no result payload; use `ok`.
+
+Example:
+
+```sqf
+job = dbAsyncLoad ["actor", "76561198027566824"]
+
+#poll
+~0.1
+? !(dbAsyncDone job) : goto "poll"
+
+result = dbAsyncResult job
+ok = result select 2
+state = result select 3
+dbAsyncClear job
+```
+
+`dbUpdate` remains synchronous because it executes a script code block in the VM
+between load and save. Use async load/save with an explicit script-side update
+flow when a non-blocking gameplay path is required.
+
+Example:
+
+```sqf
+state = jsonObject [
+  ["uid", "76561198027566824"],
+  ["cash", 0],
+  ["bank", 2000],
+  ["position", getPosASL player],
+  ["direction", getDir player],
+  ["loadout", getUnitLoadout player]
+]
+
+dbSave ["actor", "76561198027566824", state]
+```
+
+In SQS-style scripts, keep the full `jsonObject` expression on one line:
+
+```sqf
+state = jsonObject [["uid", "76561198027566824"], ["cash", 0], ["bank", 2000], ["position", getPosASL player], ["direction", getDir player], ["loadout", getUnitLoadout player]]
+dbSave ["actor", "76561198027566824", state]
+```
+
+## Query And Index Helpers
+
+`dbFind` scans the keys from `dbList`, loads each JSON record, and returns the
+keys whose top-level field matches the requested value.
+
+```sqf
+westActors = dbFind ["actor", "side", "WEST"]
+richActors = dbFind ["actor", "cash", 1000]
+```
+
+`dbFindPath` does the same check against a nested object path:
+
+```sqf
+medics = dbFindPath ["actor", ["role", "class"], "medic"]
+```
+
+`dbIndex` groups records by a top-level JSON field and returns pairs of
+`[fieldValue, [matchingKey, ...]]`.
+
+```sqf
+bySide = dbIndex ["actor", "side"]
+```
+
+`dbIndexPath` groups by a nested path:
+
+```sqf
+byTown = dbIndexPath ["container", ["location", "town"]]
+```
+
+These helpers are scan-based indexes. They are intended for moderate profile
+databases and mission startup/catalog use. For hot gameplay paths, cache the
+result in script memory or maintain a dedicated index record with `dbUpdate`.
+
+## Atomic Updates
+
+`dbUpdate` loads one record, runs a code block with `_this` set to the current
+JSON string, and saves the string returned by the code block. The load, script
+transform, save, and cache refresh run under the local DB command lock, so two
+script commands in the same process cannot interleave a read-modify-write cycle.
+
+```sqf
+dbUpdate ["actor", uid, {
+  state = _this
+  cash = jsonGet [state, "cash"]
+  jsonSet [state, "cash", cash + 100]
+}]
+```
+
+SQS-safe inline form:
+
+```sqf
+dbUpdate ["actor", uid, { state = _this; cash = jsonGet [state, "cash"]; jsonSet [state, "cash", cash + 100] }]
+```
+
+If the record does not exist, `_this` is an empty string. The block should return
+a complete JSON document.
+
+## Cache Commands
+
+```sqf
+cacheLoad ["database", "key"]
+cacheGet ["database", "key"]
+cacheSet ["database", "key", json]
+cacheFlush ["database", "key"]
+cacheFlushAll
+cacheAsyncFlush ["database", "key"]
+cacheAsyncFlushAll
+cacheRemove ["database", "key"]
+cacheClear
+```
+
+The cache layer keeps records in memory so scripts can avoid repeated disk reads
+and writes during gameplay.
+
+- `cacheLoad` reads one record from disk into memory.
+- `cacheGet` returns the in-memory JSON string.
+- `cacheSet` updates only memory.
+- `cacheFlush` writes one cached record to disk and keeps it in memory.
+- `cacheFlushAll` writes all cached records for the active profile.
+- `cacheAsyncFlush` and `cacheAsyncFlushAll` enqueue flush work on the local DB
+  worker thread. They read the current cache when the worker runs, so later
+  `cacheSet` calls can still affect the async flush before it starts.
+- `cacheRemove` removes one record from memory only.
+- `cacheClear` clears all cached records from memory.
+
+Example: update cash in memory, then enqueue a background flush.
+
+```sqf
+uid = "76561198027566824"
+
+cacheLoad ["actor", uid]
+
+state = cacheGet ["actor", uid]
+cash = jsonGet [state, "cash"]
+state = jsonSet [state, "cash", cash + 100]
+
+cacheSet ["actor", uid, state]
+cacheAsyncFlush ["actor", uid]
+```
+
+## Actor Save And Load
+
+Save the current player:
+
+```sqf
+uid = _this select 0
+
+state = jsonObject [
+  ["uid", uid],
+  ["cash", 0],
+  ["bank", 2000],
+  ["position", getPosASL player],
+  ["direction", getDir player],
+  ["loadout", getUnitLoadout player]
+]
+
+cacheSet ["actor", uid, state]
+cacheAsyncFlush ["actor", uid]
+```
+
+SQS-safe version:
+
+```sqf
+uid = _this select 0
+state = jsonObject [["uid", uid], ["cash", 0], ["bank", 2000], ["position", getPosASL player], ["direction", getDir player], ["loadout", getUnitLoadout player]]
+cacheSet ["actor", uid, state]
+cacheAsyncFlush ["actor", uid]
+```
+
+Load and apply the saved player:
+
+```sqf
+uid = _this select 0
+
+loaded = cacheLoad ["actor", uid]
+
+? !loaded : goto "new_actor"
+
+state = cacheGet ["actor", uid]
+values = jsonSelect [state, ["position", "direction", "loadout", "cash", "bank"]]
+
+player setPosASL (values select 0)
+player setDir (values select 1)
+player setUnitLoadout (values select 2)
+
+cash = values select 3
+bank = values select 4
+
+hint format ["Loaded actor\nCash: %1\nBank: %2", cash, bank]
+exit
+
+#new_actor
+state = jsonObject [
+  ["uid", uid],
+  ["cash", 0],
+  ["bank", 2000],
+  ["position", getPosASL player],
+  ["direction", getDir player],
+  ["loadout", getUnitLoadout player]
+]
+
+cacheSet ["actor", uid, state]
+cacheAsyncFlush ["actor", uid]
+
+hint "Created new actor"
+```
+
+When this load script uses SQS labels and `goto`, write the new actor state on
+one line:
+
+```sqf
+#new_actor
+state = jsonObject [["uid", uid], ["cash", 0], ["bank", 2000], ["position", getPosASL player], ["direction", getDir player], ["loadout", getUnitLoadout player]]
+cacheSet ["actor", uid, state]
+cacheAsyncFlush ["actor", uid]
+```
+
+## Single Record Versus World Document
+
+There are two useful persistence patterns.
+
+Per-record files:
+
+```text
+LocalDb/actor/<uid>.json
+LocalDb/vehicle/<id>.json
+LocalDb/container/<id>.json
+```
+
+This is good when records are independent and can be loaded or flushed one at a
+time.
+
+One shared document:
+
+```text
+LocalDb/world/state.json
+```
+
+This is useful when scripts want one world state document with nested sections:
+
+```json
+{
+  "actors": {},
+  "vehicles": {},
+  "economy": {},
+  "mission": {}
+}
+```
+
+Use `jsonPathGet`, `jsonPathSet`, and `jsonPathRemove` for this pattern. Saving
+still writes the whole document.

--- a/docs/scripting/event-system.md
+++ b/docs/scripting/event-system.md
@@ -1,0 +1,266 @@
+# Script Event System
+
+Poseidon exposes a named script event bus for mission and mod scripts. It is
+separate from object event handlers such as `unit addEventHandler [...]`.
+
+Handlers are script files. When an event fires, each handler script receives:
+
+```sqf
+_this select 0
+_this select 1
+_this select 2
+_this select 3
+```
+
+Where:
+
+```sqf
+scope = _this select 0
+name = _this select 1
+payload = _this select 2
+sender = _this select 3
+```
+
+`sender` is the remote sender DPID when an event is delivered through
+`remoteExec`. Local events and single-player fallback events use `-1`.
+
+## Commands
+
+```sqf
+eventOn ["scope", "name", "script.sqf"]
+eventOn ["scope", "name", { statement; statement }]
+eventGet handlerId
+eventList
+eventOff handlerId
+eventClear ["scope", "name"]
+
+eventEmit ["scope", "name", payload]
+eventEmitLocal ["name", payload]
+eventEmitGlobal ["name", payload]
+eventEmitServer ["name", payload]
+eventEmitTarget [target, "name", payload]
+eventReceive ["scope", "name", payload]
+```
+
+`eventOn` returns a numeric handler id. Store that id if the handler needs to be
+removed later with `eventOff`.
+
+`eventGet handlerId` returns one handler record:
+
+```sqf
+[id, scope, name, type, body]
+```
+
+`type` is `"script"` for script-file handlers or `"code"` for inline code block
+handlers. If the id is not registered, `eventGet` returns an empty array.
+
+`eventList` returns an array of all current handler records in the same format.
+
+Strings always run script files:
+
+```sqf
+eventOn ["local", "actorLoaded", "events\on_actor_loaded.sqf"]
+```
+
+Code blocks run inline:
+
+```sqf
+eventOn ["local", "actorLoaded", { payload = _this select 2; hint payload }]
+```
+
+Inline code block handlers should also stay on one line in SQS-style scripts.
+
+Inline code runs immediately during event dispatch. Script-file handlers are
+started as scripts, like `exec`, and may use SQS waits such as `~5`.
+
+Handlers are mission-scoped. The engine clears registered event handlers before
+running a mission's `init.sqs` and `init.sqf`, so each mission starts with a fresh
+event registry and can register its handlers from init scripts.
+
+`eventEmit ["scope", "name", payload]` is still available for custom local
+scopes. Use the domain-specific emitters for normal local, global, server, and
+targeted delivery.
+
+`eventReceive` is the network delivery endpoint used by `eventEmitGlobal`,
+`eventEmitServer`, and `eventEmitTarget`. Scripts can call it directly, but
+normal mission code should usually use the emit helpers.
+
+## Scopes
+
+The scope is a string, so systems can define their own scope names. The engine
+provides four expected patterns:
+
+- `local`: process-local events only.
+- `global`: events intended for every machine in multiplayer.
+- `server`: events intended for the server.
+- `target`: events intended for a selected target.
+
+`eventEmitLocal` dispatches with the `local` scope on the current machine. It
+does not perform network forwarding.
+
+`eventEmit ["scope", "name", payload]` also dispatches only on the current
+machine and is intended for custom scopes.
+
+`eventEmitGlobal` sends through `remoteExec` in multiplayer. In single-player, it
+falls back to local dispatch with the `global` scope.
+
+`eventEmitServer` sends through `remoteExec` to the server in multiplayer. In
+single-player, it falls back to local dispatch with the `server` scope.
+
+`eventEmitTarget` sends through `remoteExec` to a specific target with the
+`target` scope. The target uses the normal `remoteExec` selector rules: a
+positive DPID targets one client, an object targets its owner, `-2` targets all
+clients, and an array combines selectors. Group targets are expanded by
+`eventEmitTarget` into the group's unit objects before network dispatch, so a
+group sends to the owners of its units rather than only the owner of the group
+object itself.
+
+## Local Event Example
+
+Register a local handler:
+
+```sqf
+cashHandler = eventOn ["local", "actorCashChanged", "events\on_actor_cash_changed.sqf"]
+```
+
+Register a local inline handler:
+
+```sqf
+cashHandler = eventOn ["local", "actorCashChanged", { payload = _this select 2; hint format ["Cash: %1", jsonGet [payload, "cash"]] }]
+```
+
+Emit the event:
+
+```sqf
+payload = jsonObject [
+  ["uid", "76561198027566824"],
+  ["cash", 500]
+]
+
+eventEmitLocal ["actorCashChanged", payload]
+```
+
+SQS-safe payload form:
+
+```sqf
+payload = jsonObject [["uid", "76561198027566824"], ["cash", 500]]
+eventEmitLocal ["actorCashChanged", payload]
+```
+
+Handler script:
+
+```sqf
+scope = _this select 0
+name = _this select 1
+payload = _this select 2
+
+uid = jsonGet [payload, "uid"]
+cash = jsonGet [payload, "cash"]
+
+hint format ["%1 cash: %2", uid, cash]
+```
+
+## Global Event Example
+
+Register on each machine:
+
+```sqf
+eventOn ["global", "actorLoaded", "events\on_actor_loaded.sqf"]
+```
+
+Emit from any machine:
+
+```sqf
+payload = jsonObject [
+  ["uid", uid],
+  ["name", name player]
+]
+
+eventEmitGlobal ["actorLoaded", payload]
+```
+
+In multiplayer this is forwarded using `remoteExec ["eventReceive", 0]`.
+
+## Server Event Example
+
+Register on the server:
+
+```sqf
+? isServer : eventOn ["server", "actorSaveRequested", "events\server_actor_save.sqf"]
+```
+
+Emit from a client:
+
+```sqf
+state = jsonObject [
+  ["uid", uid],
+  ["position", getPosASL player],
+  ["direction", getDir player],
+  ["loadout", getUnitLoadout player]
+]
+
+eventEmitServer ["actorSaveRequested", state]
+```
+
+Server handler:
+
+```sqf
+scope = _this select 0
+name = _this select 1
+state = _this select 2
+sender = _this select 3
+
+uid = jsonGet [state, "uid"]
+
+cacheSet ["actor", uid, state]
+cacheFlush ["actor", uid]
+```
+
+## Targeted Client Reply
+
+A handler for targeted replies should register with the `target` scope on any
+machine that may receive the reply:
+
+```sqf
+eventOn ["target", "actorLoaded", "events\on_actor_loaded.sqf"]
+```
+
+A server handler can reply only to the client that made a request by using the
+sender DPID:
+
+```sqf
+eventOn ["server", "actorLoadRequested", {
+  payload = _this select 2
+  sender = _this select 3
+
+  uid = jsonGet [payload, "uid"]
+  state = dbLoad ["actor", uid]
+  reply = jsonObject [["uid", uid], ["state", state]]
+
+  eventEmitTarget [sender, "actorLoaded", reply]
+}]
+```
+
+The target can also be a player object, group, or array of supported target
+selectors. Groups are expanded to their units and duplicate recipients are
+deduplicated by the network dispatch layer:
+
+```sqf
+eventEmitTarget [player, "actorLoaded", reply]
+eventEmitTarget [group player, "squadStateChanged", payload]
+eventEmitTarget [[player, group cursorTarget], "squadStateChanged", payload]
+eventEmitTarget [-2, "roundStarted", payload]
+```
+
+## Removing Handlers
+
+```sqf
+handler = eventOn ["local", "test", "events\test.sqf"]
+eventOff handler
+```
+
+Remove every handler for one event:
+
+```sqf
+eventClear ["local", "test"]
+```

--- a/docs/scripting/json.md
+++ b/docs/scripting/json.md
@@ -1,0 +1,141 @@
+# JSON Commands
+
+Poseidon exposes JSON helpers for creating, reading, updating, and querying JSON
+documents from scripts. JSON values are represented as strings at the script
+level, and mutation commands return a new JSON string.
+
+## Commands
+
+```sqf
+jsonValid json
+jsonStringify value
+jsonObject [[key, value], ...]
+
+jsonGet [json, key]
+jsonGetString [json, key]
+jsonGetNumber [json, key]
+jsonGetBool [json, key]
+jsonGetArray [json, key]
+jsonSelect [json, keys]
+
+jsonSet [json, key, value]
+jsonRemove [json, key]
+jsonHas [json, key]
+jsonKeys json
+jsonValues json
+
+jsonPathGet [json, path]
+jsonPathSet [json, path, value]
+jsonPathRemove [json, path]
+
+jsonCount jsonArray
+jsonAt [jsonArray, index]
+jsonPush [jsonArray, value]
+jsonInsert [jsonArray, index, value]
+jsonSetAt [jsonArray, index, value]
+jsonDeleteAt [jsonArray, index]
+```
+
+## Objects
+
+`jsonObject` creates a JSON object from key-value pairs.
+
+```sqf
+state = jsonObject [
+  ["cash", 0],
+  ["bank", 2000]
+]
+```
+
+SQS-style scripts are parsed line by line, so keep the whole expression on one
+line when using labels, `goto`, `exit`, or waits:
+
+```sqf
+state = jsonObject [["cash", 0], ["bank", 2000]]
+```
+
+`jsonSet` returns a new JSON string with the field changed:
+
+```sqf
+state = jsonSet [state, "cash", 100]
+cash = jsonGet [state, "cash"]
+```
+
+`jsonRemove` returns a new JSON string without the field:
+
+```sqf
+state = jsonRemove [state, "cash"]
+```
+
+## Reading Values
+
+Use `jsonGet` when the field may be a string, number, bool, or array:
+
+```sqf
+cash = jsonGet [state, "cash"]
+loadout = jsonGet [state, "loadout"]
+```
+
+Use typed getters when the expected type should be explicit:
+
+```sqf
+uid = jsonGetString [state, "uid"]
+cash = jsonGetNumber [state, "cash"]
+alive = jsonGetBool [state, "alive"]
+position = jsonGetArray [state, "position"]
+```
+
+Use `jsonSelect` to read several fields at once:
+
+```sqf
+values = jsonSelect [state, ["position", "direction", "loadout", "cash", "bank"]]
+
+position = values select 0
+direction = values select 1
+loadout = values select 2
+cash = values select 3
+bank = values select 4
+```
+
+## JSON Path
+
+`jsonPathGet`, `jsonPathSet`, and `jsonPathRemove` operate on nested object keys.
+
+Example:
+
+```sqf
+world = dbLoad ["world", "state"]
+
+cash = jsonPathGet [world, ["actors", uid, "cash"]]
+world = jsonPathSet [world, ["actors", uid, "cash"], cash + 100]
+
+dbSave ["world", "state", world]
+```
+
+This writes the whole `world/state.json` document back to disk. The path helper
+only changes the nested value inside the JSON string returned to the script.
+
+## Arrays
+
+Use the array helpers when a JSON value is itself an array:
+
+```sqf
+items = jsonStringify ["M16", "Binocular"]
+items = jsonPush [items, "HandGrenade"]
+count = jsonCount items
+first = jsonAt [items, 0]
+```
+
+`jsonInsert` inserts at the requested index and appends when the index is out of
+range:
+
+```sqf
+items = jsonInsert [items, 1, "NVGoggles"]
+```
+
+`jsonSetAt` replaces an existing index and leaves the array unchanged when the
+index is out of range:
+
+```sqf
+items = jsonSetAt [items, 0, "AK74"]
+```

--- a/engine/Evaluator/EvalState.cpp
+++ b/engine/Evaluator/EvalState.cpp
@@ -274,6 +274,17 @@ static GameValue CmdGetDammage(const GameState* state, GameValuePar arg)
     return GameValue(obj ? obj->damage : 0.0f);
 }
 
+static GameValue CmdLifeState(const GameState* state, GameValuePar arg)
+{
+    int id = getObjectId(arg);
+    auto* obj = getEval(state)->objects.getObject(id);
+    if (!obj || !obj->alive || obj->damage >= 1.0f)
+    {
+        return GameValue("DEAD");
+    }
+    return GameValue(obj->damage > 0.0f ? "INJURED" : "HEALTHY");
+}
+
 static GameValue CmdIsNull(const GameState* state, GameValuePar arg)
 {
     if (!arg.GetData())
@@ -344,6 +355,7 @@ void EvalState::RegisterObjectCommands()
     NewFunction(GameFunction(GameArray, "getPos", CmdGetPos, MockGameObject));
     NewFunction(GameFunction(GameScalar, "getDir", CmdGetDir, MockGameObject));
     NewFunction(GameFunction(GameScalar, "getDammage", CmdGetDammage, MockGameObject));
+    NewFunction(GameFunction(GameString, "lifeState", CmdLifeState, MockGameObject));
     NewFunction(GameFunction(GameBool, "isNull", CmdIsNull, GameVoid));
 
     NewOperator(GameOperator(GameNothing, "setPos", function, CmdSetPos, MockGameObject, GameArray));

--- a/engine/Evaluator/express.cpp
+++ b/engine/Evaluator/express.cpp
@@ -299,7 +299,7 @@ GameValue GameState::Const() const
         if (closed)
         {
             _e->_pos = end + 1;
-            return RString(start, end - start);
+            return GameValue(new GameDataCode(RString(start, end - start)));
         }
         else
         {
@@ -1129,24 +1129,27 @@ static const GameOperator* GetDefaultBinary(int* outSize = nullptr)
         GameOperator(GameVoid, "select", function, ListSelect, GameArray, GameBool),
         GameOperator(GameNothing, "set", function, ListSet, GameArray, GameArray),
         GameOperator(GameNothing, "resize", function, ListResize, GameArray, GameScalar),
-        GameOperator(GameScalar, "count", function, ListCountCond, GameString, GameArray),
-        GameOperator(GameNothing, "forEach", function, ListForEach, GameString, GameArray),
+        GameOperator(GameScalar, "count", function, ListCountCond, GameString | GameCode, GameArray),
+        GameOperator(GameNothing, "forEach", function, ListForEach, GameString | GameCode, GameArray),
         GameOperator(GameBool, "in", function, ListIsIn, GameVoid, GameArray),
         GameOperator(GameScalar, "find", function, ListFind, GameArray, GameVoid),
 
-        GameOperator(GameAny, "then", function, StringThen, GameIf, GameString),
+        GameOperator(GameAny, "then", function, StringThen, GameIf, GameString | GameCode),
         GameOperator(GameAny, "then", function, ArrayThen, GameIf, GameArray),
-        GameOperator(GameAny, "exitWith", function, StringExitWith, GameIf, GameString),
+        GameOperator(GameAny, "exitWith", function, StringExitWith, GameIf, GameString | GameCode),
         GameOperator(GameArray, "else", functionFirst, StringElse, GameString, GameString),
-        GameOperator(GameNothing, "do", function, StringRepeat, GameWhile, GameString),
+        GameOperator(GameArray, "else", functionFirst, StringElse, GameCode, GameCode),
+        GameOperator(GameArray, "else", functionFirst, StringElse, GameString, GameCode),
+        GameOperator(GameArray, "else", functionFirst, StringElse, GameCode, GameString),
+        GameOperator(GameNothing, "do", function, StringRepeat, GameWhile, GameString | GameCode),
 
         // for "var" from N to M [step S] do { body }
         GameOperator(GameForFrom, "from", function, ForFromOp, GameFor, GameScalar),
         GameOperator(GameForTo, "to", function, ForToOp, GameForFrom, GameScalar),
         GameOperator(GameForTo, "step", function, ForStepOp, GameForTo, GameScalar),
-        GameOperator(GameAny, "do", function, ForDoOp, GameForTo, GameString),
+        GameOperator(GameAny, "do", function, ForDoOp, GameForTo, GameString | GameCode),
 
-        GameOperator(GameAny, "call", function, StringCall, GameVoid, GameString),
+        GameOperator(GameAny, "call", function, StringCall, GameVoid, GameString | GameCode),
     };
     if (outSize)
     {
@@ -1185,13 +1188,13 @@ static const GameFunction* GetDefaultUnary(int* outSize = nullptr)
         GameFunction(GameBool, "not", BoolNot, GameBool),
 
         GameFunction(GameScalar, "count", ListCount, GameArray),
-        GameFunction(GameAny, "call", StringCallNoArg, GameString),
+        GameFunction(GameAny, "call", StringCallNoArg, GameString | GameCode),
         GameFunction(GameNothing, "comment", StringIgnore, GameString),
         GameFunction(GameNothing, "private", StringLocal, GameString | GameArray),
         GameFunction(GameAny, "parseSimpleArray", ParseSimpleArray, GameString),
 
         GameFunction(GameIf, "if", IfBool, GameBool),
-        GameFunction(GameWhile, "while", WhileString, GameString),
+        GameFunction(GameWhile, "while", WhileString, GameString | GameCode),
         GameFunction(GameFor, "for", ForVarString, GameString),
     };
     if (outSize)
@@ -1940,6 +1943,10 @@ RString GameDataNil::GetText() const
         {
             strcat(buf, "string"), rest &= ~GameString;
         }
+        else if (rest & GameCode)
+        {
+            strcat(buf, "code"), rest &= ~GameCode;
+        }
         else if (rest & GameNothing)
         {
             strcat(buf, "nothing"), rest &= ~GameNothing;
@@ -2021,6 +2028,11 @@ LSError GameDataBool::Serialize(ParamArchive& ar)
 RString GameDataString::GetText() const
 {
     return RString("\"") + _value + RString("\"");
+}
+
+RString GameDataCode::GetText() const
+{
+    return RString("{") + GetString() + RString("}");
 }
 
 bool GameDataString::IsEqualTo(const GameData* data) const
@@ -2333,6 +2345,10 @@ GameData* CreateGameDataString()
 {
     return new GameDataString();
 }
+GameData* CreateGameDataCode()
+{
+    return new GameDataCode();
+}
 GameData* CreateGameDataNothing()
 {
     return new GameDataNothing();
@@ -2365,6 +2381,7 @@ void GameState::Init()
     NewType("BOOL", GameBool, CreateGameDataBool, DefaultInfoFunctions()->GetTypeName(GameBool));
     NewType("ARRAY", GameArray, CreateGameDataArray, DefaultInfoFunctions()->GetTypeName(GameArray));
     NewType("STRING", GameString, CreateGameDataString, DefaultInfoFunctions()->GetTypeName(GameString));
+    NewType("CODE", GameCode, CreateGameDataCode, DefaultInfoFunctions()->GetTypeName(GameCode));
     NewType("NOTHING", GameNothing, CreateGameDataNothing, DefaultInfoFunctions()->GetTypeName(GameNothing));
 
     NewType("IF", GameIf, CreateGameDataIf, DefaultInfoFunctions()->GetTypeName(GameIf));

--- a/engine/Evaluator/express.hpp
+++ b/engine/Evaluator/express.hpp
@@ -46,6 +46,7 @@ const GameType GameArray(2);
 const GameType GameBool(4);
 const GameType GameString(8);
 const GameType GameNothing(16);
+const GameType GameCode(32);
 const GameType GameIf(0x1000000);
 const GameType GameWhile(0x2000000);
 const GameType GameFor(0x4000000);
@@ -205,6 +206,17 @@ class GameDataString : public GameData
 #endif
 
     USE_FAST_ALLOCATOR
+};
+
+class GameDataCode : public GameDataString
+{
+  public:
+    GameDataCode() = default;
+    GameDataCode(GameStringType value) : GameDataString(value) {}
+    GameType GetType() const override { return GameCode; }
+    RString GetText() const override;
+    const char* GetTypeName() const override { return "code"; }
+    GameData* Clone() const override { return new GameDataCode(*this); }
 };
 
 class GameDataBool : public GameData
@@ -414,7 +426,7 @@ class GameValue : public SerializeClass
 
 #pragma clang diagnostic pop
 
-    typedef const GameValue& GameValuePar;
+typedef const GameValue& GameValuePar;
 
 class GameVariable
 {
@@ -436,7 +448,6 @@ class GameVariable
 
     bool IsReadOnly() const { return _readOnly; }
 };
-
 
 typedef MapStringToClass<GameVariable, AutoArray<GameVariable>> VarBankType;
 
@@ -472,7 +483,7 @@ struct GameNular : public GameOpName
     const char* GetKey() const { return _name; }
 };
 
-    typedef MapStringToClass<GameNular, AutoArray<GameNular>> GameNularsType;
+typedef MapStringToClass<GameNular, AutoArray<GameNular>> GameNularsType;
 
 struct GameFunction : public GameOpName
 {
@@ -489,8 +500,7 @@ struct GameFunction : public GameOpName
     }
 };
 
-    struct GameFunctions : public AutoArray<GameFunction>,
-                           public GameOpName
+struct GameFunctions : public AutoArray<GameFunction>, public GameOpName
 {
     RString _name;
     GameFunctions() = default;
@@ -498,7 +508,7 @@ struct GameFunction : public GameOpName
     const char* GetKey() const { return _name; }
 };
 
-    typedef MapStringToClass<GameFunctions, AutoArray<GameFunctions>> GameFunctionsType;
+typedef MapStringToClass<GameFunctions, AutoArray<GameFunctions>> GameFunctionsType;
 
 enum GamePriority
 {
@@ -533,8 +543,7 @@ struct GameOperator : public GameOpName
     }
 };
 
-    struct GameOperators : public AutoArray<GameOperator>,
-                           public GameOpName
+struct GameOperators : public AutoArray<GameOperator>, public GameOpName
 {
     RString _name;
     GamePriority _priority;
@@ -546,7 +555,7 @@ struct GameOperator : public GameOpName
     const char* GetKey() const { return _name; }
 };
 
-    typedef MapStringToClass<GameOperators, AutoArray<GameOperators>> GameOperatorsType;
+typedef MapStringToClass<GameOperators, AutoArray<GameOperators>> GameOperatorsType;
 
 typedef MapStringToClass<RString, AutoArray<RString>> GameNameType;
 
@@ -689,8 +698,7 @@ struct GameTypeType : public Poseidon::Foundation::EnumName
     GameData* CreateGameData() { return createFunction(); }
 };
 
-    class GameState : public SerializeClass,
-                      public GameVarSpace
+class GameState : public SerializeClass, public GameVarSpace
 {
   private:
     AutoArray<GameTypeType> _typeNames; // symbolic name list

--- a/engine/Poseidon/Core/LocalDb/LocalDbStore.cpp
+++ b/engine/Poseidon/Core/LocalDb/LocalDbStore.cpp
@@ -1,0 +1,234 @@
+#include <Poseidon/Core/LocalDb/LocalDbStore.hpp>
+
+#include <cctype>
+#include <chrono>
+#include <fstream>
+#include <filesystem>
+#include <iterator>
+#include <system_error>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace Poseidon::LocalDb
+{
+namespace fs = std::filesystem;
+
+namespace
+{
+#ifdef _WIN32
+std::wstring Utf8ToWide(const std::string& text)
+{
+    if (text.empty())
+        return {};
+
+    const int length = MultiByteToWideChar(CP_UTF8, 0, text.data(), static_cast<int>(text.size()), nullptr, 0);
+    if (length <= 0)
+        return {};
+
+    std::wstring wide(static_cast<size_t>(length), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, text.data(), static_cast<int>(text.size()), wide.data(), length);
+    return wide;
+}
+
+std::string WideToUtf8(const std::wstring& text)
+{
+    if (text.empty())
+        return {};
+
+    const int length =
+        WideCharToMultiByte(CP_UTF8, 0, text.data(), static_cast<int>(text.size()), nullptr, 0, nullptr, nullptr);
+    if (length <= 0)
+        return {};
+
+    std::string utf8(static_cast<size_t>(length), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, text.data(), static_cast<int>(text.size()), utf8.data(), length, nullptr, nullptr);
+    return utf8;
+}
+#endif
+
+fs::path FsPathFromUtf8(const std::string& path)
+{
+#ifdef _WIN32
+    return fs::path(Utf8ToWide(path));
+#else
+    return fs::path(path);
+#endif
+}
+
+std::string FsPathToUtf8(const fs::path& path)
+{
+#ifdef _WIN32
+    return WideToUtf8(path.wstring());
+#else
+    return path.string();
+#endif
+}
+
+bool WriteTextFile(const fs::path& path, const std::string& contents)
+{
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    if (!output)
+        return false;
+    output.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+    return output.good();
+}
+
+std::vector<char> ReadBinaryFile(const fs::path& path)
+{
+    std::ifstream input(path, std::ios::binary);
+    if (!input)
+        return {};
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
+bool ReplaceFileAtomically(const fs::path& source, const fs::path& destination)
+{
+#ifdef _WIN32
+    // MoveFileExW replaces an existing destination as one operation, unlike a
+    // remove-then-rename sequence that risks losing a player's record on a crash.
+    return MoveFileExW(source.wstring().c_str(), destination.wstring().c_str(), MOVEFILE_REPLACE_EXISTING) != 0;
+#else
+    std::error_code ec;
+    fs::rename(source, destination, ec); // POSIX rename replaces atomically.
+    return !ec;
+#endif
+}
+
+std::string SchemaDocument()
+{
+    return "{\n  \"format\": \"local-db-store\",\n  \"schemaVersion\": " + std::to_string(Store::SchemaVersion) +
+           "\n}\n";
+}
+} // namespace
+
+Store::Store(std::string profileDirectory)
+{
+    if (!profileDirectory.empty())
+        m_root = FsPathToUtf8(FsPathFromUtf8(profileDirectory) / "LocalDb");
+}
+
+bool Store::IsSafeIdentifier(const std::string& value)
+{
+    if (value.empty() || value == "." || value == "..")
+        return false;
+
+    for (unsigned char c : value)
+    {
+        if (!(std::isalnum(c) || c == '-' || c == '_' || c == '.'))
+            return false;
+    }
+    return true;
+}
+
+std::string Store::RecordPath(const std::string& database, const std::string& key) const
+{
+    if (m_root.empty() || !IsSafeIdentifier(database) || !IsSafeIdentifier(key))
+        return {};
+    return FsPathToUtf8(FsPathFromUtf8(m_root) / database / (key + ".json"));
+}
+
+bool Store::EnsureInitialized() const
+{
+    if (m_root.empty())
+        return false;
+
+    std::error_code ec;
+    const fs::path rootPath = FsPathFromUtf8(m_root);
+    fs::create_directories(rootPath, ec);
+    if (ec || !fs::is_directory(rootPath, ec))
+        return false;
+
+    const fs::path schemaPath = rootPath / "schema.json";
+    if (fs::exists(schemaPath, ec))
+        return !ec;
+
+    const std::string schema = SchemaDocument();
+    return WriteTextFile(schemaPath, schema);
+}
+
+bool Store::Save(const std::string& database, const std::string& key, const std::string& json) const
+{
+    const std::string recordPath = RecordPath(database, key);
+    if (recordPath.empty() || json.empty() || !EnsureInitialized())
+        return false;
+
+    const fs::path destination = FsPathFromUtf8(recordPath);
+    std::error_code ec;
+    fs::create_directories(destination.parent_path(), ec);
+    if (ec)
+        return false;
+
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const fs::path temporary = FsPathFromUtf8(FsPathToUtf8(destination) + ".tmp." + std::to_string(nonce));
+    if (!WriteTextFile(temporary, json))
+        return false;
+
+    if (ReplaceFileAtomically(temporary, destination))
+        return true;
+
+    fs::remove(temporary, ec);
+    return false;
+}
+
+bool Store::Load(const std::string& database, const std::string& key, std::string& json) const
+{
+    json.clear();
+    const std::string recordPath = RecordPath(database, key);
+    if (recordPath.empty() || !EnsureInitialized())
+        return false;
+
+    const std::vector<char> bytes = ReadBinaryFile(FsPathFromUtf8(recordPath));
+    if (bytes.empty())
+        return false;
+    json.assign(bytes.begin(), bytes.end());
+    return true;
+}
+
+bool Store::Remove(const std::string& database, const std::string& key) const
+{
+    const std::string recordPath = RecordPath(database, key);
+    if (recordPath.empty() || !EnsureInitialized())
+        return false;
+
+    std::error_code ec;
+    fs::remove(FsPathFromUtf8(recordPath), ec);
+    return !ec;
+}
+
+bool Store::Exists(const std::string& database, const std::string& key) const
+{
+    const std::string recordPath = RecordPath(database, key);
+    if (recordPath.empty() || !EnsureInitialized())
+        return false;
+
+    std::error_code ec;
+    return fs::is_regular_file(FsPathFromUtf8(recordPath), ec) && !ec;
+}
+
+std::vector<std::string> Store::List(const std::string& database) const
+{
+    std::vector<std::string> keys;
+    if (m_root.empty() || !IsSafeIdentifier(database) || !EnsureInitialized())
+        return keys;
+
+    const fs::path databasePath = FsPathFromUtf8(m_root) / database;
+    std::error_code ec;
+    if (!fs::is_directory(databasePath, ec) || ec)
+        return keys;
+
+    for (const fs::directory_entry& entry : fs::directory_iterator(databasePath, ec))
+    {
+        if (ec)
+            break;
+        if (!entry.is_regular_file(ec) || ec)
+            continue;
+        const fs::path path = entry.path();
+        if (path.extension() == ".json")
+            keys.push_back(FsPathToUtf8(path.stem()));
+    }
+    return keys;
+}
+} // namespace Poseidon::LocalDb

--- a/engine/Poseidon/Core/LocalDb/LocalDbStore.hpp
+++ b/engine/Poseidon/Core/LocalDb/LocalDbStore.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+namespace Poseidon::LocalDb
+{
+/// File-backed local JSON persistence under the active profile directory.
+///
+/// Records are intentionally scoped by database and key rather than by a mission save.
+/// A dedicated server supplies its __SERVER__ profile directory as root; a local game
+/// can supply the active player's profile directory. Neither identifier is ever treated
+/// as a path component until it has passed IsSafeIdentifier().
+class Store
+{
+  public:
+    static constexpr int SchemaVersion = 1;
+
+    /// Creates <profileDirectory>/LocalDb and writes schema.json when it is absent.
+    /// Existing schema versions are preserved so a future migration can inspect them.
+    explicit Store(std::string profileDirectory);
+
+    /// Store an opaque JSON document for one database/key record. The write is atomic
+    /// on supported platforms: a crash cannot leave a partially-written destination.
+    bool Save(const std::string& database, const std::string& key, const std::string& json) const;
+
+    /// Load the exact JSON document stored by Save. Returns false for a missing or
+    /// unreadable record; callers can then construct their normal default state.
+    bool Load(const std::string& database, const std::string& key, std::string& json) const;
+
+    /// Remove a record. Missing records count as already deleted.
+    bool Remove(const std::string& database, const std::string& key) const;
+
+    /// Check whether a database/key record exists.
+    bool Exists(const std::string& database, const std::string& key) const;
+
+    /// List record keys stored in one database.
+    std::vector<std::string> List(const std::string& database) const;
+
+    /// Valid identifiers are ASCII letters, digits, '-', '_' and '.'. This keeps all
+    /// local DB data rooted under its profile directory, including on Windows.
+    static bool IsSafeIdentifier(const std::string& value);
+
+    /// The on-disk root: <profileDirectory>/LocalDb.
+    const std::string& Root() const { return m_root; }
+
+  private:
+    std::string RecordPath(const std::string& database, const std::string& key) const;
+    bool EnsureInitialized() const;
+
+    std::string m_root;
+};
+} // namespace Poseidon::LocalDb

--- a/engine/Poseidon/Foundation/platform.hpp
+++ b/engine/Poseidon/Foundation/platform.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef POSEIDON_FOUNDATION_PLATFORM_HPP
+#define POSEIDON_FOUNDATION_PLATFORM_HPP
 
 const int MaxFileName = 2048;
 
@@ -133,7 +135,7 @@ namespace Poseidon::Foundation
 {
 extern void sleepMs(unsigned ms);
 extern unsigned long long getSystemTime();
-}
+} // namespace Poseidon::Foundation
 
 inline unsigned long long GetTickCount()
 {
@@ -273,3 +275,4 @@ inline std::string platformPath(const std::string& path)
 #define __END_DECLS   /* empty */
 #endif
 
+#endif // POSEIDON_FOUNDATION_PLATFORM_HPP

--- a/engine/Poseidon/Game/Commands/GameStateExt.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExt.cpp
@@ -442,6 +442,9 @@ GameValue UsedVersion(const GameState* state);
 GameValue VoiceLanguage(const GameState* state);
 GameValue WorldName(const GameState* state);
 GameValue WorldSize(const GameState* state);
+GameValue LocalDbRoot(const GameState* state);
+GameValue LocalDbCacheClear(const GameState* state);
+GameValue LocalDbCacheFlushAll(const GameState* state);
 
 // Unary functions
 GameValue BriefingOnGear(const GameState* state, GameValuePar oper1);
@@ -579,6 +582,36 @@ GameValue ObjWeaponsFromPool(const GameState* state, GameValuePar oper1);
 GameValue PlayMusic(const GameState* state, GameValuePar oper1);
 GameValue PlaySound(const GameState* state, GameValuePar oper1);
 GameValue SoundLength(const GameState* state, GameValuePar oper1);
+GameValue LocalDbSave(const GameState* state, GameValuePar oper1);
+GameValue LocalDbLoad(const GameState* state, GameValuePar oper1);
+GameValue LocalDbRemove(const GameState* state, GameValuePar oper1);
+GameValue LocalDbExists(const GameState* state, GameValuePar oper1);
+GameValue LocalDbList(const GameState* state, GameValuePar oper1);
+GameValue LocalDbFind(const GameState* state, GameValuePar oper1);
+GameValue LocalDbFindPath(const GameState* state, GameValuePar oper1);
+GameValue LocalDbIndex(const GameState* state, GameValuePar oper1);
+GameValue LocalDbIndexPath(const GameState* state, GameValuePar oper1);
+GameValue LocalDbUpdate(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncSave(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncLoad(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncRemove(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncExists(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncList(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncFind(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncFindPath(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncIndex(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncIndexPath(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncDone(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncResult(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncJobs(const GameState* state);
+GameValue LocalDbAsyncClear(const GameState* state, GameValuePar oper1);
+GameValue LocalDbCacheLoad(const GameState* state, GameValuePar oper1);
+GameValue LocalDbCacheGet(const GameState* state, GameValuePar oper1);
+GameValue LocalDbCacheSet(const GameState* state, GameValuePar oper1);
+GameValue LocalDbCacheFlush(const GameState* state, GameValuePar oper1);
+GameValue LocalDbCacheAsyncFlush(const GameState* state, GameValuePar oper1);
+GameValue LocalDbCacheAsyncFlushAll(const GameState* state);
+GameValue LocalDbCacheRemove(const GameState* state, GameValuePar oper1);
 GameValue JsonValid(const GameState* state, GameValuePar oper1);
 GameValue JsonGetString(const GameState* state, GameValuePar oper1);
 GameValue JsonGetNumber(const GameState* state, GameValuePar oper1);
@@ -925,6 +958,7 @@ static const GameNular* GetExtNular(int& count)
 
         GameNular(GameFile, "newConfig", ConfigNew),
         GameNular(GameArray, "listConfigNames", ConfigListNames),
+        GameNular(GameString, "dbRoot", LocalDbRoot),
         GameNular(GameString, "missionName", MissionName),
         GameNular(GameArray, "missionStart", MissionStart),
         GameNular(GameString, "getWorld", WorldName),
@@ -933,6 +967,10 @@ static const GameNular* GetExtNular(int& count)
         GameNular(GameBool, "isJIP", IsJIP),
         GameNular(GameNothing, "serverPause", ServerPause),
         GameNular(GameNothing, "serverResume", ServerResume),
+        GameNular(GameBool, "cacheClear", LocalDbCacheClear),
+        GameNular(GameBool, "cacheFlushAll", LocalDbCacheFlushAll),
+        GameNular(GameScalar, "cacheAsyncFlushAll", LocalDbCacheAsyncFlushAll),
+        GameNular(GameArray, "dbAsyncJobs", LocalDbAsyncJobs),
 
         GameNular(GameScalar, "worldSize", WorldSize),
         GameNular(GameScalar, "mapWidth", MapWidth),
@@ -1073,6 +1111,34 @@ static const GameFunction* GetExtUnary(int& count)
 
         GameFunction(GameString, "format", StrFormat, GameArray),
         GameFunction(GameString, "localize", StrLocalize, GameString),
+        GameFunction(GameBool, "dbSave", LocalDbSave, GameArray),
+        GameFunction(GameString, "dbLoad", LocalDbLoad, GameArray),
+        GameFunction(GameBool, "dbRemove", LocalDbRemove, GameArray),
+        GameFunction(GameBool, "dbExists", LocalDbExists, GameArray),
+        GameFunction(GameArray, "dbList", LocalDbList, GameString),
+        GameFunction(GameArray, "dbFind", LocalDbFind, GameArray),
+        GameFunction(GameArray, "dbFindPath", LocalDbFindPath, GameArray),
+        GameFunction(GameArray, "dbIndex", LocalDbIndex, GameArray),
+        GameFunction(GameArray, "dbIndexPath", LocalDbIndexPath, GameArray),
+        GameFunction(GameBool, "dbUpdate", LocalDbUpdate, GameArray),
+        GameFunction(GameScalar, "dbAsyncSave", LocalDbAsyncSave, GameArray),
+        GameFunction(GameScalar, "dbAsyncLoad", LocalDbAsyncLoad, GameArray),
+        GameFunction(GameScalar, "dbAsyncRemove", LocalDbAsyncRemove, GameArray),
+        GameFunction(GameScalar, "dbAsyncExists", LocalDbAsyncExists, GameArray),
+        GameFunction(GameScalar, "dbAsyncList", LocalDbAsyncList, GameString),
+        GameFunction(GameScalar, "dbAsyncFind", LocalDbAsyncFind, GameArray),
+        GameFunction(GameScalar, "dbAsyncFindPath", LocalDbAsyncFindPath, GameArray),
+        GameFunction(GameScalar, "dbAsyncIndex", LocalDbAsyncIndex, GameArray),
+        GameFunction(GameScalar, "dbAsyncIndexPath", LocalDbAsyncIndexPath, GameArray),
+        GameFunction(GameBool, "dbAsyncDone", LocalDbAsyncDone, GameScalar),
+        GameFunction(GameArray, "dbAsyncResult", LocalDbAsyncResult, GameScalar),
+        GameFunction(GameBool, "dbAsyncClear", LocalDbAsyncClear, GameScalar),
+        GameFunction(GameBool, "cacheLoad", LocalDbCacheLoad, GameArray),
+        GameFunction(GameString, "cacheGet", LocalDbCacheGet, GameArray),
+        GameFunction(GameBool, "cacheSet", LocalDbCacheSet, GameArray),
+        GameFunction(GameBool, "cacheFlush", LocalDbCacheFlush, GameArray),
+        GameFunction(GameScalar, "cacheAsyncFlush", LocalDbCacheAsyncFlush, GameArray),
+        GameFunction(GameBool, "cacheRemove", LocalDbCacheRemove, GameArray),
         GameFunction(GameBool, "jsonValid", JsonValid, GameString),
         GameFunction(GameString, "jsonGetString", JsonGetString, GameArray),
         GameFunction(GameScalar, "jsonGetNumber", JsonGetNumber, GameArray),

--- a/engine/Poseidon/Game/Commands/GameStateExt.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExt.cpp
@@ -647,6 +647,17 @@ GameValue PoolSetWeapons(const GameState* state, GameValuePar oper1);
 GameValue LoadMission(const GameState* state, GameValuePar oper1);
 GameValue OnPlayerConnected(const GameState* state, GameValuePar oper1);
 GameValue OnPlayerDisconnected(const GameState* state, GameValuePar oper1);
+GameValue EventOn(const GameState* state, GameValuePar oper1);
+GameValue EventGet(const GameState* state, GameValuePar oper1);
+GameValue EventList(const GameState* state);
+GameValue EventOff(const GameState* state, GameValuePar oper1);
+GameValue EventClear(const GameState* state, GameValuePar oper1);
+GameValue EventEmit(const GameState* state, GameValuePar oper1);
+GameValue EventEmitLocal(const GameState* state, GameValuePar oper1);
+GameValue EventEmitGlobal(const GameState* state, GameValuePar oper1);
+GameValue EventEmitServer(const GameState* state, GameValuePar oper1);
+GameValue EventEmitTarget(const GameState* state, GameValuePar oper1);
+GameValue EventReceive(const GameState* state, GameValuePar oper1);
 GameValue PublicExec(const GameState* state, GameValuePar oper1);
 GameValue RemoteExec(const GameState* state, GameValuePar oper1, GameValuePar oper2);
 GameValue RemoteExecCall(const GameState* state, GameValuePar oper1, GameValuePar oper2);
@@ -968,6 +979,7 @@ static const GameNular* GetExtNular(int& count)
         GameNular(GameString, "voiceLanguage", VoiceLanguage),
         GameNular(GameBool, "isServer", IsServer),
         GameNular(GameBool, "isJIP", IsJIP),
+        GameNular(GameArray, "eventList", EventList),
         GameNular(GameNothing, "serverPause", ServerPause),
         GameNular(GameNothing, "serverResume", ServerResume),
         GameNular(GameBool, "cacheClear", LocalDbCacheClear),
@@ -1104,6 +1116,16 @@ static const GameFunction* GetExtUnary(int& count)
         GameFunction(GameNothing, "loadMission", LoadMission, GameString),
         GameFunction(GameNothing, "onPlayerConnected", OnPlayerConnected, GameString),
         GameFunction(GameNothing, "onPlayerDisconnected", OnPlayerDisconnected, GameString),
+        GameFunction(GameScalar, "eventOn", EventOn, GameArray),
+        GameFunction(GameArray, "eventGet", EventGet, GameScalar),
+        GameFunction(GameBool, "eventOff", EventOff, GameScalar),
+        GameFunction(GameScalar, "eventClear", EventClear, GameArray),
+        GameFunction(GameScalar, "eventEmit", EventEmit, GameArray),
+        GameFunction(GameScalar, "eventEmitLocal", EventEmitLocal, GameArray),
+        GameFunction(GameBool, "eventEmitGlobal", EventEmitGlobal, GameArray),
+        GameFunction(GameBool, "eventEmitServer", EventEmitServer, GameArray),
+        GameFunction(GameBool, "eventEmitTarget", EventEmitTarget, GameArray),
+        GameFunction(GameScalar, "eventReceive", EventReceive, GameArray),
         GameFunction(GameNothing, "publicVariable", PublicVariable, GameString),
         GameFunction(GameNothing, "saveMission", SaveMission, GameString),
         GameFunction(GameNothing, "publicVariableArray", PublicVariable, GameString),

--- a/engine/Poseidon/Game/Commands/GameStateExt.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExt.cpp
@@ -579,6 +579,29 @@ GameValue ObjWeaponsFromPool(const GameState* state, GameValuePar oper1);
 GameValue PlayMusic(const GameState* state, GameValuePar oper1);
 GameValue PlaySound(const GameState* state, GameValuePar oper1);
 GameValue SoundLength(const GameState* state, GameValuePar oper1);
+GameValue JsonValid(const GameState* state, GameValuePar oper1);
+GameValue JsonGetString(const GameState* state, GameValuePar oper1);
+GameValue JsonGetNumber(const GameState* state, GameValuePar oper1);
+GameValue JsonGetBool(const GameState* state, GameValuePar oper1);
+GameValue JsonGetArray(const GameState* state, GameValuePar oper1);
+GameValue JsonGet(const GameState* state, GameValuePar oper1);
+GameValue JsonSelect(const GameState* state, GameValuePar oper1);
+GameValue JsonPathGet(const GameState* state, GameValuePar oper1);
+GameValue JsonPathSet(const GameState* state, GameValuePar oper1);
+GameValue JsonPathRemove(const GameState* state, GameValuePar oper1);
+GameValue JsonStringify(const GameState* state, GameValuePar oper1);
+GameValue JsonObject(const GameState* state, GameValuePar oper1);
+GameValue JsonSet(const GameState* state, GameValuePar oper1);
+GameValue JsonRemove(const GameState* state, GameValuePar oper1);
+GameValue JsonHas(const GameState* state, GameValuePar oper1);
+GameValue JsonKeys(const GameState* state, GameValuePar oper1);
+GameValue JsonValues(const GameState* state, GameValuePar oper1);
+GameValue JsonCount(const GameState* state, GameValuePar oper1);
+GameValue JsonAt(const GameState* state, GameValuePar oper1);
+GameValue JsonPush(const GameState* state, GameValuePar oper1);
+GameValue JsonInsert(const GameState* state, GameValuePar oper1);
+GameValue JsonSetAt(const GameState* state, GameValuePar oper1);
+GameValue JsonDeleteAt(const GameState* state, GameValuePar oper1);
 GameValue PlayersNumber(const GameState* state, GameValuePar oper1);
 GameValue PoolAddMagazine(const GameState* state, GameValuePar oper1);
 GameValue PoolAddWeapon(const GameState* state, GameValuePar oper1);
@@ -1050,6 +1073,29 @@ static const GameFunction* GetExtUnary(int& count)
 
         GameFunction(GameString, "format", StrFormat, GameArray),
         GameFunction(GameString, "localize", StrLocalize, GameString),
+        GameFunction(GameBool, "jsonValid", JsonValid, GameString),
+        GameFunction(GameString, "jsonGetString", JsonGetString, GameArray),
+        GameFunction(GameScalar, "jsonGetNumber", JsonGetNumber, GameArray),
+        GameFunction(GameBool, "jsonGetBool", JsonGetBool, GameArray),
+        GameFunction(GameArray, "jsonGetArray", JsonGetArray, GameArray),
+        GameFunction(GameAny, "jsonGet", JsonGet, GameArray),
+        GameFunction(GameArray, "jsonSelect", JsonSelect, GameArray),
+        GameFunction(GameAny, "jsonPathGet", JsonPathGet, GameArray),
+        GameFunction(GameString, "jsonPathSet", JsonPathSet, GameArray),
+        GameFunction(GameString, "jsonPathRemove", JsonPathRemove, GameArray),
+        GameFunction(GameString, "jsonStringify", JsonStringify, GameAny),
+        GameFunction(GameString, "jsonObject", JsonObject, GameArray),
+        GameFunction(GameString, "jsonSet", JsonSet, GameArray),
+        GameFunction(GameString, "jsonRemove", JsonRemove, GameArray),
+        GameFunction(GameBool, "jsonHas", JsonHas, GameArray),
+        GameFunction(GameArray, "jsonKeys", JsonKeys, GameString),
+        GameFunction(GameArray, "jsonValues", JsonValues, GameString),
+        GameFunction(GameScalar, "jsonCount", JsonCount, GameString),
+        GameFunction(GameAny, "jsonAt", JsonAt, GameArray),
+        GameFunction(GameString, "jsonPush", JsonPush, GameArray),
+        GameFunction(GameString, "jsonInsert", JsonInsert, GameArray),
+        GameFunction(GameString, "jsonSetAt", JsonSetAt, GameArray),
+        GameFunction(GameString, "jsonDeleteAt", JsonDeleteAt, GameArray),
 
         GameFunction(GameNothing, "skipTime", SkipDayTime, GameScalar),
         GameFunction(GameNothing, "setViewDistance", SetViewDistance, GameScalar),

--- a/engine/Poseidon/Game/Commands/GameStateExt.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExt.cpp
@@ -523,6 +523,7 @@ GameValue MarkerGetPos(const GameState* state, GameValuePar oper1);
 GameValue MarkerGetSize(const GameState* state, GameValuePar oper1);
 GameValue MarkerGetType(const GameState* state, GameValuePar oper1);
 GameValue ObjAlive(const GameState* state, GameValuePar oper1);
+GameValue ObjLifeState(const GameState* state, GameValuePar oper1);
 GameValue ObjBehaviour(const GameState* state, GameValuePar oper1);
 GameValue ObjCanFire(const GameState* state, GameValuePar oper1);
 GameValue ObjCanMove(const GameState* state, GameValuePar oper1);
@@ -537,6 +538,7 @@ GameValue ObjFlee(const GameState* state, GameValuePar oper1);
 GameValue ObjFuel(const GameState* state, GameValuePar oper1);
 GameValue ObjGetAllMagazines(const GameState* state, GameValuePar oper1);
 GameValue ObjGetAllWeapons(const GameState* state, GameValuePar oper1);
+GameValue ObjUnitLoadout(const GameState* state, GameValuePar oper1);
 GameValue ObjGetDammage(const GameState* state, GameValuePar oper1);
 GameValue ObjGetDir(const GameState* state, GameValuePar oper1);
 GameValue ObjGetFlag(const GameState* state, GameValuePar oper1);
@@ -803,6 +805,7 @@ GameValue ObjSaveIdentity(const GameState* state, GameValuePar oper1, GameValueP
 GameValue ObjSaveStatus(const GameState* state, GameValuePar oper1, GameValuePar oper2);
 GameValue ObjSay(const GameState* state, GameValuePar oper1, GameValuePar oper2);
 GameValue ObjSelectWeapon(const GameState* state, GameValuePar oper1, GameValuePar oper2);
+GameValue ObjSetUnitLoadout(const GameState* state, GameValuePar oper1, GameValuePar oper2);
 GameValue ObjSetAmmoCargo(const GameState* state, GameValuePar oper1, GameValuePar oper2);
 GameValue ObjSetCaptive(const GameState* state, GameValuePar oper1, GameValuePar oper2);
 GameValue ObjSetDammage(const GameState* state, GameValuePar oper1, GameValuePar oper2);
@@ -994,6 +997,7 @@ static const GameFunction* GetExtUnary(int& count)
         GameFunction(GameBool, "isNull", ObjIsNull, GameObject),
         GameFunction(GameBool, "isNull", GrpIsNull, GameGroup),
         GameFunction(GameBool, "alive", ObjAlive, GameObject),
+        GameFunction(GameString, "lifeState", ObjLifeState, GameObject),
         GameFunction(GameBool, "local", ObjIsLocal, GameObject),
         GameFunction(GameBool, "requiredVersion", RequiredVersion, GameString),
         GameFunction(GameArray, "getPos", ObjGetPos, GameObject),
@@ -1250,6 +1254,7 @@ static const GameFunction* GetExtUnary(int& count)
         GameFunction(GameString, "secondaryWeapon", ObjGetSecondaryWeapon, GameObject),
         GameFunction(GameArray, "weapons", ObjGetAllWeapons, GameObject),
         GameFunction(GameArray, "magazines", ObjGetAllMagazines, GameObject),
+        GameFunction(GameArray, "getUnitLoadout", ObjUnitLoadout, GameObject),
 
         GameFunction(GameObject, "object", GetObject, GameScalar),
 
@@ -1370,6 +1375,7 @@ static const GameOperator* GetExtBinary(int& count)
         GameOperator(GameNothing, "removeMagazine", function, ObjRemoveMagazine, GameObject, GameString),
         GameOperator(GameNothing, "removeMagazines", function, ObjRemoveMagazines, GameObject, GameString),
         GameOperator(GameNothing, "selectWeapon", function, ObjSelectWeapon, GameObject, GameString),
+        GameOperator(GameNothing, "setUnitLoadout", function, ObjSetUnitLoadout, GameObject, GameArray),
         GameOperator(GameNothing, "fire", function, ObjFire, GameObject, GameString),
         GameOperator(GameNothing, "fire", function, ObjFireEx, GameObject, GameArray),
         GameOperator(GameScalar, "muzzleReloadTime", function, ObjMuzzleReloadTime, GameObject, GameString),

--- a/engine/Poseidon/Game/Commands/GameStateExt.hpp
+++ b/engine/Poseidon/Game/Commands/GameStateExt.hpp
@@ -6,8 +6,18 @@
 
 namespace Poseidon
 {
-} // namespace Poseidon
+int CurrentScriptEventSender();
 
+class ScriptEventSenderScope
+{
+  public:
+    explicit ScriptEventSenderScope(int sender);
+    ~ScriptEventSenderScope();
+
+  private:
+    int _previous;
+};
+} // namespace Poseidon
 
 const GameType GameObject(0x100);
 const GameType GameVector(0x200);
@@ -27,142 +37,149 @@ typedef Matrix3 GameOrientType;
 
 class GameFileType
 {
-private:
-	int _index;
+  private:
+    int _index;
 
-public:
-	bool readOnly;
+  public:
+    bool readOnly;
 
-	GameFileType() {_index = -1; readOnly = false;}
-	GameFileType(const GameFileType &src);
-	~GameFileType();
+    GameFileType()
+    {
+        _index = -1;
+        readOnly = false;
+    }
+    GameFileType(const GameFileType& src);
+    ~GameFileType();
 
-	void operator = (const GameFileType &src);
+    void operator=(const GameFileType& src);
 
-	int GetIndex() const {return _index;}
-	void SetIndex(int index);
+    int GetIndex() const { return _index; }
+    void SetIndex(int index);
 };
 
-
-class GameDataObject: public GameData
+class GameDataObject : public GameData
 {
-	typedef GameData base;
+    typedef GameData base;
 
-	GameObjectType _value;
+    GameObjectType _value;
 
-	public:
-	GameDataObject();
-	GameDataObject( GameObjectType value );
-	~GameDataObject() override{}
+  public:
+    GameDataObject();
+    GameDataObject(GameObjectType value);
+    ~GameDataObject() override {}
 
-	GameType GetType() const override {return GameObject;}
-	GameObjectType GetObject() const;
+    GameType GetType() const override { return GameObject; }
+    GameObjectType GetObject() const;
 
-	RString GetText() const override;
-	bool IsEqualTo(const GameData *data) const override;
-	const char *GetTypeName() const override {return "object";}
-	GameData *Clone() const override;
+    RString GetText() const override;
+    bool IsEqualTo(const GameData* data) const override;
+    const char* GetTypeName() const override { return "object"; }
+    GameData* Clone() const override;
 
-	LSError Serialize(ParamArchive &ar) override;	
+    LSError Serialize(ParamArchive& ar) override;
 
-	USE_FAST_ALLOCATOR
+    USE_FAST_ALLOCATOR
 };
 
-class GameDataGroup: public GameData
+class GameDataGroup : public GameData
 {
-	typedef GameData base;
+    typedef GameData base;
 
-	GameGroupType _value;
+    GameGroupType _value;
 
-	public:
-	GameDataGroup();
-	GameDataGroup( GameGroupType value );
-	~GameDataGroup() override{}
+  public:
+    GameDataGroup();
+    GameDataGroup(GameGroupType value);
+    ~GameDataGroup() override {}
 
-	GameType GetType() const override {return GameGroup;}
-	GameGroupType GetGroup() const;
+    GameType GetType() const override { return GameGroup; }
+    GameGroupType GetGroup() const;
 
-	RString GetText() const override;
-	bool IsEqualTo(const GameData *data) const override;
-	const char *GetTypeName() const override {return "group";}
-	GameData *Clone() const override;
+    RString GetText() const override;
+    bool IsEqualTo(const GameData* data) const override;
+    const char* GetTypeName() const override { return "group"; }
+    GameData* Clone() const override;
 
-	LSError Serialize(ParamArchive &ar) override;	
+    LSError Serialize(ParamArchive& ar) override;
 
-	USE_FAST_ALLOCATOR
+    USE_FAST_ALLOCATOR
 };
 
-
-class GameDataSide: public GameData
+class GameDataSide : public GameData
 {
-	typedef GameData base;
+    typedef GameData base;
 
-	GameSideType _value;
+    GameSideType _value;
 
-	public:
-	GameDataSide():_value(TSideUnknown){}
-	GameDataSide( GameSideType value ):_value(value){}
-	~GameDataSide() override{}
+  public:
+    GameDataSide() : _value(TSideUnknown) {}
+    GameDataSide(GameSideType value) : _value(value) {}
+    ~GameDataSide() override {}
 
-	GameType GetType() const override {return GameSide;}
-	GameSideType GetSide() const {return _value;}
+    GameType GetType() const override { return GameSide; }
+    GameSideType GetSide() const { return _value; }
 
-	RString GetText() const override;
-	bool IsEqualTo(const GameData *data) const override;
-	const char *GetTypeName() const override {return "side";}
-	GameData *Clone() const override {return new GameDataSide(*this);}
+    RString GetText() const override;
+    bool IsEqualTo(const GameData* data) const override;
+    const char* GetTypeName() const override { return "side"; }
+    GameData* Clone() const override { return new GameDataSide(*this); }
 
-	LSError Serialize(ParamArchive &ar) override;
+    LSError Serialize(ParamArchive& ar) override;
 
-	USE_FAST_ALLOCATOR
+    USE_FAST_ALLOCATOR
 };
 
-class GameDataFile: public GameData
+class GameDataFile : public GameData
 {
-	typedef GameData base;
+    typedef GameData base;
 
-	GameFileType _value;
+    GameFileType _value;
 
-	public:
-	GameDataFile(){}
-	GameDataFile( GameFileType value ):_value(value){}
-	~GameDataFile() override{}
+  public:
+    GameDataFile() {}
+    GameDataFile(GameFileType value) : _value(value) {}
+    ~GameDataFile() override {}
 
-	GameType GetType() const override {return GameFile;}
-	GameFileType GetFile() const {return _value;}
+    GameType GetType() const override { return GameFile; }
+    GameFileType GetFile() const { return _value; }
 
-	RString GetText() const override;
-	bool IsEqualTo(const GameData *data) const override;
-	const char *GetTypeName() const override {return "file";}
-	GameData *Clone() const override {return new GameDataFile(*this);}
+    RString GetText() const override;
+    bool IsEqualTo(const GameData* data) const override;
+    const char* GetTypeName() const override { return "file"; }
+    GameData* Clone() const override { return new GameDataFile(*this); }
 
-	LSError Serialize(ParamArchive &ar) override;
+    LSError Serialize(ParamArchive& ar) override;
 
-	USE_FAST_ALLOCATOR
+    USE_FAST_ALLOCATOR
 };
 
-
-inline TargetSide GetSide( GameValuePar oper )
+inline TargetSide GetSide(GameValuePar oper)
 {
-	if( oper.GetType()!=GameSide ) return TSideUnknown;
-	return static_cast<GameDataSide *>(oper.GetData())->GetSide();
+    if (oper.GetType() != GameSide)
+        return TSideUnknown;
+    return static_cast<GameDataSide*>(oper.GetData())->GetSide();
 }
 
-typedef bool (AICenter::*IsSide)( TargetSide side) const;
+typedef bool (AICenter::*IsSide)(TargetSide side) const;
 
-namespace Poseidon { class EntityType; }
-
-class GameValueExt: public GameValue
+namespace Poseidon
 {
-	public:
+class EntityType;
+}
 
-	GameValueExt( AIGroup *value );
-	GameValueExt( Object *value );
-	GameValueExt( GameSideType value ) {_data=new GameDataSide(value);}
-	GameValueExt( GameVectorType value );
-	GameValueExt( GameTransType value );
-	GameValueExt( GameOrientType value );
-	GameValueExt( GameFileType value ) {_data=new GameDataFile(value);}
+class GameValueExt : public GameValue
+{
+  public:
+    GameValueExt(AIGroup* value);
+    GameValueExt(Object* value);
+    GameValueExt(GameSideType value) { _data = new GameDataSide(value); }
+    GameValueExt(GameVectorType value);
+    GameValueExt(GameTransType value);
+    GameValueExt(GameOrientType value);
+    GameValueExt(GameFileType value) { _data = new GameDataFile(value); }
 };
 
-inline GameValue CreateGameSide( TargetSide side ) {return GameValueExt(side);}
+inline GameValue CreateGameSide(TargetSide side)
+{
+    return GameValueExt(side);
+}

--- a/engine/Poseidon/Game/Commands/GameStateExtEvents.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtEvents.cpp
@@ -1,0 +1,545 @@
+#include <Poseidon/Game/Commands/GameStateExtCommon.hpp>
+#include <Poseidon/AI/AI.hpp>
+#include <Poseidon/Game/Scripting/Scripts.hpp>
+#include <Poseidon/Network/Network.hpp>
+#include <Poseidon/Network/NetworkScriptValueCodec.hpp>
+#include <Poseidon/World/World.hpp>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace
+{
+struct EventHandler
+{
+    int id = 0;
+    std::string scope;
+    std::string name;
+    bool inlineCode = false;
+    RString body;
+};
+
+std::string GameStringToStdString(GameValuePar value)
+{
+    return std::string(((RString)(GameStringType)value).Data());
+}
+
+std::vector<EventHandler>& EventHandlers()
+{
+    static std::vector<EventHandler> handlers;
+    return handlers;
+}
+
+int& NextEventHandlerId()
+{
+    static int id = 1;
+    return id;
+}
+
+bool CheckStringArrayArg(const GameState* state, GameValuePar arg, int size)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != size)
+    {
+        state->SetError(EvalDim, array.Size(), size);
+        return false;
+    }
+
+    for (int i = 0; i < size; ++i)
+    {
+        if (array[i].GetType() != GameString)
+        {
+            state->TypeError(GameString, array[i].GetType());
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CheckEventOnArg(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 3)
+    {
+        state->SetError(EvalDim, array.Size(), 3);
+        return false;
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return false;
+    }
+    if (array[1].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[1].GetType());
+        return false;
+    }
+    if (array[2].GetType() != GameString && array[2].GetType() != GameCode)
+    {
+        state->TypeError(GameString | GameCode, array[2].GetType());
+        return false;
+    }
+    return true;
+}
+
+bool ParseEventHandlerTarget(GameValuePar arg, EventHandler& handler)
+{
+    if (arg.GetType() == GameString || arg.GetType() == GameCode)
+    {
+        handler.inlineCode = arg.GetType() == GameCode;
+        handler.body = (RString)(GameStringType)arg;
+        return handler.body.GetLength() > 0;
+    }
+    return false;
+}
+
+bool CheckEventEmitArg(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 3)
+    {
+        state->SetError(EvalDim, array.Size(), 3);
+        return false;
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return false;
+    }
+    if (array[1].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[1].GetType());
+        return false;
+    }
+    return true;
+}
+
+bool CheckEventReceiveArg(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 3 && array.Size() != 4)
+    {
+        state->SetError(EvalDim, array.Size(), array.Size() < 3 ? 3 : 4);
+        return false;
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return false;
+    }
+    if (array[1].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[1].GetType());
+        return false;
+    }
+    return true;
+}
+
+bool CheckEventNetworkEmitArg(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 2)
+    {
+        state->SetError(EvalDim, array.Size(), 2);
+        return false;
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return false;
+    }
+    return true;
+}
+
+bool CheckEventClientEmitArg(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 3)
+    {
+        state->SetError(EvalDim, array.Size(), 3);
+        return false;
+    }
+    if (array[1].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[1].GetType());
+        return false;
+    }
+    return true;
+}
+
+GameValue MakeEventArgs(const GameState* state, const char* scope, const char* name, GameValuePar payload, int sender)
+{
+    GameValue value = state->CreateGameValue(GameArray);
+    GameArrayType& array = value;
+    array.Resize(4);
+    array[0] = GameValue(scope);
+    array[1] = GameValue(name);
+    array[2] = payload;
+    array[3] = GameValue(static_cast<float>(sender));
+    return value;
+}
+
+GameValue MakeEventHandlerInfo(const GameState* state, const EventHandler& handler)
+{
+    GameValue value = state->CreateGameValue(GameArray);
+    GameArrayType& array = value;
+    array.Resize(5);
+    array[0] = GameValue(static_cast<float>(handler.id));
+    array[1] = GameValue(handler.scope.c_str());
+    array[2] = GameValue(handler.name.c_str());
+    array[3] = GameValue(handler.inlineCode ? "code" : "script");
+    array[4] = GameValue(handler.body);
+    return value;
+}
+
+void AppendExpandedEventTarget(GameArrayType& out, GameValuePar target)
+{
+    if (target.GetType() == GameGroup)
+    {
+        AIGroup* group = GetGroup(target);
+        if (!group)
+        {
+            return;
+        }
+        for (int i = 0; i < MAX_UNITS_PER_GROUP; ++i)
+        {
+            AIUnit* unit = group->UnitWithID(i + 1);
+            if (!unit)
+            {
+                continue;
+            }
+            Person* person = unit->GetPerson();
+            if (!person)
+            {
+                continue;
+            }
+            out.Add(GameValueExt(person));
+        }
+        return;
+    }
+
+    if (target.GetType() == GameArray)
+    {
+        const GameArrayType& array = target;
+        for (int i = 0; i < array.Size(); ++i)
+        {
+            AppendExpandedEventTarget(out, array[i]);
+        }
+        return;
+    }
+
+    out.Add(target);
+}
+
+GameValue ExpandEventTargetGroups(const GameState* state, GameValuePar target)
+{
+    if (target.GetType() != GameGroup && target.GetType() != GameArray)
+    {
+        return target;
+    }
+
+    GameValue value = state->CreateGameValue(GameArray);
+    GameArrayType& array = value;
+    AppendExpandedEventTarget(array, target);
+    return value;
+}
+
+int DispatchEvent(const GameState* state, const std::string& scope, const std::string& name, GameValuePar payload,
+                  int sender)
+{
+    if (!state)
+        return 0;
+
+    std::vector<EventHandler> matchingHandlers;
+    for (const EventHandler& handler : EventHandlers())
+    {
+        if (handler.scope == scope && handler.name == name)
+            matchingHandlers.push_back(handler);
+    }
+
+    int dispatched = 0;
+    for (const EventHandler& handler : matchingHandlers)
+    {
+        GameValue args = MakeEventArgs(state, handler.scope.c_str(), handler.name.c_str(), payload, sender);
+        if (handler.inlineCode)
+        {
+            GameVarSpace local(state->GetContext());
+            state->BeginContext(&local);
+            state->VarSetLocal("_this", args, true);
+            state->EvaluateMultiple(handler.body);
+            state->EndContext();
+        }
+        else
+        {
+            if (!Poseidon::GWorld)
+                continue;
+
+            Poseidon::Script* script = new Poseidon::Script(handler.body, args);
+            Poseidon::GWorld->AddScript(script);
+        }
+        ++dispatched;
+    }
+    return dispatched;
+}
+
+bool EncodeRemoteEvent(const GameState* state, GameValuePar params, GameValuePar target, AutoArray<char>& encodedParams,
+                       int& scalarTarget, AutoArray<char>& encodedTarget)
+{
+    if (!Poseidon::EncodeScriptValue(encodedParams, params))
+        return false;
+
+    GameValue expandedTarget = ExpandEventTargetGroups(state, target);
+    Poseidon::RemoteExecTargetSelector selector;
+    if (!Poseidon::BuildRemoteExecTargetSelector(selector, expandedTarget) ||
+        !Poseidon::EncodeRemoteExecTargetSelector(encodedTarget, selector))
+    {
+        return false;
+    }
+
+    scalarTarget = selector.kind == Poseidon::RemoteExecTargetKind::Scalar ? selector.scalar : 0;
+    return true;
+}
+
+GameValue EmitRemoteEventToTarget(const GameState* state, const char* scope, const std::string& name,
+                                  GameValuePar payload, GameValuePar target)
+{
+    GameValue params = MakeEventArgs(state, scope, name.c_str(), payload, -1);
+
+    if (!Poseidon::GWorld || Poseidon::GWorld->GetMode() != Poseidon::GModeNetware)
+    {
+        DispatchEvent(state, scope, name, payload, -1);
+        return GameValue(true);
+    }
+
+    AutoArray<char> encodedParams;
+    AutoArray<char> encodedTarget;
+    int scalarTarget = 0;
+    if (!EncodeRemoteEvent(state, params, target, encodedParams, scalarTarget, encodedTarget))
+        return GameValue(false);
+
+    return GameValue(GetNetworkManager().RemoteExec(RString("eventReceive"), encodedParams, scalarTarget, encodedTarget,
+                                                    false, RString(), false));
+}
+
+GameValue EmitRemoteEvent(const GameState* state, const char* scope, GameValuePar arg, int target)
+{
+    if (!CheckEventNetworkEmitArg(state, arg))
+        return GameValue(false);
+
+    const GameArrayType& array = arg;
+    return EmitRemoteEventToTarget(state, scope, GameStringToStdString(array[0]), array[1],
+                                   GameValue(static_cast<float>(target)));
+}
+
+thread_local int GScriptEventSender = -1;
+} // namespace
+
+namespace Poseidon
+{
+int CurrentScriptEventSender()
+{
+    return GScriptEventSender;
+}
+
+ScriptEventSenderScope::ScriptEventSenderScope(int sender) : _previous(GScriptEventSender)
+{
+    GScriptEventSender = sender;
+}
+
+ScriptEventSenderScope::~ScriptEventSenderScope()
+{
+    GScriptEventSender = _previous;
+}
+
+void ClearScriptEventHandlers()
+{
+    EventHandlers().clear();
+    NextEventHandlerId() = 1;
+}
+} // namespace Poseidon
+
+GameValue EventOn(const GameState* state, GameValuePar arg)
+{
+    if (!CheckEventOnArg(state, arg))
+        return GameValue(-1.0f);
+
+    const GameArrayType& array = arg;
+    EventHandler handler;
+    handler.scope = GameStringToStdString(array[0]);
+    handler.name = GameStringToStdString(array[1]);
+    if (!ParseEventHandlerTarget(array[2], handler))
+        return GameValue(-1.0f);
+
+    handler.id = NextEventHandlerId()++;
+    EventHandlers().push_back(handler);
+    return GameValue(static_cast<float>(handler.id));
+}
+
+GameValue EventGet(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameScalar)
+    {
+        state->TypeError(GameScalar, arg.GetType());
+        return state->CreateGameValue(GameArray);
+    }
+
+    const int id = toInt(static_cast<float>(arg));
+    for (const EventHandler& handler : EventHandlers())
+    {
+        if (handler.id == id)
+        {
+            return MakeEventHandlerInfo(state, handler);
+        }
+    }
+    return state->CreateGameValue(GameArray);
+}
+
+GameValue EventList(const GameState* state)
+{
+    GameValue value = state->CreateGameValue(GameArray);
+    GameArrayType& array = value;
+    const std::vector<EventHandler>& handlers = EventHandlers();
+    array.Realloc(static_cast<int>(handlers.size()));
+    for (const EventHandler& handler : handlers)
+    {
+        array.Add(MakeEventHandlerInfo(state, handler));
+    }
+    return value;
+}
+
+GameValue EventOff(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameScalar)
+    {
+        state->TypeError(GameScalar, arg.GetType());
+        return GameValue(false);
+    }
+
+    const int id = toInt(static_cast<float>(arg));
+    std::vector<EventHandler>& handlers = EventHandlers();
+    for (auto it = handlers.begin(); it != handlers.end(); ++it)
+    {
+        if (it->id == id)
+        {
+            handlers.erase(it);
+            return GameValue(true);
+        }
+    }
+    return GameValue(false);
+}
+
+GameValue EventClear(const GameState* state, GameValuePar arg)
+{
+    if (!CheckStringArrayArg(state, arg, 2))
+        return GameValue(false);
+
+    const GameArrayType& array = arg;
+    const std::string scope = GameStringToStdString(array[0]);
+    const std::string name = GameStringToStdString(array[1]);
+
+    std::vector<EventHandler>& handlers = EventHandlers();
+    int removed = 0;
+    for (auto it = handlers.begin(); it != handlers.end();)
+    {
+        if (it->scope == scope && it->name == name)
+        {
+            it = handlers.erase(it);
+            ++removed;
+        }
+        else
+        {
+            ++it;
+        }
+    }
+    return GameValue(static_cast<float>(removed));
+}
+
+GameValue EventEmit(const GameState* state, GameValuePar arg)
+{
+    if (!CheckEventEmitArg(state, arg))
+        return GameValue(0.0f);
+
+    const GameArrayType& array = arg;
+    const std::string scope = GameStringToStdString(array[0]);
+    const std::string name = GameStringToStdString(array[1]);
+    return GameValue(static_cast<float>(DispatchEvent(state, scope, name, array[2], -1)));
+}
+
+GameValue EventEmitLocal(const GameState* state, GameValuePar arg)
+{
+    if (!CheckEventNetworkEmitArg(state, arg))
+        return GameValue(0.0f);
+
+    const GameArrayType& array = arg;
+    return GameValue(static_cast<float>(DispatchEvent(state, "local", GameStringToStdString(array[0]), array[1], -1)));
+}
+
+GameValue EventEmitGlobal(const GameState* state, GameValuePar arg)
+{
+    return EmitRemoteEvent(state, "global", arg, 0);
+}
+
+GameValue EventEmitServer(const GameState* state, GameValuePar arg)
+{
+    return EmitRemoteEvent(state, "server", arg, 2);
+}
+
+GameValue EventEmitTarget(const GameState* state, GameValuePar arg)
+{
+    if (!CheckEventClientEmitArg(state, arg))
+        return GameValue(false);
+
+    const GameArrayType& array = arg;
+    return EmitRemoteEventToTarget(state, "target", GameStringToStdString(array[1]), array[2], array[0]);
+}
+
+GameValue EventReceive(const GameState* state, GameValuePar arg)
+{
+    if (!CheckEventReceiveArg(state, arg))
+        return GameValue(0.0f);
+
+    const GameArrayType& array = arg;
+    const std::string scope = GameStringToStdString(array[0]);
+    const std::string name = GameStringToStdString(array[1]);
+    int sender = Poseidon::CurrentScriptEventSender();
+    if (sender < 0 && array.Size() > 3 && array[3].GetType() == GameScalar)
+        sender = toInt(static_cast<float>(array[3]));
+    return GameValue(static_cast<float>(DispatchEvent(state, scope, name, array[2], sender)));
+}

--- a/engine/Poseidon/Game/Commands/GameStateExtJson.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtJson.cpp
@@ -1,0 +1,934 @@
+#include <Poseidon/Foundation/Strings/RString.hpp>
+#include <Poseidon/Game/Commands/GameStateExtCommon.hpp>
+
+#include <cjson/cJSON.h>
+
+#include <string>
+
+namespace
+{
+std::string GameStringToStdString(GameValuePar value)
+{
+    return std::string(((RString)(GameStringType)value).Data());
+}
+
+bool CheckJsonFieldArg(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 2)
+    {
+        state->SetError(EvalDim, array.Size(), 2);
+        return false;
+    }
+
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return false;
+    }
+    if (array[1].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[1].GetType());
+        return false;
+    }
+    return true;
+}
+
+bool CheckJsonPathArg(const GameState* state, GameValuePar arg, int size)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != size)
+    {
+        state->SetError(EvalDim, array.Size(), size);
+        return false;
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return false;
+    }
+    if (array[1].GetType() != GameArray)
+    {
+        state->TypeError(GameArray, array[1].GetType());
+        return false;
+    }
+
+    const GameArrayType& path = array[1];
+    for (int i = 0; i < path.Size(); ++i)
+    {
+        if (path[i].GetType() != GameString)
+        {
+            state->TypeError(GameString, path[i].GetType());
+            return false;
+        }
+    }
+    return true;
+}
+
+GameValue EmptyGameArray(const GameState* state)
+{
+    return state->CreateGameValue(GameArray);
+}
+
+const cJSON* JsonField(const cJSON* root, const std::string& field)
+{
+    if (!cJSON_IsObject(root))
+        return nullptr;
+    return cJSON_GetObjectItemCaseSensitive(root, field.c_str());
+}
+
+cJSON* JsonPathParent(cJSON* root, const GameArrayType& path, bool createMissing)
+{
+    if (!cJSON_IsObject(root) || path.Size() <= 0)
+        return nullptr;
+
+    cJSON* current = root;
+    for (int i = 0; i < path.Size() - 1; ++i)
+    {
+        const std::string key = GameStringToStdString(path[i]);
+        cJSON* child = cJSON_GetObjectItemCaseSensitive(current, key.c_str());
+        if (!child)
+        {
+            if (!createMissing)
+                return nullptr;
+
+            child = cJSON_CreateObject();
+            if (!child || !cJSON_AddItemToObject(current, key.c_str(), child))
+            {
+                cJSON_Delete(child);
+                return nullptr;
+            }
+        }
+        if (!cJSON_IsObject(child))
+        {
+            if (!createMissing)
+                return nullptr;
+
+            cJSON_DeleteItemFromObjectCaseSensitive(current, key.c_str());
+            child = cJSON_CreateObject();
+            if (!child || !cJSON_AddItemToObject(current, key.c_str(), child))
+            {
+                cJSON_Delete(child);
+                return nullptr;
+            }
+        }
+        current = child;
+    }
+
+    return current;
+}
+
+GameValue JsonArrayToGameValue(const GameState* state, const cJSON* item)
+{
+    GameValue value = EmptyGameArray(state);
+    GameArrayType& array = value;
+
+    if (!cJSON_IsArray(item))
+        return value;
+
+    const cJSON* element = nullptr;
+    cJSON_ArrayForEach(element, item)
+    {
+        if (cJSON_IsArray(element))
+            array.Add(JsonArrayToGameValue(state, element));
+        else if (cJSON_IsString(element))
+            array.Add(GameValue(element->valuestring ? element->valuestring : ""));
+        else if (cJSON_IsNumber(element))
+            array.Add(GameValue(static_cast<float>(element->valuedouble)));
+        else if (cJSON_IsBool(element))
+            array.Add(GameValue(cJSON_IsTrue(element) != 0));
+        else
+            array.Add(GameValue());
+    }
+
+    return value;
+}
+
+GameValue JsonValueToGameValue(const GameState* state, const cJSON* item)
+{
+    if (!item || cJSON_IsNull(item))
+        return GameValue();
+    if (cJSON_IsArray(item))
+        return JsonArrayToGameValue(state, item);
+    if (cJSON_IsString(item))
+        return GameValue(item->valuestring ? item->valuestring : "");
+    if (cJSON_IsNumber(item))
+        return GameValue(static_cast<float>(item->valuedouble));
+    if (cJSON_IsBool(item))
+        return GameValue(cJSON_IsTrue(item) != 0);
+    return GameValue();
+}
+
+cJSON* GameValueToJson(GameValuePar value)
+{
+    if (value.GetNil())
+        return cJSON_CreateNull();
+
+    const GameType type = value.GetType();
+    if (type == GameString)
+        return cJSON_CreateString(GameStringToStdString(value).c_str());
+    if (type == GameScalar)
+        return cJSON_CreateNumber(static_cast<double>(static_cast<float>(value)));
+    if (type == GameBool)
+        return cJSON_CreateBool(static_cast<bool>(value));
+    if (type == GameArray)
+    {
+        cJSON* arrayJson = cJSON_CreateArray();
+        if (!arrayJson)
+            return nullptr;
+
+        const GameArrayType& array = value;
+        for (int i = 0; i < array.Size(); ++i)
+        {
+            cJSON* item = GameValueToJson(array[i]);
+            if (!item || !cJSON_AddItemToArray(arrayJson, item))
+            {
+                cJSON_Delete(item);
+                cJSON_Delete(arrayJson);
+                return nullptr;
+            }
+        }
+        return arrayJson;
+    }
+
+    return cJSON_CreateNull();
+}
+
+std::string JsonToCompactString(cJSON* item)
+{
+    if (!item)
+        return {};
+
+    char* printed = cJSON_PrintUnformatted(item);
+    if (!printed)
+        return {};
+
+    std::string result(printed);
+    cJSON_free(printed);
+    return result;
+}
+} // namespace
+
+GameValue JsonValid(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameString)
+    {
+        state->TypeError(GameString, arg.GetType());
+        return GameValue(false);
+    }
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(arg).c_str());
+    if (!root)
+        return GameValue(false);
+
+    cJSON_Delete(root);
+    return GameValue(true);
+}
+
+GameValue JsonGetString(const GameState* state, GameValuePar arg)
+{
+    if (!CheckJsonFieldArg(state, arg))
+        return GameValue("");
+
+    const GameArrayType& array = arg;
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!root)
+        return GameValue("");
+
+    const cJSON* item = JsonField(root, GameStringToStdString(array[1]));
+    GameValue result("");
+    if (cJSON_IsString(item))
+        result = item->valuestring ? item->valuestring : "";
+
+    cJSON_Delete(root);
+    return result;
+}
+
+GameValue JsonGetNumber(const GameState* state, GameValuePar arg)
+{
+    if (!CheckJsonFieldArg(state, arg))
+        return GameValue(0.0f);
+
+    const GameArrayType& array = arg;
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!root)
+        return GameValue(0.0f);
+
+    const cJSON* item = JsonField(root, GameStringToStdString(array[1]));
+    GameValue result(0.0f);
+    if (cJSON_IsNumber(item))
+        result = static_cast<float>(item->valuedouble);
+
+    cJSON_Delete(root);
+    return result;
+}
+
+GameValue JsonGetBool(const GameState* state, GameValuePar arg)
+{
+    if (!CheckJsonFieldArg(state, arg))
+        return GameValue(false);
+
+    const GameArrayType& array = arg;
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!root)
+        return GameValue(false);
+
+    const cJSON* item = JsonField(root, GameStringToStdString(array[1]));
+    GameValue result(false);
+    if (cJSON_IsBool(item))
+        result = cJSON_IsTrue(item) != 0;
+
+    cJSON_Delete(root);
+    return result;
+}
+
+GameValue JsonGetArray(const GameState* state, GameValuePar arg)
+{
+    if (!CheckJsonFieldArg(state, arg))
+        return EmptyGameArray(state);
+
+    const GameArrayType& array = arg;
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!root)
+        return EmptyGameArray(state);
+
+    const cJSON* item = JsonField(root, GameStringToStdString(array[1]));
+    GameValue result = JsonArrayToGameValue(state, item);
+    cJSON_Delete(root);
+    return result;
+}
+
+GameValue JsonGet(const GameState* state, GameValuePar arg)
+{
+    if (!CheckJsonFieldArg(state, arg))
+        return GameValue();
+
+    const GameArrayType& array = arg;
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!root)
+        return GameValue();
+
+    const cJSON* item = JsonField(root, GameStringToStdString(array[1]));
+    GameValue result = JsonValueToGameValue(state, item);
+    cJSON_Delete(root);
+    return result;
+}
+
+GameValue JsonSelect(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return EmptyGameArray(state);
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 2)
+    {
+        state->SetError(EvalDim, array.Size(), 2);
+        return EmptyGameArray(state);
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return EmptyGameArray(state);
+    }
+    if (array[1].GetType() != GameArray)
+    {
+        state->TypeError(GameArray, array[1].GetType());
+        return EmptyGameArray(state);
+    }
+
+    const GameArrayType& keys = array[1];
+    for (int i = 0; i < keys.Size(); ++i)
+    {
+        if (keys[i].GetType() != GameString)
+        {
+            state->TypeError(GameString, keys[i].GetType());
+            return EmptyGameArray(state);
+        }
+    }
+
+    GameValue value = EmptyGameArray(state);
+    GameArrayType& selected = value;
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!cJSON_IsObject(root))
+    {
+        cJSON_Delete(root);
+        return value;
+    }
+
+    for (int i = 0; i < keys.Size(); ++i)
+    {
+        selected.Add(JsonValueToGameValue(state, JsonField(root, GameStringToStdString(keys[i]))));
+    }
+
+    cJSON_Delete(root);
+    return value;
+}
+
+GameValue JsonPathGet(const GameState* state, GameValuePar arg)
+{
+    if (!CheckJsonPathArg(state, arg, 2))
+        return GameValue();
+
+    const GameArrayType& array = arg;
+    const GameArrayType& path = array[1];
+    if (path.Size() == 0)
+        return GameValue();
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!cJSON_IsObject(root))
+    {
+        cJSON_Delete(root);
+        return GameValue();
+    }
+
+    cJSON* parent = JsonPathParent(root, path, false);
+    GameValue result;
+    if (parent)
+        result = JsonValueToGameValue(state, JsonField(parent, GameStringToStdString(path[path.Size() - 1])));
+
+    cJSON_Delete(root);
+    return result;
+}
+
+GameValue JsonPathSet(const GameState* state, GameValuePar arg)
+{
+    if (!CheckJsonPathArg(state, arg, 3))
+        return GameValue("");
+
+    const GameArrayType& array = arg;
+    const GameArrayType& path = array[1];
+    if (path.Size() == 0)
+        return GameValue(GameStringToStdString(array[0]).c_str());
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!root)
+        root = cJSON_CreateObject();
+    if (!cJSON_IsObject(root))
+    {
+        cJSON_Delete(root);
+        root = cJSON_CreateObject();
+    }
+    if (!root)
+        return GameValue("");
+
+    cJSON* parent = JsonPathParent(root, path, true);
+    if (!parent)
+    {
+        cJSON_Delete(root);
+        return GameValue("");
+    }
+
+    const std::string key = GameStringToStdString(path[path.Size() - 1]);
+    cJSON* value = GameValueToJson(array[2]);
+    cJSON_DeleteItemFromObjectCaseSensitive(parent, key.c_str());
+    if (!value || !cJSON_AddItemToObject(parent, key.c_str(), value))
+    {
+        cJSON_Delete(value);
+        cJSON_Delete(root);
+        return GameValue("");
+    }
+
+    const std::string result = JsonToCompactString(root);
+    cJSON_Delete(root);
+    return GameValue(result.c_str());
+}
+
+GameValue JsonPathRemove(const GameState* state, GameValuePar arg)
+{
+    if (!CheckJsonPathArg(state, arg, 2))
+        return GameValue("");
+
+    const GameArrayType& array = arg;
+    const GameArrayType& path = array[1];
+    if (path.Size() == 0)
+        return GameValue(GameStringToStdString(array[0]).c_str());
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!cJSON_IsObject(root))
+    {
+        cJSON_Delete(root);
+        return GameValue("{}");
+    }
+
+    cJSON* parent = JsonPathParent(root, path, false);
+    if (parent)
+        cJSON_DeleteItemFromObjectCaseSensitive(parent, GameStringToStdString(path[path.Size() - 1]).c_str());
+
+    const std::string result = JsonToCompactString(root);
+    cJSON_Delete(root);
+    return GameValue(result.c_str());
+}
+
+GameValue JsonStringify(const GameState* /*state*/, GameValuePar arg)
+{
+    cJSON* json = GameValueToJson(arg);
+    const std::string result = JsonToCompactString(json);
+    cJSON_Delete(json);
+    return GameValue(result.c_str());
+}
+
+GameValue JsonObject(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return GameValue("");
+    }
+
+    cJSON* object = cJSON_CreateObject();
+    if (!object)
+        return GameValue("");
+
+    const GameArrayType& pairs = arg;
+    for (int i = 0; i < pairs.Size(); ++i)
+    {
+        if (pairs[i].GetType() != GameArray)
+        {
+            state->TypeError(GameArray, pairs[i].GetType());
+            cJSON_Delete(object);
+            return GameValue("");
+        }
+
+        const GameArrayType& pair = pairs[i];
+        if (pair.Size() != 2)
+        {
+            state->SetError(EvalDim, pair.Size(), 2);
+            cJSON_Delete(object);
+            return GameValue("");
+        }
+        if (pair[0].GetType() != GameString)
+        {
+            state->TypeError(GameString, pair[0].GetType());
+            cJSON_Delete(object);
+            return GameValue("");
+        }
+
+        cJSON* value = GameValueToJson(pair[1]);
+        if (!value || !cJSON_AddItemToObject(object, GameStringToStdString(pair[0]).c_str(), value))
+        {
+            cJSON_Delete(value);
+            cJSON_Delete(object);
+            return GameValue("");
+        }
+    }
+
+    const std::string result = JsonToCompactString(object);
+    cJSON_Delete(object);
+    return GameValue(result.c_str());
+}
+
+GameValue JsonSet(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return GameValue("");
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 3)
+    {
+        state->SetError(EvalDim, array.Size(), 3);
+        return GameValue("");
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return GameValue("");
+    }
+    if (array[1].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[1].GetType());
+        return GameValue("");
+    }
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!root)
+        root = cJSON_CreateObject();
+    if (!cJSON_IsObject(root))
+    {
+        cJSON_Delete(root);
+        root = cJSON_CreateObject();
+    }
+    if (!root)
+        return GameValue("");
+
+    const std::string key = GameStringToStdString(array[1]);
+    cJSON* value = GameValueToJson(array[2]);
+    cJSON_DeleteItemFromObjectCaseSensitive(root, key.c_str());
+    if (!value || !cJSON_AddItemToObject(root, key.c_str(), value))
+    {
+        cJSON_Delete(value);
+        cJSON_Delete(root);
+        return GameValue("");
+    }
+
+    const std::string result = JsonToCompactString(root);
+    cJSON_Delete(root);
+    return GameValue(result.c_str());
+}
+
+GameValue JsonRemove(const GameState* state, GameValuePar arg)
+{
+    if (!CheckJsonFieldArg(state, arg))
+        return GameValue("");
+
+    const GameArrayType& array = arg;
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!root)
+        root = cJSON_CreateObject();
+    if (!cJSON_IsObject(root))
+    {
+        cJSON_Delete(root);
+        root = cJSON_CreateObject();
+    }
+    if (!root)
+        return GameValue("");
+
+    cJSON_DeleteItemFromObjectCaseSensitive(root, GameStringToStdString(array[1]).c_str());
+
+    const std::string result = JsonToCompactString(root);
+    cJSON_Delete(root);
+    return GameValue(result.c_str());
+}
+
+GameValue JsonHas(const GameState* state, GameValuePar arg)
+{
+    if (!CheckJsonFieldArg(state, arg))
+        return GameValue(false);
+
+    const GameArrayType& array = arg;
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!cJSON_IsObject(root))
+    {
+        cJSON_Delete(root);
+        return GameValue(false);
+    }
+
+    const cJSON* item = JsonField(root, GameStringToStdString(array[1]));
+    const bool result = item != nullptr;
+    cJSON_Delete(root);
+    return GameValue(result);
+}
+
+GameValue JsonKeys(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameString)
+    {
+        state->TypeError(GameString, arg.GetType());
+        return EmptyGameArray(state);
+    }
+
+    GameValue value = EmptyGameArray(state);
+    GameArrayType& keys = value;
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(arg).c_str());
+    if (!cJSON_IsObject(root))
+    {
+        cJSON_Delete(root);
+        return value;
+    }
+
+    const cJSON* item = nullptr;
+    cJSON_ArrayForEach(item, root)
+    {
+        keys.Add(GameValue(item->string ? item->string : ""));
+    }
+
+    cJSON_Delete(root);
+    return value;
+}
+
+GameValue JsonValues(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameString)
+    {
+        state->TypeError(GameString, arg.GetType());
+        return EmptyGameArray(state);
+    }
+
+    GameValue value = EmptyGameArray(state);
+    GameArrayType& values = value;
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(arg).c_str());
+    if (!cJSON_IsObject(root))
+    {
+        cJSON_Delete(root);
+        return value;
+    }
+
+    const cJSON* item = nullptr;
+    cJSON_ArrayForEach(item, root)
+    {
+        values.Add(JsonValueToGameValue(state, item));
+    }
+
+    cJSON_Delete(root);
+    return value;
+}
+
+GameValue JsonCount(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameString)
+    {
+        state->TypeError(GameString, arg.GetType());
+        return GameValue(0.0f);
+    }
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(arg).c_str());
+    const int count = cJSON_IsArray(root) ? cJSON_GetArraySize(root) : 0;
+    cJSON_Delete(root);
+    return GameValue(static_cast<float>(count));
+}
+
+GameValue JsonAt(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return GameValue();
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 2)
+    {
+        state->SetError(EvalDim, array.Size(), 2);
+        return GameValue();
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return GameValue();
+    }
+    if (array[1].GetType() != GameScalar)
+    {
+        state->TypeError(GameScalar, array[1].GetType());
+        return GameValue();
+    }
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!cJSON_IsArray(root))
+    {
+        cJSON_Delete(root);
+        return GameValue();
+    }
+
+    const int index = toInt(static_cast<float>(array[1]));
+    GameValue result = JsonValueToGameValue(state, cJSON_GetArrayItem(root, index));
+    cJSON_Delete(root);
+    return result;
+}
+
+GameValue JsonPush(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return GameValue("");
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 2)
+    {
+        state->SetError(EvalDim, array.Size(), 2);
+        return GameValue("");
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return GameValue("");
+    }
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!root)
+        root = cJSON_CreateArray();
+    if (!cJSON_IsArray(root))
+    {
+        cJSON_Delete(root);
+        root = cJSON_CreateArray();
+    }
+    if (!root)
+        return GameValue("");
+
+    cJSON* value = GameValueToJson(array[1]);
+    if (!value)
+    {
+        cJSON_Delete(root);
+        return GameValue("");
+    }
+    if (!cJSON_AddItemToArray(root, value))
+    {
+        cJSON_Delete(value);
+        cJSON_Delete(root);
+        return GameValue("");
+    }
+
+    const std::string result = JsonToCompactString(root);
+    cJSON_Delete(root);
+    return GameValue(result.c_str());
+}
+
+GameValue JsonInsert(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return GameValue("");
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 3)
+    {
+        state->SetError(EvalDim, array.Size(), 3);
+        return GameValue("");
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return GameValue("");
+    }
+    if (array[1].GetType() != GameScalar)
+    {
+        state->TypeError(GameScalar, array[1].GetType());
+        return GameValue("");
+    }
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!root)
+        root = cJSON_CreateArray();
+    if (!cJSON_IsArray(root))
+    {
+        cJSON_Delete(root);
+        root = cJSON_CreateArray();
+    }
+    if (!root)
+        return GameValue("");
+
+    cJSON* value = GameValueToJson(array[2]);
+    if (!value)
+    {
+        cJSON_Delete(root);
+        return GameValue("");
+    }
+
+    const int index = toInt(static_cast<float>(array[1]));
+    const int count = cJSON_GetArraySize(root);
+    const bool added = index < 0 || index >= count ? cJSON_AddItemToArray(root, value) != 0
+                                                   : cJSON_InsertItemInArray(root, index, value) != 0;
+    if (!added)
+    {
+        cJSON_Delete(value);
+        cJSON_Delete(root);
+        return GameValue("");
+    }
+
+    const std::string result = JsonToCompactString(root);
+    cJSON_Delete(root);
+    return GameValue(result.c_str());
+}
+
+GameValue JsonSetAt(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return GameValue("");
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 3)
+    {
+        state->SetError(EvalDim, array.Size(), 3);
+        return GameValue("");
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return GameValue("");
+    }
+    if (array[1].GetType() != GameScalar)
+    {
+        state->TypeError(GameScalar, array[1].GetType());
+        return GameValue("");
+    }
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!cJSON_IsArray(root))
+    {
+        cJSON_Delete(root);
+        return GameValue("[]");
+    }
+
+    const int index = toInt(static_cast<float>(array[1]));
+    if (index >= 0 && index < cJSON_GetArraySize(root))
+    {
+        cJSON* value = GameValueToJson(array[2]);
+        if (!value || !cJSON_ReplaceItemInArray(root, index, value))
+        {
+            cJSON_Delete(value);
+            cJSON_Delete(root);
+            return GameValue("");
+        }
+    }
+
+    const std::string result = JsonToCompactString(root);
+    cJSON_Delete(root);
+    return GameValue(result.c_str());
+}
+
+GameValue JsonDeleteAt(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return GameValue("");
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 2)
+    {
+        state->SetError(EvalDim, array.Size(), 2);
+        return GameValue("");
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return GameValue("");
+    }
+    if (array[1].GetType() != GameScalar)
+    {
+        state->TypeError(GameScalar, array[1].GetType());
+        return GameValue("");
+    }
+
+    cJSON* root = cJSON_Parse(GameStringToStdString(array[0]).c_str());
+    if (!cJSON_IsArray(root))
+    {
+        cJSON_Delete(root);
+        return GameValue("[]");
+    }
+
+    const int index = toInt(static_cast<float>(array[1]));
+    if (index >= 0 && index < cJSON_GetArraySize(root))
+        cJSON_DeleteItemFromArray(root, index);
+
+    const std::string result = JsonToCompactString(root);
+    cJSON_Delete(root);
+    return GameValue(result.c_str());
+}

--- a/engine/Poseidon/Game/Commands/GameStateExtLocalDb.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtLocalDb.cpp
@@ -1,0 +1,1369 @@
+#include <Poseidon/Core/LocalDb/LocalDbStore.hpp>
+#include <Poseidon/Core/Profile/ProfileManager.hpp>
+#include <Poseidon/Core/Global.hpp>
+#include <Poseidon/Foundation/Common/GamePaths.hpp>
+#include <Poseidon/Foundation/Strings/RString.hpp>
+#include <Poseidon/Game/Commands/GameStateExtCommon.hpp>
+
+#include <cjson/cJSON.h>
+
+#include <condition_variable>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+std::string GameStringToStdString(GameValuePar value)
+{
+    return std::string(((RString)(GameStringType)value).Data());
+}
+
+bool CheckLocalDbArrayArg(const GameState* state, GameValuePar arg, int size)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != size)
+    {
+        state->SetError(EvalDim, array.Size(), size);
+        return false;
+    }
+
+    for (int i = 0; i < size; ++i)
+    {
+        if (array[i].GetType() != GameString)
+        {
+            state->TypeError(GameString, array[i].GetType());
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CheckLocalDbUpdateArg(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 3)
+    {
+        state->SetError(EvalDim, array.Size(), 3);
+        return false;
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return false;
+    }
+    if (array[1].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[1].GetType());
+        return false;
+    }
+    if (array[2].GetType() != GameString && array[2].GetType() != GameCode)
+    {
+        state->TypeError(GameString | GameCode, array[2].GetType());
+        return false;
+    }
+    return true;
+}
+
+bool CheckLocalDbFindArg(const GameState* state, GameValuePar arg, bool path)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 3)
+    {
+        state->SetError(EvalDim, array.Size(), 3);
+        return false;
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return false;
+    }
+    if (!path && array[1].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[1].GetType());
+        return false;
+    }
+    if (path)
+    {
+        if (array[1].GetType() != GameArray)
+        {
+            state->TypeError(GameArray, array[1].GetType());
+            return false;
+        }
+
+        const GameArrayType& pathArray = array[1];
+        for (int i = 0; i < pathArray.Size(); ++i)
+        {
+            if (pathArray[i].GetType() != GameString)
+            {
+                state->TypeError(GameString, pathArray[i].GetType());
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool CheckLocalDbIndexArg(const GameState* state, GameValuePar arg, bool path)
+{
+    if (arg.GetType() != GameArray)
+    {
+        state->TypeError(GameArray, arg.GetType());
+        return false;
+    }
+
+    const GameArrayType& array = arg;
+    if (array.Size() != 2)
+    {
+        state->SetError(EvalDim, array.Size(), 2);
+        return false;
+    }
+    if (array[0].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[0].GetType());
+        return false;
+    }
+    if (!path && array[1].GetType() != GameString)
+    {
+        state->TypeError(GameString, array[1].GetType());
+        return false;
+    }
+    if (path)
+    {
+        if (array[1].GetType() != GameArray)
+        {
+            state->TypeError(GameArray, array[1].GetType());
+            return false;
+        }
+
+        const GameArrayType& pathArray = array[1];
+        for (int i = 0; i < pathArray.Size(); ++i)
+        {
+            if (pathArray[i].GetType() != GameString)
+            {
+                state->TypeError(GameString, pathArray[i].GetType());
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+std::string ActiveLocalDbProfileDirectory()
+{
+    const GamePaths& paths = GamePaths::Instance();
+    if (!paths.IsInitialized() || paths.UserDir().empty() || Glob.header.playerName.GetLength() == 0)
+        return {};
+
+    return Poseidon::ProfileManager::GetProfileDirPath(paths.UserDir(),
+                                                       std::string((const char*)Glob.header.playerName));
+}
+
+Poseidon::LocalDb::Store ActiveLocalDbStore()
+{
+    return Poseidon::LocalDb::Store(ActiveLocalDbProfileDirectory());
+}
+
+std::string CacheKey(const Poseidon::LocalDb::Store& store, const std::string& database, const std::string& key)
+{
+    return store.Root() + "\n" + database + "\n" + key;
+}
+
+struct CacheRecord
+{
+    std::string root;
+    std::string database;
+    std::string key;
+    std::string json;
+};
+
+std::map<std::string, CacheRecord>& LocalDbCache()
+{
+    static std::map<std::string, CacheRecord> cache;
+    return cache;
+}
+
+std::recursive_mutex& LocalDbMutex()
+{
+    static std::recursive_mutex mutex;
+    return mutex;
+}
+
+GameValue StringArrayValue(const GameState* state, const std::vector<std::string>& strings)
+{
+    GameValue value = state->CreateGameValue(GameArray);
+    GameArrayType& array = value;
+    for (const std::string& string : strings)
+        array.Add(GameValue(string.c_str()));
+    return value;
+}
+
+cJSON* GameValueToJson(GameValuePar value)
+{
+    if (value.GetNil())
+        return cJSON_CreateNull();
+
+    const GameType type = value.GetType();
+    if (type == GameString)
+        return cJSON_CreateString(GameStringToStdString(value).c_str());
+    if (type == GameScalar)
+        return cJSON_CreateNumber(static_cast<double>(static_cast<float>(value)));
+    if (type == GameBool)
+        return cJSON_CreateBool(static_cast<bool>(value));
+    if (type == GameArray)
+    {
+        cJSON* jsonArray = cJSON_CreateArray();
+        if (!jsonArray)
+            return nullptr;
+
+        const GameArrayType& array = value;
+        for (int i = 0; i < array.Size(); ++i)
+        {
+            cJSON* item = GameValueToJson(array[i]);
+            if (!item || !cJSON_AddItemToArray(jsonArray, item))
+            {
+                cJSON_Delete(item);
+                cJSON_Delete(jsonArray);
+                return nullptr;
+            }
+        }
+        return jsonArray;
+    }
+    return cJSON_CreateNull();
+}
+
+GameValue JsonArrayToGameValue(const GameState* state, const cJSON* item)
+{
+    GameValue value = state->CreateGameValue(GameArray);
+    GameArrayType& array = value;
+
+    if (!cJSON_IsArray(item))
+        return value;
+
+    const cJSON* element = nullptr;
+    cJSON_ArrayForEach(element, item)
+    {
+        if (cJSON_IsArray(element))
+            array.Add(JsonArrayToGameValue(state, element));
+        else if (cJSON_IsString(element))
+            array.Add(GameValue(element->valuestring ? element->valuestring : ""));
+        else if (cJSON_IsNumber(element))
+            array.Add(GameValue(static_cast<float>(element->valuedouble)));
+        else if (cJSON_IsBool(element))
+            array.Add(GameValue(cJSON_IsTrue(element) != 0));
+        else
+            array.Add(GameValue());
+    }
+
+    return value;
+}
+
+GameValue JsonValueToGameValue(const GameState* state, const cJSON* item)
+{
+    if (!item || cJSON_IsNull(item))
+        return GameValue();
+    if (cJSON_IsArray(item))
+        return JsonArrayToGameValue(state, item);
+    if (cJSON_IsString(item))
+        return GameValue(item->valuestring ? item->valuestring : "");
+    if (cJSON_IsNumber(item))
+        return GameValue(static_cast<float>(item->valuedouble));
+    if (cJSON_IsBool(item))
+        return GameValue(cJSON_IsTrue(item) != 0);
+    return GameValue();
+}
+
+const cJSON* JsonPathItem(const cJSON* root, const GameArrayType& path)
+{
+    const cJSON* current = root;
+    for (int i = 0; current && i < path.Size(); ++i)
+    {
+        if (!cJSON_IsObject(current))
+            return nullptr;
+        current = cJSON_GetObjectItemCaseSensitive(current, GameStringToStdString(path[i]).c_str());
+    }
+    return current;
+}
+
+const cJSON* QueryItem(const cJSON* root, GameValuePar selector, bool path)
+{
+    if (path)
+        return JsonPathItem(root, selector);
+    if (!cJSON_IsObject(root))
+        return nullptr;
+    return cJSON_GetObjectItemCaseSensitive(root, GameStringToStdString(selector).c_str());
+}
+
+std::string JsonComparableKey(const cJSON* item)
+{
+    if (!item)
+        return {};
+
+    const char* prefix = "x:";
+    if (cJSON_IsString(item))
+        return std::string("s:") + (item->valuestring ? item->valuestring : "");
+    if (cJSON_IsNumber(item))
+        prefix = "n:";
+    else if (cJSON_IsBool(item))
+        return std::string("b:") + (cJSON_IsTrue(item) ? "1" : "0");
+    else if (cJSON_IsArray(item))
+        prefix = "a:";
+    else if (cJSON_IsObject(item))
+        prefix = "o:";
+    else if (cJSON_IsNull(item))
+        return "z:null";
+
+    char* printed = cJSON_PrintUnformatted(item);
+    if (!printed)
+        return {};
+
+    std::string key = std::string(prefix) + printed;
+    cJSON_free(printed);
+    return key;
+}
+
+std::string ComparableKeyForGameValue(GameValuePar value)
+{
+    cJSON* json = GameValueToJson(value);
+    const std::string key = JsonComparableKey(json);
+    cJSON_Delete(json);
+    return key;
+}
+
+GameValue LocalDbFindImpl(const GameState* state, GameValuePar arg, bool path)
+{
+    if (!CheckLocalDbFindArg(state, arg, path))
+        return state->CreateGameValue(GameArray);
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    const GameArrayType& array = arg;
+    Poseidon::LocalDb::Store store = ActiveLocalDbStore();
+    const std::string database = GameStringToStdString(array[0]);
+    const std::string wanted = ComparableKeyForGameValue(array[2]);
+    std::vector<std::string> matches;
+
+    for (const std::string& key : store.List(database))
+    {
+        std::string json;
+        if (!store.Load(database, key, json))
+            continue;
+
+        cJSON* root = cJSON_Parse(json.c_str());
+        const std::string actual = JsonComparableKey(QueryItem(root, array[1], path));
+        cJSON_Delete(root);
+
+        if (!actual.empty() && actual == wanted)
+            matches.push_back(key);
+    }
+
+    return StringArrayValue(state, matches);
+}
+
+GameValue LocalDbIndexImpl(const GameState* state, GameValuePar arg, bool path)
+{
+    if (!CheckLocalDbIndexArg(state, arg, path))
+        return state->CreateGameValue(GameArray);
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    struct IndexBucket
+    {
+        GameValue value;
+        std::vector<std::string> keys;
+    };
+
+    const GameArrayType& array = arg;
+    Poseidon::LocalDb::Store store = ActiveLocalDbStore();
+    const std::string database = GameStringToStdString(array[0]);
+    std::map<std::string, IndexBucket> buckets;
+
+    for (const std::string& key : store.List(database))
+    {
+        std::string json;
+        if (!store.Load(database, key, json))
+            continue;
+
+        cJSON* root = cJSON_Parse(json.c_str());
+        const cJSON* item = QueryItem(root, array[1], path);
+        const std::string bucketKey = JsonComparableKey(item);
+        if (!bucketKey.empty())
+        {
+            IndexBucket& bucket = buckets[bucketKey];
+            if (bucket.keys.empty())
+                bucket.value = JsonValueToGameValue(state, item);
+            bucket.keys.push_back(key);
+        }
+        cJSON_Delete(root);
+    }
+
+    GameValue result = state->CreateGameValue(GameArray);
+    GameArrayType& resultArray = result;
+    for (const auto& entry : buckets)
+    {
+        GameValue pair = state->CreateGameValue(GameArray);
+        GameArrayType& pairArray = pair;
+        pairArray.Resize(2);
+        pairArray[0] = entry.second.value;
+        pairArray[1] = StringArrayValue(state, entry.second.keys);
+        resultArray.Add(pair);
+    }
+    return result;
+}
+
+enum class AsyncLocalDbOp
+{
+    Save,
+    Load,
+    Remove,
+    Exists,
+    List,
+    Find,
+    FindPath,
+    Index,
+    IndexPath,
+    CacheFlush,
+    CacheFlushAll,
+};
+
+enum class AsyncLocalDbStatus
+{
+    Queued,
+    Running,
+    Done,
+};
+
+struct AsyncJsonValue
+{
+    enum class Kind
+    {
+        Empty,
+        String,
+        Number,
+        Bool,
+        Json,
+    };
+
+    Kind kind = Kind::Empty;
+    std::string text;
+    double number = 0.0;
+    bool boolean = false;
+};
+
+struct AsyncIndexBucket
+{
+    AsyncJsonValue value;
+    std::vector<std::string> keys;
+};
+
+struct AsyncLocalDbResult
+{
+    bool ok = false;
+    AsyncJsonValue value;
+    std::vector<std::string> strings;
+    std::vector<AsyncIndexBucket> index;
+};
+
+struct AsyncLocalDbJob
+{
+    int id = 0;
+    AsyncLocalDbOp op = AsyncLocalDbOp::Load;
+    std::string profileDirectory;
+    std::string database;
+    std::string key;
+    std::string json;
+    std::string selector;
+    std::vector<std::string> selectorPath;
+    std::string wanted;
+};
+
+struct AsyncLocalDbRecord
+{
+    int id = 0;
+    AsyncLocalDbOp op = AsyncLocalDbOp::Load;
+    AsyncLocalDbStatus status = AsyncLocalDbStatus::Queued;
+    AsyncLocalDbResult result;
+};
+
+const char* AsyncLocalDbOpName(AsyncLocalDbOp op)
+{
+    switch (op)
+    {
+        case AsyncLocalDbOp::Save:
+            return "save";
+        case AsyncLocalDbOp::Load:
+            return "load";
+        case AsyncLocalDbOp::Remove:
+            return "remove";
+        case AsyncLocalDbOp::Exists:
+            return "exists";
+        case AsyncLocalDbOp::List:
+            return "list";
+        case AsyncLocalDbOp::Find:
+            return "find";
+        case AsyncLocalDbOp::FindPath:
+            return "findPath";
+        case AsyncLocalDbOp::Index:
+            return "index";
+        case AsyncLocalDbOp::IndexPath:
+            return "indexPath";
+        case AsyncLocalDbOp::CacheFlush:
+            return "cacheFlush";
+        case AsyncLocalDbOp::CacheFlushAll:
+            return "cacheFlushAll";
+    }
+    return "unknown";
+}
+
+const char* AsyncLocalDbStatusName(AsyncLocalDbStatus status)
+{
+    switch (status)
+    {
+        case AsyncLocalDbStatus::Queued:
+            return "queued";
+        case AsyncLocalDbStatus::Running:
+            return "running";
+        case AsyncLocalDbStatus::Done:
+            return "done";
+    }
+    return "unknown";
+}
+
+AsyncJsonValue CaptureJsonValue(const cJSON* item)
+{
+    AsyncJsonValue value;
+    if (!item || cJSON_IsNull(item))
+        return value;
+    if (cJSON_IsString(item))
+    {
+        value.kind = AsyncJsonValue::Kind::String;
+        value.text = item->valuestring ? item->valuestring : "";
+        return value;
+    }
+    if (cJSON_IsNumber(item))
+    {
+        value.kind = AsyncJsonValue::Kind::Number;
+        value.number = item->valuedouble;
+        return value;
+    }
+    if (cJSON_IsBool(item))
+    {
+        value.kind = AsyncJsonValue::Kind::Bool;
+        value.boolean = cJSON_IsTrue(item) != 0;
+        return value;
+    }
+
+    char* printed = cJSON_PrintUnformatted(item);
+    if (printed)
+    {
+        value.kind = AsyncJsonValue::Kind::Json;
+        value.text = printed;
+        cJSON_free(printed);
+    }
+    return value;
+}
+
+GameValue AsyncJsonValueToGameValue(const GameState* state, const AsyncJsonValue& value)
+{
+    switch (value.kind)
+    {
+        case AsyncJsonValue::Kind::String:
+            return GameValue(value.text.c_str());
+        case AsyncJsonValue::Kind::Json:
+        {
+            cJSON* root = cJSON_Parse(value.text.c_str());
+            GameValue result = JsonValueToGameValue(state, root);
+            cJSON_Delete(root);
+            return result;
+        }
+        case AsyncJsonValue::Kind::Number:
+            return GameValue(static_cast<float>(value.number));
+        case AsyncJsonValue::Kind::Bool:
+            return GameValue(value.boolean);
+        case AsyncJsonValue::Kind::Empty:
+            return GameValue();
+    }
+    return GameValue();
+}
+
+const cJSON* QueryItemForAsync(const cJSON* root, const AsyncLocalDbJob& job)
+{
+    if (job.op == AsyncLocalDbOp::FindPath || job.op == AsyncLocalDbOp::IndexPath)
+    {
+        const cJSON* current = root;
+        for (const std::string& pathPart : job.selectorPath)
+        {
+            if (!current || !cJSON_IsObject(current))
+                return nullptr;
+            current = cJSON_GetObjectItemCaseSensitive(current, pathPart.c_str());
+        }
+        return current;
+    }
+
+    if (!cJSON_IsObject(root))
+        return nullptr;
+    return cJSON_GetObjectItemCaseSensitive(root, job.selector.c_str());
+}
+
+AsyncLocalDbResult ExecuteAsyncLocalDbJob(const AsyncLocalDbJob& job)
+{
+    AsyncLocalDbResult result;
+    Poseidon::LocalDb::Store store(job.profileDirectory);
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    switch (job.op)
+    {
+        case AsyncLocalDbOp::Save:
+            result.ok = store.Save(job.database, job.key, job.json);
+            return result;
+        case AsyncLocalDbOp::Load:
+        {
+            result.ok = store.Load(job.database, job.key, result.value.text);
+            if (result.ok)
+                result.value.kind = AsyncJsonValue::Kind::String;
+            return result;
+        }
+        case AsyncLocalDbOp::Remove:
+            result.ok = store.Remove(job.database, job.key);
+            if (result.ok)
+                LocalDbCache().erase(CacheKey(store, job.database, job.key));
+            return result;
+        case AsyncLocalDbOp::Exists:
+            result.ok = true;
+            result.value.kind = AsyncJsonValue::Kind::Bool;
+            result.value.boolean = store.Exists(job.database, job.key);
+            return result;
+        case AsyncLocalDbOp::List:
+            result.strings = store.List(job.database);
+            result.ok = true;
+            return result;
+        case AsyncLocalDbOp::Find:
+        case AsyncLocalDbOp::FindPath:
+            for (const std::string& key : store.List(job.database))
+            {
+                std::string json;
+                if (!store.Load(job.database, key, json))
+                    continue;
+
+                cJSON* root = cJSON_Parse(json.c_str());
+                const std::string actual = JsonComparableKey(QueryItemForAsync(root, job));
+                cJSON_Delete(root);
+                if (!actual.empty() && actual == job.wanted)
+                    result.strings.push_back(key);
+            }
+            result.ok = true;
+            return result;
+        case AsyncLocalDbOp::Index:
+        case AsyncLocalDbOp::IndexPath:
+        {
+            std::map<std::string, AsyncIndexBucket> buckets;
+            for (const std::string& key : store.List(job.database))
+            {
+                std::string json;
+                if (!store.Load(job.database, key, json))
+                    continue;
+
+                cJSON* root = cJSON_Parse(json.c_str());
+                const cJSON* item = QueryItemForAsync(root, job);
+                const std::string bucketKey = JsonComparableKey(item);
+                if (!bucketKey.empty())
+                {
+                    AsyncIndexBucket& bucket = buckets[bucketKey];
+                    if (bucket.keys.empty())
+                        bucket.value = CaptureJsonValue(item);
+                    bucket.keys.push_back(key);
+                }
+                cJSON_Delete(root);
+            }
+            for (auto& entry : buckets)
+                result.index.push_back(entry.second);
+            result.ok = true;
+            return result;
+        }
+        case AsyncLocalDbOp::CacheFlush:
+        {
+            const auto found = LocalDbCache().find(CacheKey(store, job.database, job.key));
+            result.ok = found != LocalDbCache().end() && store.Save(job.database, job.key, found->second.json);
+            return result;
+        }
+        case AsyncLocalDbOp::CacheFlushAll:
+        {
+            bool flushed = false;
+            result.ok = true;
+            for (const auto& entry : LocalDbCache())
+            {
+                const CacheRecord& record = entry.second;
+                if (record.root != store.Root())
+                    continue;
+
+                flushed = true;
+                result.ok = store.Save(record.database, record.key, record.json) && result.ok;
+            }
+            result.ok = flushed && result.ok;
+            return result;
+        }
+    }
+
+    return result;
+}
+
+class AsyncLocalDbQueue
+{
+  public:
+    AsyncLocalDbQueue() : m_worker(&AsyncLocalDbQueue::WorkerLoop, this) {}
+
+    ~AsyncLocalDbQueue()
+    {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_stopping = true;
+        }
+        m_condition.notify_one();
+        if (m_worker.joinable())
+            m_worker.join();
+    }
+
+    int Enqueue(AsyncLocalDbJob job)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        PruneDoneLocked();
+        if (m_records.size() >= kMaxAsyncLocalDbRecords)
+            return -1;
+
+        job.id = m_nextId++;
+        AsyncLocalDbRecord record;
+        record.id = job.id;
+        record.op = job.op;
+        m_records[job.id] = record;
+        m_jobs.push_back(job);
+        m_condition.notify_one();
+        return job.id;
+    }
+
+    bool Get(int id, AsyncLocalDbRecord& record) const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        const auto found = m_records.find(id);
+        if (found == m_records.end())
+            return false;
+        record = found->second;
+        return true;
+    }
+
+    std::vector<AsyncLocalDbRecord> List() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        std::vector<AsyncLocalDbRecord> records;
+        for (const auto& entry : m_records)
+            records.push_back(entry.second);
+        return records;
+    }
+
+    bool Clear(int id)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        const auto found = m_records.find(id);
+        if (found == m_records.end() || found->second.status != AsyncLocalDbStatus::Done)
+            return false;
+        m_records.erase(found);
+        return true;
+    }
+
+  private:
+    static constexpr size_t kMaxAsyncLocalDbRecords = 1024;
+
+    void PruneDoneLocked()
+    {
+        while (m_records.size() >= kMaxAsyncLocalDbRecords)
+        {
+            auto done = m_records.end();
+            for (auto it = m_records.begin(); it != m_records.end(); ++it)
+            {
+                if (it->second.status == AsyncLocalDbStatus::Done)
+                {
+                    done = it;
+                    break;
+                }
+            }
+            if (done == m_records.end())
+                return;
+            m_records.erase(done);
+        }
+    }
+
+    void WorkerLoop()
+    {
+        while (true)
+        {
+            AsyncLocalDbJob job;
+            {
+                std::unique_lock<std::mutex> lock(m_mutex);
+                m_condition.wait(lock, [&]() { return m_stopping || !m_jobs.empty(); });
+                if (m_stopping && m_jobs.empty())
+                    return;
+                job = m_jobs.front();
+                m_jobs.pop_front();
+                m_records[job.id].status = AsyncLocalDbStatus::Running;
+            }
+
+            AsyncLocalDbResult result = ExecuteAsyncLocalDbJob(job);
+
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                AsyncLocalDbRecord& record = m_records[job.id];
+                record.status = AsyncLocalDbStatus::Done;
+                record.result = result;
+            }
+        }
+    }
+
+    mutable std::mutex m_mutex;
+    std::condition_variable m_condition;
+    std::deque<AsyncLocalDbJob> m_jobs;
+    std::map<int, AsyncLocalDbRecord> m_records;
+    std::thread m_worker;
+    int m_nextId = 1;
+    bool m_stopping = false;
+};
+
+AsyncLocalDbQueue& LocalDbAsyncQueue()
+{
+    static AsyncLocalDbQueue queue;
+    return queue;
+}
+
+GameValue AsyncLocalDbResultValue(const GameState* state, const AsyncLocalDbRecord& record)
+{
+    GameValue value = state->CreateGameValue(GameArray);
+    GameArrayType& array = value;
+    array.Resize(4);
+    array[0] = GameValue(static_cast<float>(record.id));
+    array[1] = GameValue(AsyncLocalDbStatusName(record.status));
+    array[2] = GameValue(record.result.ok);
+
+    if (record.op == AsyncLocalDbOp::Find || record.op == AsyncLocalDbOp::FindPath || record.op == AsyncLocalDbOp::List)
+    {
+        array[3] = StringArrayValue(state, record.result.strings);
+    }
+    else if (record.op == AsyncLocalDbOp::Index || record.op == AsyncLocalDbOp::IndexPath)
+    {
+        GameValue indexValue = state->CreateGameValue(GameArray);
+        GameArrayType& indexArray = indexValue;
+        for (const AsyncIndexBucket& bucket : record.result.index)
+        {
+            GameValue pair = state->CreateGameValue(GameArray);
+            GameArrayType& pairArray = pair;
+            pairArray.Resize(2);
+            pairArray[0] = AsyncJsonValueToGameValue(state, bucket.value);
+            pairArray[1] = StringArrayValue(state, bucket.keys);
+            indexArray.Add(pair);
+        }
+        array[3] = indexValue;
+    }
+    else
+    {
+        array[3] = AsyncJsonValueToGameValue(state, record.result.value);
+    }
+    return value;
+}
+
+GameValue AsyncLocalDbJobInfoValue(const GameState* state, const AsyncLocalDbRecord& record)
+{
+    GameValue value = state->CreateGameValue(GameArray);
+    GameArrayType& array = value;
+    array.Resize(4);
+    array[0] = GameValue(static_cast<float>(record.id));
+    array[1] = GameValue(AsyncLocalDbOpName(record.op));
+    array[2] = GameValue(AsyncLocalDbStatusName(record.status));
+    array[3] = GameValue(record.status == AsyncLocalDbStatus::Done ? record.result.ok : false);
+    return value;
+}
+
+bool FillAsyncDatabaseKeyJob(const GameState* state, GameValuePar arg, int size, AsyncLocalDbOp op,
+                             AsyncLocalDbJob& job)
+{
+    if (!CheckLocalDbArrayArg(state, arg, size))
+        return false;
+
+    const GameArrayType& array = arg;
+    job.op = op;
+    job.profileDirectory = ActiveLocalDbProfileDirectory();
+    job.database = GameStringToStdString(array[0]);
+    job.key = GameStringToStdString(array[1]);
+    if (size == 3)
+        job.json = GameStringToStdString(array[2]);
+    return true;
+}
+
+bool FillAsyncFindJob(const GameState* state, GameValuePar arg, bool path, AsyncLocalDbJob& job)
+{
+    if (!CheckLocalDbFindArg(state, arg, path))
+        return false;
+
+    const GameArrayType& array = arg;
+    job.op = path ? AsyncLocalDbOp::FindPath : AsyncLocalDbOp::Find;
+    job.profileDirectory = ActiveLocalDbProfileDirectory();
+    job.database = GameStringToStdString(array[0]);
+    job.wanted = ComparableKeyForGameValue(array[2]);
+    if (path)
+    {
+        const GameArrayType& pathArray = array[1];
+        for (int i = 0; i < pathArray.Size(); ++i)
+            job.selectorPath.push_back(GameStringToStdString(pathArray[i]));
+    }
+    else
+    {
+        job.selector = GameStringToStdString(array[1]);
+    }
+    return true;
+}
+
+bool FillAsyncIndexJob(const GameState* state, GameValuePar arg, bool path, AsyncLocalDbJob& job)
+{
+    if (!CheckLocalDbIndexArg(state, arg, path))
+        return false;
+
+    const GameArrayType& array = arg;
+    job.op = path ? AsyncLocalDbOp::IndexPath : AsyncLocalDbOp::Index;
+    job.profileDirectory = ActiveLocalDbProfileDirectory();
+    job.database = GameStringToStdString(array[0]);
+    if (path)
+    {
+        const GameArrayType& pathArray = array[1];
+        for (int i = 0; i < pathArray.Size(); ++i)
+            job.selectorPath.push_back(GameStringToStdString(pathArray[i]));
+    }
+    else
+    {
+        job.selector = GameStringToStdString(array[1]);
+    }
+    return true;
+}
+} // namespace
+
+GameValue LocalDbRoot(const GameState* /*state*/)
+{
+    return GameValue(ActiveLocalDbStore().Root().c_str());
+}
+
+GameValue LocalDbSave(const GameState* state, GameValuePar arg)
+{
+    if (!CheckLocalDbArrayArg(state, arg, 3))
+        return GameValue(false);
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    const GameArrayType& array = arg;
+    return GameValue(ActiveLocalDbStore().Save(GameStringToStdString(array[0]), GameStringToStdString(array[1]),
+                                               GameStringToStdString(array[2])));
+}
+
+GameValue LocalDbLoad(const GameState* state, GameValuePar arg)
+{
+    if (!CheckLocalDbArrayArg(state, arg, 2))
+        return GameValue("");
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    const GameArrayType& array = arg;
+    std::string json;
+    if (!ActiveLocalDbStore().Load(GameStringToStdString(array[0]), GameStringToStdString(array[1]), json))
+        return GameValue("");
+    return GameValue(json.c_str());
+}
+
+GameValue LocalDbRemove(const GameState* state, GameValuePar arg)
+{
+    if (!CheckLocalDbArrayArg(state, arg, 2))
+        return GameValue(false);
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    const GameArrayType& array = arg;
+    Poseidon::LocalDb::Store store = ActiveLocalDbStore();
+    const std::string database = GameStringToStdString(array[0]);
+    const std::string key = GameStringToStdString(array[1]);
+    LocalDbCache().erase(CacheKey(store, database, key));
+    return GameValue(store.Remove(database, key));
+}
+
+GameValue LocalDbExists(const GameState* state, GameValuePar arg)
+{
+    if (!CheckLocalDbArrayArg(state, arg, 2))
+        return GameValue(false);
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    const GameArrayType& array = arg;
+    return GameValue(ActiveLocalDbStore().Exists(GameStringToStdString(array[0]), GameStringToStdString(array[1])));
+}
+
+GameValue LocalDbList(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameString)
+    {
+        state->TypeError(GameString, arg.GetType());
+        return state->CreateGameValue(GameArray);
+    }
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    return StringArrayValue(state, ActiveLocalDbStore().List(GameStringToStdString(arg)));
+}
+
+GameValue LocalDbFind(const GameState* state, GameValuePar arg)
+{
+    return LocalDbFindImpl(state, arg, false);
+}
+
+GameValue LocalDbFindPath(const GameState* state, GameValuePar arg)
+{
+    return LocalDbFindImpl(state, arg, true);
+}
+
+GameValue LocalDbIndex(const GameState* state, GameValuePar arg)
+{
+    return LocalDbIndexImpl(state, arg, false);
+}
+
+GameValue LocalDbIndexPath(const GameState* state, GameValuePar arg)
+{
+    return LocalDbIndexImpl(state, arg, true);
+}
+
+GameValue LocalDbUpdate(const GameState* state, GameValuePar arg)
+{
+    if (!CheckLocalDbUpdateArg(state, arg))
+        return GameValue(false);
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    const GameArrayType& array = arg;
+    Poseidon::LocalDb::Store store = ActiveLocalDbStore();
+    const std::string database = GameStringToStdString(array[0]);
+    const std::string key = GameStringToStdString(array[1]);
+
+    std::string current;
+    store.Load(database, key, current);
+
+    GameVarSpace local(state->GetContext());
+    state->BeginContext(&local);
+    state->VarSetLocal("_this", GameValue(current.c_str()), true);
+    GameValue updated = state->EvaluateMultiple((RString)(GameStringType)array[2]);
+    state->EndContext();
+
+    if (updated.GetType() != GameString)
+    {
+        state->TypeError(GameString, updated.GetType());
+        return GameValue(false);
+    }
+
+    const std::string json = GameStringToStdString(updated);
+    if (json.empty())
+        return GameValue(false);
+
+    const bool saved = store.Save(database, key, json);
+    if (saved)
+    {
+        const std::string cacheKey = CacheKey(store, database, key);
+        const auto found = LocalDbCache().find(cacheKey);
+        if (found != LocalDbCache().end())
+            found->second.json = json;
+    }
+    return GameValue(saved);
+}
+
+GameValue LocalDbCacheLoad(const GameState* state, GameValuePar arg)
+{
+    if (!CheckLocalDbArrayArg(state, arg, 2))
+        return GameValue(false);
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    const GameArrayType& array = arg;
+    Poseidon::LocalDb::Store store = ActiveLocalDbStore();
+    const std::string database = GameStringToStdString(array[0]);
+    const std::string key = GameStringToStdString(array[1]);
+
+    std::string json;
+    if (!store.Load(database, key, json))
+        return GameValue(false);
+
+    LocalDbCache()[CacheKey(store, database, key)] = {store.Root(), database, key, json};
+    return GameValue(true);
+}
+
+GameValue LocalDbCacheGet(const GameState* state, GameValuePar arg)
+{
+    if (!CheckLocalDbArrayArg(state, arg, 2))
+        return GameValue("");
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    const GameArrayType& array = arg;
+    Poseidon::LocalDb::Store store = ActiveLocalDbStore();
+    const std::string database = GameStringToStdString(array[0]);
+    const std::string key = GameStringToStdString(array[1]);
+
+    const auto found = LocalDbCache().find(CacheKey(store, database, key));
+    if (found == LocalDbCache().end())
+        return GameValue("");
+    return GameValue(found->second.json.c_str());
+}
+
+GameValue LocalDbCacheSet(const GameState* state, GameValuePar arg)
+{
+    if (!CheckLocalDbArrayArg(state, arg, 3))
+        return GameValue(false);
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    const GameArrayType& array = arg;
+    Poseidon::LocalDb::Store store = ActiveLocalDbStore();
+    const std::string database = GameStringToStdString(array[0]);
+    const std::string key = GameStringToStdString(array[1]);
+    const std::string json = GameStringToStdString(array[2]);
+    if (json.empty())
+        return GameValue(false);
+
+    LocalDbCache()[CacheKey(store, database, key)] = {store.Root(), database, key, json};
+    return GameValue(true);
+}
+
+GameValue LocalDbCacheFlush(const GameState* state, GameValuePar arg)
+{
+    if (!CheckLocalDbArrayArg(state, arg, 2))
+        return GameValue(false);
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    const GameArrayType& array = arg;
+    Poseidon::LocalDb::Store store = ActiveLocalDbStore();
+    const std::string database = GameStringToStdString(array[0]);
+    const std::string key = GameStringToStdString(array[1]);
+
+    const auto found = LocalDbCache().find(CacheKey(store, database, key));
+    if (found == LocalDbCache().end())
+        return GameValue(false);
+    return GameValue(store.Save(database, key, found->second.json));
+}
+
+GameValue LocalDbCacheFlushAll(const GameState* /*state*/)
+{
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    Poseidon::LocalDb::Store store = ActiveLocalDbStore();
+    bool ok = true;
+    bool flushed = false;
+
+    for (const auto& entry : LocalDbCache())
+    {
+        const CacheRecord& record = entry.second;
+        if (record.root != store.Root())
+            continue;
+
+        flushed = true;
+        ok = store.Save(record.database, record.key, record.json) && ok;
+    }
+
+    return GameValue(flushed && ok);
+}
+
+GameValue LocalDbCacheRemove(const GameState* state, GameValuePar arg)
+{
+    if (!CheckLocalDbArrayArg(state, arg, 2))
+        return GameValue(false);
+
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    const GameArrayType& array = arg;
+    Poseidon::LocalDb::Store store = ActiveLocalDbStore();
+    const std::string database = GameStringToStdString(array[0]);
+    const std::string key = GameStringToStdString(array[1]);
+    LocalDbCache().erase(CacheKey(store, database, key));
+    return GameValue(true);
+}
+
+GameValue LocalDbCacheClear(const GameState* /*state*/)
+{
+    std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+
+    LocalDbCache().clear();
+    return GameValue(true);
+}
+
+GameValue LocalDbAsyncSave(const GameState* state, GameValuePar arg)
+{
+    AsyncLocalDbJob job;
+    if (!FillAsyncDatabaseKeyJob(state, arg, 3, AsyncLocalDbOp::Save, job))
+        return GameValue(-1.0f);
+    return GameValue(static_cast<float>(LocalDbAsyncQueue().Enqueue(job)));
+}
+
+GameValue LocalDbAsyncLoad(const GameState* state, GameValuePar arg)
+{
+    AsyncLocalDbJob job;
+    if (!FillAsyncDatabaseKeyJob(state, arg, 2, AsyncLocalDbOp::Load, job))
+        return GameValue(-1.0f);
+    return GameValue(static_cast<float>(LocalDbAsyncQueue().Enqueue(job)));
+}
+
+GameValue LocalDbAsyncRemove(const GameState* state, GameValuePar arg)
+{
+    AsyncLocalDbJob job;
+    if (!FillAsyncDatabaseKeyJob(state, arg, 2, AsyncLocalDbOp::Remove, job))
+        return GameValue(-1.0f);
+
+    return GameValue(static_cast<float>(LocalDbAsyncQueue().Enqueue(job)));
+}
+
+GameValue LocalDbAsyncExists(const GameState* state, GameValuePar arg)
+{
+    AsyncLocalDbJob job;
+    if (!FillAsyncDatabaseKeyJob(state, arg, 2, AsyncLocalDbOp::Exists, job))
+        return GameValue(-1.0f);
+    return GameValue(static_cast<float>(LocalDbAsyncQueue().Enqueue(job)));
+}
+
+GameValue LocalDbAsyncList(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameString)
+    {
+        state->TypeError(GameString, arg.GetType());
+        return GameValue(-1.0f);
+    }
+
+    AsyncLocalDbJob job;
+    job.op = AsyncLocalDbOp::List;
+    job.profileDirectory = ActiveLocalDbProfileDirectory();
+    job.database = GameStringToStdString(arg);
+    return GameValue(static_cast<float>(LocalDbAsyncQueue().Enqueue(job)));
+}
+
+GameValue LocalDbAsyncFind(const GameState* state, GameValuePar arg)
+{
+    AsyncLocalDbJob job;
+    if (!FillAsyncFindJob(state, arg, false, job))
+        return GameValue(-1.0f);
+    return GameValue(static_cast<float>(LocalDbAsyncQueue().Enqueue(job)));
+}
+
+GameValue LocalDbAsyncFindPath(const GameState* state, GameValuePar arg)
+{
+    AsyncLocalDbJob job;
+    if (!FillAsyncFindJob(state, arg, true, job))
+        return GameValue(-1.0f);
+    return GameValue(static_cast<float>(LocalDbAsyncQueue().Enqueue(job)));
+}
+
+GameValue LocalDbAsyncIndex(const GameState* state, GameValuePar arg)
+{
+    AsyncLocalDbJob job;
+    if (!FillAsyncIndexJob(state, arg, false, job))
+        return GameValue(-1.0f);
+    return GameValue(static_cast<float>(LocalDbAsyncQueue().Enqueue(job)));
+}
+
+GameValue LocalDbAsyncIndexPath(const GameState* state, GameValuePar arg)
+{
+    AsyncLocalDbJob job;
+    if (!FillAsyncIndexJob(state, arg, true, job))
+        return GameValue(-1.0f);
+    return GameValue(static_cast<float>(LocalDbAsyncQueue().Enqueue(job)));
+}
+
+GameValue LocalDbCacheAsyncFlush(const GameState* state, GameValuePar arg)
+{
+    if (!CheckLocalDbArrayArg(state, arg, 2))
+        return GameValue(-1.0f);
+
+    const GameArrayType& array = arg;
+    AsyncLocalDbJob job;
+    job.op = AsyncLocalDbOp::CacheFlush;
+    job.profileDirectory = ActiveLocalDbProfileDirectory();
+    job.database = GameStringToStdString(array[0]);
+    job.key = GameStringToStdString(array[1]);
+
+    {
+        std::lock_guard<std::recursive_mutex> lock(LocalDbMutex());
+        Poseidon::LocalDb::Store store(job.profileDirectory);
+        if (LocalDbCache().find(CacheKey(store, job.database, job.key)) == LocalDbCache().end())
+            return GameValue(-1.0f);
+    }
+
+    return GameValue(static_cast<float>(LocalDbAsyncQueue().Enqueue(job)));
+}
+
+GameValue LocalDbCacheAsyncFlushAll(const GameState* /*state*/)
+{
+    AsyncLocalDbJob job;
+    job.op = AsyncLocalDbOp::CacheFlushAll;
+    job.profileDirectory = ActiveLocalDbProfileDirectory();
+
+    return GameValue(static_cast<float>(LocalDbAsyncQueue().Enqueue(job)));
+}
+
+GameValue LocalDbAsyncDone(const GameState* /*state*/, GameValuePar arg)
+{
+    if (arg.GetType() != GameScalar)
+        return GameValue(false);
+
+    AsyncLocalDbRecord record;
+    if (!LocalDbAsyncQueue().Get(static_cast<int>(static_cast<GameScalarType>(arg)), record))
+        return GameValue(false);
+    return GameValue(record.status == AsyncLocalDbStatus::Done);
+}
+
+GameValue LocalDbAsyncResult(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameScalar)
+    {
+        state->TypeError(GameScalar, arg.GetType());
+        return state->CreateGameValue(GameArray);
+    }
+
+    AsyncLocalDbRecord record;
+    if (!LocalDbAsyncQueue().Get(static_cast<int>(static_cast<GameScalarType>(arg)), record))
+        return state->CreateGameValue(GameArray);
+    return AsyncLocalDbResultValue(state, record);
+}
+
+GameValue LocalDbAsyncJobs(const GameState* state)
+{
+    GameValue value = state->CreateGameValue(GameArray);
+    GameArrayType& array = value;
+    for (const AsyncLocalDbRecord& record : LocalDbAsyncQueue().List())
+        array.Add(AsyncLocalDbJobInfoValue(state, record));
+    return value;
+}
+
+GameValue LocalDbAsyncClear(const GameState* state, GameValuePar arg)
+{
+    if (arg.GetType() != GameScalar)
+    {
+        state->TypeError(GameScalar, arg.GetType());
+        return GameValue(false);
+    }
+    return GameValue(LocalDbAsyncQueue().Clear(static_cast<int>(static_cast<GameScalarType>(arg))));
+}

--- a/engine/Poseidon/Game/Commands/GameStateExtObj.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtObj.cpp
@@ -105,6 +105,39 @@ GameValue ObjAlive(const GameState* state, GameValuePar oper1)
     return (!obj->IsDammageDestroyed());
 }
 
+GameValue ObjLifeState(const GameState* state, GameValuePar oper1)
+{
+    Object* obj = GetObject(oper1);
+    if (!obj)
+    {
+        return "DEAD";
+    }
+
+    EntityAI* ai = dyn_cast<EntityAI>(obj);
+    AIUnit* unit = ai ? ai->CommanderUnit() : nullptr;
+    if (unit)
+    {
+        switch (unit->GetLifeState())
+        {
+            case AIUnit::LSDead:
+            case AIUnit::LSDeadInRespawn:
+                return "DEAD";
+            case AIUnit::LSUnconscious:
+            case AIUnit::LSAsleep:
+                return "UNCONSCIOUS";
+            case AIUnit::LSAlive:
+            case AIUnit::NLifeStates:
+                break;
+        }
+    }
+
+    if (obj->IsDammageDestroyed())
+    {
+        return "DEAD";
+    }
+    return obj->GetTotalDammage() > 0.0f ? "INJURED" : "HEALTHY";
+}
+
 GameValue ObjCanMove(const GameState* state, GameValuePar oper1)
 {
     Object* obj = GetObject(oper1);
@@ -953,6 +986,160 @@ GameValue ObjMagazinesArray(const GameState* state, GameValuePar oper1)
     }
 
     return value;
+}
+
+GameValue ObjUnitLoadout(const GameState* state, GameValuePar oper1)
+{
+    GameValue value = state->CreateGameValue(GameArray);
+    GameArrayType& loadout = value;
+
+    Object* obj = GetObject(oper1);
+    if (!obj)
+    {
+        return value;
+    }
+    EntityAI* ai = dyn_cast<EntityAI>(obj);
+    if (!ai)
+    {
+        return value;
+    }
+
+    GameValue weapons = state->CreateGameValue(GameArray);
+    GameArrayType& weaponArray = weapons;
+    for (int i = 0; i < ai->NWeaponSystems(); i++)
+    {
+        const WeaponType* weapon = ai->GetWeaponSystem(i);
+        if (!weapon || weapon->_weaponType == 0)
+        {
+            continue;
+        }
+        weaponArray.Add(weapon->GetName());
+    }
+
+    GameValue magazines = state->CreateGameValue(GameArray);
+    GameArrayType& magazineArray = magazines;
+    for (int i = 0; i < ai->NMagazines(); i++)
+    {
+        const Magazine* magazine = ai->GetMagazine(i);
+        if (!magazine || !magazine->_type)
+        {
+            continue;
+        }
+        magazineArray.Add(magazine->_type->GetName());
+        magazineArray.Add(static_cast<float>(magazine->_ammo));
+    }
+
+    RString selectedWeapon;
+    const int selected = ai->SelectedWeapon();
+    if (selected >= 0 && selected < ai->NMagazineSlots())
+    {
+        const MuzzleType* muzzle = ai->GetMagazineSlot(selected)._muzzle;
+        if (muzzle)
+        {
+            selectedWeapon = muzzle->GetName();
+        }
+    }
+
+    loadout.Add(weapons);
+    loadout.Add(magazines);
+    loadout.Add(selectedWeapon);
+    return value;
+}
+
+GameValue ObjSetUnitLoadout(const GameState* state, GameValuePar oper1, GameValuePar oper2)
+{
+    Object* obj = GetObject(oper1);
+    if (!obj)
+    {
+        return NOTHING;
+    }
+    EntityAI* ai = dyn_cast<EntityAI>(obj);
+    if (!ai)
+    {
+        return NOTHING;
+    }
+
+    const GameArrayType& loadout = oper2;
+    if (loadout.Size() < 2)
+    {
+        state->SetError(EvalDim, loadout.Size(), 2);
+        return NOTHING;
+    }
+    if (!CheckType(state, loadout[0], GameArray) || !CheckType(state, loadout[1], GameArray))
+    {
+        return NOTHING;
+    }
+    if (loadout.Size() >= 3 && loadout[2].GetType() != GameString)
+    {
+        state->TypeError(GameString, loadout[2].GetType());
+        return NOTHING;
+    }
+
+    const GameArrayType& weapons = loadout[0];
+    const GameArrayType& magazines = loadout[1];
+    for (int i = 0; i < weapons.Size(); ++i)
+    {
+        if (!CheckType(state, weapons[i], GameString))
+        {
+            return NOTHING;
+        }
+    }
+    if ((magazines.Size() % 2) != 0)
+    {
+        state->SetError(EvalDim, magazines.Size(), magazines.Size() + 1);
+        return NOTHING;
+    }
+    for (int i = 0; i < magazines.Size(); i += 2)
+    {
+        if (!CheckType(state, magazines[i], GameString) || !CheckType(state, magazines[i + 1], GameScalar))
+        {
+            return NOTHING;
+        }
+    }
+
+    ai->RemoveAllWeapons();
+    ai->RemoveAllMagazines();
+
+    for (int i = 0; i < magazines.Size(); i += 2)
+    {
+        GameStringType magazineName = magazines[i];
+        const int ammo = toInt(static_cast<float>(magazines[i + 1]));
+        Ref<MagazineType> magazineType = MagazineTypes.New(magazineName);
+        if (!magazineType)
+        {
+            continue;
+        }
+        Ref<Magazine> magazine = new Magazine(magazineType);
+        magazine->_ammo = ammo >= 0 ? ammo : magazineType->_maxAmmo;
+        ai->AddMagazine(magazine, false);
+    }
+
+    for (int i = 0; i < weapons.Size(); ++i)
+    {
+        GameStringType weaponName = weapons[i];
+        ai->AddWeapon(weaponName);
+    }
+
+    ai->AutoReloadAll();
+
+    if (loadout.Size() >= 3)
+    {
+        GameStringType selectedWeapon = loadout[2];
+        if (selectedWeapon.GetLength() > 0)
+        {
+            for (int i = 0; i < ai->NMagazineSlots(); i++)
+            {
+                const MuzzleType* muzzle = ai->GetMagazineSlot(i)._muzzle;
+                if (muzzle && stricmp(muzzle->GetName(), selectedWeapon) == 0)
+                {
+                    ai->SelectWeapon(i);
+                    break;
+                }
+            }
+        }
+    }
+
+    return NOTHING;
 }
 
 GameValue ObjAmmoArray(const GameState* state, GameValuePar oper1, GameValuePar oper2)

--- a/engine/Poseidon/Network/NetworkClientOnMessage.cpp
+++ b/engine/Poseidon/Network/NetworkClientOnMessage.cpp
@@ -223,13 +223,14 @@ static NetworkObject* ResolveClientNetworkObject(void* context, const NetworkId&
     return client ? client->GetObject(const_cast<NetworkId&>(id)) : nullptr;
 }
 
-static void ExecuteNamedRemoteExec(GameState* gstate, RString name, GameValuePar params)
+static void ExecuteNamedRemoteExec(GameState* gstate, RString name, GameValuePar params, int sender)
 {
     if (!gstate || !WireBounds::ValidIdentifier(name, 256))
     {
         return;
     }
 
+    Poseidon::ScriptEventSenderScope senderScope(sender);
     GameVarSpace local(gstate->GetContext());
     gstate->BeginContext(&local);
     gstate->VarSetLocal("_this", params, true);
@@ -2420,7 +2421,7 @@ void NetworkClient::OnMessage(int from, NetworkMessage* msg, NetworkMessageType 
 
             GameValue payload = Poseidon::DecodeScriptValue(params._params, ResolveClientNetworkObject, this);
             if (!payload.GetNil() && GWorld && GWorld->GetGameState())
-                ExecuteNamedRemoteExec(GWorld->GetGameState(), params._name, payload);
+                ExecuteNamedRemoteExec(GWorld->GetGameState(), params._name, payload, from);
         }
         break;
         default:

--- a/engine/Poseidon/Network/NetworkImplServer.hpp
+++ b/engine/Poseidon/Network/NetworkImplServer.hpp
@@ -594,6 +594,9 @@ class NetworkServer : public NetworkComponent
     // Broadcast a global system chat line to every connected player. Works on a
     // dedicated server, where GNetworkManager.Chat() is a no-op (no local client).
     void ChatToAllPlayers(RString message);
+    bool RemoteExec(RString name, const AutoArray<char>& params, int target, const AutoArray<char>& targetSpec,
+                    bool jip, RString jipKey, bool callMode);
+    bool RemoteExecRemove(RString jipKey);
     // Number of dynamic (runtime) ban entries — id + IP. Used by tests.
     int GetBanCount() const { return _banListLocal.Size() + _banListIPLocal.Size(); }
     // First runtime id-ban entry as a decimal string, or "" when none. Used by tests

--- a/engine/Poseidon/Network/NetworkMisc.cpp
+++ b/engine/Poseidon/Network/NetworkMisc.cpp
@@ -1869,6 +1869,10 @@ bool NetworkManager::RemoteExec(RString name, const AutoArray<char>& params, int
     {
         return _client->RemoteExec(name, params, target, targetSpec, jip, jipKey, callMode);
     }
+    if (_server)
+    {
+        return _server->RemoteExec(name, params, target, targetSpec, jip, jipKey, callMode);
+    }
     return false;
 }
 
@@ -1877,6 +1881,10 @@ bool NetworkManager::RemoteExecRemove(RString jipKey)
     if (_client)
     {
         return _client->RemoteExecRemove(jipKey);
+    }
+    if (_server)
+    {
+        return _server->RemoteExecRemove(jipKey);
     }
     return false;
 }

--- a/engine/Poseidon/Network/NetworkServerMsgOnMessage.cpp
+++ b/engine/Poseidon/Network/NetworkServerMsgOnMessage.cpp
@@ -110,13 +110,14 @@ static NetworkObject* ResolveServerNetworkObject(void* context, const NetworkId&
     return server ? server->GetObject(mutableId) : nullptr;
 }
 
-static void ExecuteNamedRemoteExec(GameState* gstate, RString name, GameValuePar params)
+static void ExecuteNamedRemoteExec(GameState* gstate, RString name, GameValuePar params, int sender)
 {
     if (!gstate || !WireBounds::ValidIdentifier(name, 256))
     {
         return;
     }
 
+    Poseidon::ScriptEventSenderScope senderScope(sender);
     GameVarSpace local(gstate->GetContext());
     gstate->BeginContext(&local);
     gstate->VarSetLocal("_this", params, true);
@@ -131,6 +132,12 @@ static void ExecuteNamedRemoteExec(GameState* gstate, RString name, GameValuePar
     gstate->EndContext();
 }
 
+static int NextServerRemoteExecSequence()
+{
+    static int sequence = 0;
+    return ++sequence;
+}
+
 static bool RemoteExecCanRunServer(int from, int gameMaster)
 {
     return Poseidon::RemoteExecServerAuthorized(from, gameMaster, AI_PLAYER);
@@ -139,6 +146,139 @@ static bool RemoteExecCanRunServer(int from, int gameMaster)
 static bool PublicExecCanRunClients(int from, int gameMaster, int botClient)
 {
     return from == botClient || (gameMaster != AI_PLAYER && from == gameMaster);
+}
+
+bool NetworkServer::RemoteExec(RString name, const AutoArray<char>& params, int target,
+                               const AutoArray<char>& targetSpec, bool jip, RString jipKey, bool callMode)
+{
+    if (!WireBounds::ValidIdentifier(name, 256))
+    {
+        return false;
+    }
+
+    RemoteExecMessage msg;
+    msg._name = name;
+    msg._params = params;
+    msg._target = target;
+    msg._targetSpec = targetSpec;
+    msg._jip = jip;
+    msg._jipKey = jipKey;
+    msg._callMode = callMode;
+    msg._originator = AI_PLAYER;
+    msg._sequence = NextServerRemoteExecSequence();
+    msg._remove = false;
+
+    RemoteExecTargetSelector targetSelector;
+    bool selectorDecoded = false;
+    if (targetSpec.Size() > 0)
+    {
+        selectorDecoded = DecodeRemoteExecTargetSelector(targetSelector, targetSpec);
+        if (!selectorDecoded)
+        {
+            LOG_WARN(Network, "server remoteExec '{}' rejected malformed target selector", (const char*)name);
+            return false;
+        }
+    }
+    if (!selectorDecoded)
+    {
+        targetSelector.kind = RemoteExecTargetKind::Scalar;
+        targetSelector.scalar = target;
+    }
+
+    bool acceptedForJip = false;
+    NetworkRemoteExecDispatchResult dispatch;
+    if (targetSelector.kind == RemoteExecTargetKind::Scalar)
+    {
+        dispatch = DispatchNetworkRemoteExecTarget(
+            target, _players.Size(), [this](int index) { return _players[index].dpid; },
+            [this](int index) { return _players[index].state; }, NGSLoadIsland,
+            [this, &msg](int dpid) { SendMsg(dpid, &msg, NMFGuaranteed); },
+            [this, &msg]()
+            {
+                GameValue payload = Poseidon::DecodeScriptValue(msg._params, ResolveServerNetworkObject, this);
+                if (!payload.GetNil() && GWorld && GWorld->GetGameState())
+                {
+                    ExecuteNamedRemoteExec(GWorld->GetGameState(), msg._name, payload, AI_PLAYER);
+                }
+            });
+        acceptedForJip = dispatch.acceptedClientTarget || dispatch.executedOnServer;
+    }
+    else
+    {
+        dispatch = DispatchNetworkRemoteExecTargetSelector(
+            targetSelector, _players.Size(), [this](int index) { return _players[index].dpid; },
+            [this](int index) { return _players[index].state; }, NGSLoadIsland,
+            [this, &msg](int dpid) { SendMsg(dpid, &msg, NMFGuaranteed); },
+            [this, &msg]()
+            {
+                GameValue payload = Poseidon::DecodeScriptValue(msg._params, ResolveServerNetworkObject, this);
+                if (!payload.GetNil() && GWorld && GWorld->GetGameState())
+                {
+                    ExecuteNamedRemoteExec(GWorld->GetGameState(), msg._name, payload, AI_PLAYER);
+                }
+            },
+            [this](const NetworkId& id)
+            {
+                if (id.IsNull())
+                {
+                    return 0;
+                }
+                NetworkId mutableId = id;
+                NetworkObjectInfo* info = GetObjectInfo(mutableId);
+                return info ? info->owner : 0;
+            });
+        acceptedForJip = dispatch.acceptedClientTarget || dispatch.executedOnServer;
+    }
+
+    if (acceptedForJip && jip && _missionHeader.joinInProgress)
+    {
+        static const int kMaxJIPMessages = 10000;
+        NetworkMessageFormatBase* format = GetFormat(NMTRemoteExec);
+        Ref<NetworkMessage> storedMsg = new NetworkMessage();
+        if (!format)
+        {
+            return dispatch.executedOnServer || dispatch.sentToClient || acceptedForJip;
+        }
+        storedMsg->time = Glob.time;
+        NetworkMessageContext ctx(storedMsg, format, this, TO_SERVER, MSG_SEND);
+        if (msg.TransferMsg(ctx) != TMOK)
+        {
+            return dispatch.executedOnServer || dispatch.sentToClient || acceptedForJip;
+        }
+        NetworkJipMessageStoreAction action = BuildNetworkJipMessageStoreAction(
+            _jipMessages.Size(), [this](int index) { return _jipMessages[index].type; },
+            [this](int index) { return _jipMessages[index].key; }, NMTRemoteExec, jipKey, kMaxJIPMessages);
+        if (action.shouldReplace)
+        {
+            _jipMessages[action.replaceIndex].msg = storedMsg;
+        }
+        else if (action.shouldAppend)
+        {
+            JIPInitMessage jipMsg;
+            jipMsg.type = NMTRemoteExec;
+            jipMsg.msg = storedMsg;
+            jipMsg.key = jipKey;
+            _jipMessages.Add(jipMsg);
+        }
+    }
+
+    return dispatch.executedOnServer || dispatch.sentToClient || acceptedForJip;
+}
+
+bool NetworkServer::RemoteExecRemove(RString jipKey)
+{
+    bool removed = false;
+    for (int i = 0; i < _jipMessages.Size();)
+    {
+        if (_jipMessages[i].type == NMTRemoteExec && _jipMessages[i].key == jipKey)
+        {
+            _jipMessages.Delete(i);
+            removed = true;
+            continue;
+        }
+        ++i;
+    }
+    return removed;
 }
 
 void NetworkServer::OnMessage(int from, NetworkMessage* msg, NetworkMessageType type)
@@ -699,7 +839,7 @@ void NetworkServer::OnMessage(int from, NetworkMessage* msg, NetworkMessageType 
                     GameValue payload = Poseidon::DecodeScriptValue(params._params, ResolveServerNetworkObject, this);
                     if (!payload.GetNil() && GWorld && GWorld->GetGameState())
                     {
-                        ExecuteNamedRemoteExec(GWorld->GetGameState(), params._name, payload);
+                        ExecuteNamedRemoteExec(GWorld->GetGameState(), params._name, payload, from);
                     }
                     acceptedForJip = true;
                 }
@@ -753,7 +893,7 @@ void NetworkServer::OnMessage(int from, NetworkMessage* msg, NetworkMessageType 
                                     Poseidon::DecodeScriptValue(params._params, ResolveServerNetworkObject, this);
                                 if (!payload.GetNil() && GWorld && GWorld->GetGameState())
                                 {
-                                    ExecuteNamedRemoteExec(GWorld->GetGameState(), params._name, payload);
+                                    ExecuteNamedRemoteExec(GWorld->GetGameState(), params._name, payload, from);
                                 }
                             },
                             [this](const NetworkId& id)

--- a/engine/Poseidon/UI/DisplayUI.cpp
+++ b/engine/Poseidon/UI/DisplayUI.cpp
@@ -76,6 +76,7 @@ namespace Poseidon
 {
 
 void ShowCinemaBorder(bool show);
+void ClearScriptEventHandlers();
 
 int GetNetworkPort();
 RString GetNetworkPassword();
@@ -120,6 +121,8 @@ void CopyDirectoryStructure(const char* dst, const char* src)
 }
 void RunInitScript()
 {
+    Poseidon::ClearScriptEventHandlers();
+
     RString initScript = GetMissionDirectory() + RString("init.sqs");
     if (QIFStreamB::FileExist(initScript))
     {

--- a/engine/README.md
+++ b/engine/README.md
@@ -13,3 +13,7 @@ Poseidon (+ PoseidonGL33, PoseidonOpenAL)  ← full game engine
 | **PoseidonOpenAL** | `PoseidonOpenAL/` | `PoseidonOpenAL.lib` | OpenAL audio backend (linked by client apps) |
 | **PoseidonFormats** | `PoseidonFormats/` | `.dll` / `.lib` | C API for P3D/PAA/PBO/RTM (used by Blender addon) |
 | **Trident** | `Trident/` | `tri` | Rust-based test runner and integration tool |
+
+## Notes
+
+- [Documentation](../docs/README.md)

--- a/tests/unit/apps/Evaluator/test_mock_objects.cpp
+++ b/tests/unit/apps/Evaluator/test_mock_objects.cpp
@@ -178,6 +178,24 @@ TEST_CASE("Object commands - setDammage makes alive false", "[evaluator][mock][c
     REQUIRE((float)dmg == Catch::Approx(1.0f));
 }
 
+TEST_CASE("Object commands - lifeState derives health labels", "[evaluator][mock][commands]")
+{
+    EvalFixture f;
+    int id = f.state().objects.createObject("SyntheticSoldierWest", 0, 0, 0);
+    f.state().VarSet("testObj", makeObjectValue(id));
+
+    GameValue healthy = f.state().Evaluate("lifeState testObj");
+    REQUIRE(strcmp(((GameStringType)healthy).Data(), "HEALTHY") == 0);
+
+    f.state().Execute("testObj setDammage 0.5");
+    GameValue injured = f.state().Evaluate("lifeState testObj");
+    REQUIRE(strcmp(((GameStringType)injured).Data(), "INJURED") == 0);
+
+    f.state().Execute("testObj setDammage 1.0");
+    GameValue dead = f.state().Evaluate("lifeState testObj");
+    REQUIRE(strcmp(((GameStringType)dead).Data(), "DEAD") == 0);
+}
+
 TEST_CASE("Object commands - setDir/getDir", "[evaluator][mock][commands]")
 {
     EvalFixture f;

--- a/tests/unit/engine/Poseidon/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/CMakeLists.txt
@@ -184,6 +184,7 @@ list(APPEND POSEIDON_TEST_SOURCES
     Core/test_splash_gating.cpp
     Core/test_profile_manager.cpp
     Core/test_profile_service.cpp
+    Core/test_local_db_store.cpp
     Core/test_fsm.cpp
     Core/test_globalAlive.cpp
     Core/test_legacy_logging.cpp

--- a/tests/unit/engine/Poseidon/Core/test_local_db_store.cpp
+++ b/tests/unit/engine/Poseidon/Core/test_local_db_store.cpp
@@ -1,0 +1,53 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <Poseidon/Core/LocalDb/LocalDbStore.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+TEST_CASE("Local DB store persists isolated database-key records", "[local_db][persistence]")
+{
+    const fs::path root =
+        fs::temp_directory_path() /
+        ("poseidon_local_db_store_test_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::error_code ec;
+    fs::remove_all(root, ec);
+
+    Poseidon::LocalDb::Store store(root.string());
+    REQUIRE(store.Save("actor", "76561198000000000", R"({"name":"Player One","cash":100})"));
+    REQUIRE(store.Save("bank", "76561198000000000", R"({"balance":250})"));
+    REQUIRE(store.Save("actor", "76561198000000001", R"({"name":"Player Two","cash":50})"));
+
+    std::string actor;
+    REQUIRE(store.Load("actor", "76561198000000000", actor));
+    REQUIRE(actor == R"({"name":"Player One","cash":100})");
+    REQUIRE(fs::is_regular_file(root / "LocalDb" / "schema.json"));
+    REQUIRE(store.Exists("actor", "76561198000000000"));
+    REQUIRE_FALSE(store.Exists("actor", "missing"));
+
+    const std::vector<std::string> actorKeys = store.List("actor");
+    REQUIRE(actorKeys.size() == 2);
+    REQUIRE(std::find(actorKeys.begin(), actorKeys.end(), "76561198000000000") != actorKeys.end());
+    REQUIRE(std::find(actorKeys.begin(), actorKeys.end(), "76561198000000001") != actorKeys.end());
+
+    std::string bank;
+    REQUIRE(store.Load("bank", "76561198000000000", bank));
+    REQUIRE(bank == R"({"balance":250})");
+    REQUIRE(store.Remove("actor", "76561198000000000"));
+    REQUIRE_FALSE(store.Load("actor", "76561198000000000", actor));
+
+    fs::remove_all(root, ec);
+}
+
+TEST_CASE("Local DB store rejects unsafe path identifiers", "[local_db][persistence]")
+{
+    REQUIRE(Poseidon::LocalDb::Store::IsSafeIdentifier("actor.hot-v1"));
+    REQUIRE_FALSE(Poseidon::LocalDb::Store::IsSafeIdentifier("../actor"));
+    REQUIRE_FALSE(Poseidon::LocalDb::Store::IsSafeIdentifier("actor/other"));
+    REQUIRE_FALSE(Poseidon::LocalDb::Store::IsSafeIdentifier(""));
+}

--- a/tests/unit/engine/Poseidon/Game/test_game_state_ext.cpp
+++ b/tests/unit/engine/Poseidon/Game/test_game_state_ext.cpp
@@ -16,10 +16,13 @@
 #include <fstream>
 #include <ctime>
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
+#include <initializer_list>
 #include <map>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "../test_fixtures.hpp"
@@ -57,6 +60,13 @@ GameValue ClassOpen(const GameState* state, GameValuePar oper1, GameValuePar ope
 GameValue ClassAdd(const GameState* state, GameValuePar oper1, GameValuePar oper2);
 GameValue ValueGet(const GameState* state, GameValuePar oper1, GameValuePar oper2);
 GameValue ValueAdd(const GameState* state, GameValuePar oper1, GameValuePar oper2);
+GameValue LocalDbAsyncSave(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncLoad(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncRemove(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncDone(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncResult(const GameState* state, GameValuePar oper1);
+GameValue LocalDbAsyncClear(const GameState* state, GameValuePar oper1);
+GameValue LocalDbLoad(const GameState* state, GameValuePar oper1);
 extern bool GUseFileBanks;
 
 namespace
@@ -242,6 +252,39 @@ GameValue MakeConfigAssignment(const GameState& state, const char* name, GameVal
     return pair;
 }
 
+GameValue MakeStringArray(const GameState& state, std::initializer_list<const char*> values)
+{
+    GameValue value = state.CreateGameValue(GameArray);
+    GameArrayType& array = value;
+    array.Resize(static_cast<int>(values.size()));
+
+    int index = 0;
+    for (const char* item : values)
+        array[index++] = GameValue(item);
+    return value;
+}
+
+GameValue MakeMissionPhaseRegistration(const GameState& state, const char* phase, const char* code)
+{
+    GameValue value = state.CreateGameValue(GameArray);
+    GameArrayType& array = value;
+    array.Resize(2);
+    array[0] = GameValue(phase);
+    array[1] = GameValue(new GameDataCode(code));
+    return value;
+}
+
+GameValue WaitForAsyncLocalDbResult(const GameState& state, GameValue job)
+{
+    for (int attempt = 0; attempt < 200; ++attempt)
+    {
+        if ((bool)LocalDbAsyncDone(&state, job))
+            return LocalDbAsyncResult(&state, job);
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return LocalDbAsyncResult(&state, job);
+}
+
 std::string BankConfigQuery(const std::string& stem)
 {
 #ifdef _WIN32
@@ -270,6 +313,14 @@ struct ScopedMissionHeader
         std::snprintf(Glob.header.worldname, sizeof(Glob.header.worldname), "%s", world.c_str());
         Glob.header.filenameReal = filenameReal;
     }
+};
+
+struct ScopedPlayerName
+{
+    explicit ScopedPlayerName(const char* name) : previous(Glob.header.playerName) { Glob.header.playerName = name; }
+    ~ScopedPlayerName() { Glob.header.playerName = previous; }
+
+    RString previous;
 };
 
 } // namespace
@@ -337,6 +388,21 @@ TEST_CASE("VBS-derived functions remain registered in GGameState", "[game][gameS
     REQUIRE(ContainsName(functions, "VBS_kills"));
     REQUIRE(ContainsName(functions, "VBS_killed"));
     REQUIRE(ContainsName(functions, "VBS_injuries"));
+    REQUIRE(ContainsName(functions, "dbAsyncSave"));
+    REQUIRE(ContainsName(functions, "dbAsyncLoad"));
+    REQUIRE(ContainsName(functions, "dbAsyncRemove"));
+    REQUIRE(ContainsName(functions, "dbAsyncExists"));
+    REQUIRE(ContainsName(functions, "dbAsyncList"));
+    REQUIRE(ContainsName(functions, "dbAsyncFind"));
+    REQUIRE(ContainsName(functions, "dbAsyncFindPath"));
+    REQUIRE(ContainsName(functions, "dbAsyncIndex"));
+    REQUIRE(ContainsName(functions, "dbAsyncIndexPath"));
+    REQUIRE(ContainsName(functions, "dbAsyncDone"));
+    REQUIRE(ContainsName(functions, "dbAsyncResult"));
+    REQUIRE(ContainsName(functions, "dbAsyncClear"));
+    REQUIRE(ContainsName(functions, "cacheAsyncFlush"));
+    REQUIRE(ContainsName(nulars, "cacheAsyncFlushAll"));
+    REQUIRE(ContainsName(nulars, "dbAsyncJobs"));
     REQUIRE(ContainsName(functions, "createGuardedPoint"));
     REQUIRE(ContainsName(functions, "deleteWaypoint"));
     REQUIRE(ContainsName(operators, "saveConfig"));
@@ -350,6 +416,43 @@ TEST_CASE("VBS-derived functions remain registered in GGameState", "[game][gameS
     REQUIRE(ContainsName(operators, "addWaypoint"));
 }
 
+TEST_CASE("async local DB save load and remove complete end to end", "[game][gameStateExt][local_db]")
+{
+    GGameState.Reset();
+    Poseidon::Foundation::InitModules();
+    ScopedPlayerName player("AsyncLocalDbTestPlayer");
+
+    GameValue saveArgs = MakeStringArray(GGameState, {"unit_async", "record", "{\"value\":42}"});
+    GameValue saveJob = LocalDbAsyncSave(&GGameState, saveArgs);
+    REQUIRE(static_cast<GameScalarType>(saveJob) > 0.0f);
+    GameValue saveResultValue = WaitForAsyncLocalDbResult(GGameState, saveJob);
+    const GameArrayType& saveResult = saveResultValue;
+    REQUIRE(saveResult.Size() == 4);
+    REQUIRE(strcmp(((GameStringType)saveResult[1]).Data(), "done") == 0);
+    REQUIRE((bool)saveResult[2]);
+    REQUIRE((bool)LocalDbAsyncClear(&GGameState, saveJob));
+
+    GameValue loadArgs = MakeStringArray(GGameState, {"unit_async", "record"});
+    GameValue loadJob = LocalDbAsyncLoad(&GGameState, loadArgs);
+    REQUIRE(static_cast<GameScalarType>(loadJob) > 0.0f);
+    GameValue loadResultValue = WaitForAsyncLocalDbResult(GGameState, loadJob);
+    const GameArrayType& loadResult = loadResultValue;
+    REQUIRE(loadResult.Size() == 4);
+    REQUIRE(strcmp(((GameStringType)loadResult[1]).Data(), "done") == 0);
+    REQUIRE((bool)loadResult[2]);
+    REQUIRE(strcmp(((GameStringType)loadResult[3]).Data(), "{\"value\":42}") == 0);
+    REQUIRE((bool)LocalDbAsyncClear(&GGameState, loadJob));
+
+    GameValue removeJob = LocalDbAsyncRemove(&GGameState, loadArgs);
+    REQUIRE(static_cast<GameScalarType>(removeJob) > 0.0f);
+    GameValue removeResultValue = WaitForAsyncLocalDbResult(GGameState, removeJob);
+    const GameArrayType& removeResult = removeResultValue;
+    REQUIRE(removeResult.Size() == 4);
+    REQUIRE(strcmp(((GameStringType)removeResult[1]).Data(), "done") == 0);
+    REQUIRE((bool)removeResult[2]);
+    REQUIRE((bool)LocalDbAsyncClear(&GGameState, removeJob));
+    REQUIRE(strcmp(((GameStringType)LocalDbLoad(&GGameState, loadArgs)).Data(), "") == 0);
+}
 TEST_CASE("XOR1024 encryption registers and round-trips data", "[game][gameStateExt][encryption]")
 {
     static bool registered = false;

--- a/tests/unit/engine/Poseidon/Game/test_game_state_ext.cpp
+++ b/tests/unit/engine/Poseidon/Game/test_game_state_ext.cpp
@@ -42,6 +42,7 @@ bool IsAddonMetadataAccepted(const char* product, const char* encryption, const 
 std::string BuildMPReportPathForUserDir(const std::string& userDir, const std::tm& tm);
 bool DefaultAdvancedEditorMode();
 bool LoadAdvancedEditorModeFromUserParams(const char* userParamsPath);
+void ClearScriptEventHandlers();
 } // namespace Poseidon
 
 namespace Poseidon
@@ -60,6 +61,11 @@ GameValue ClassOpen(const GameState* state, GameValuePar oper1, GameValuePar ope
 GameValue ClassAdd(const GameState* state, GameValuePar oper1, GameValuePar oper2);
 GameValue ValueGet(const GameState* state, GameValuePar oper1, GameValuePar oper2);
 GameValue ValueAdd(const GameState* state, GameValuePar oper1, GameValuePar oper2);
+GameValue EventOn(const GameState* state, GameValuePar oper1);
+GameValue EventGet(const GameState* state, GameValuePar oper1);
+GameValue EventList(const GameState* state);
+GameValue EventOff(const GameState* state, GameValuePar oper1);
+GameValue EventEmitLocal(const GameState* state, GameValuePar oper1);
 GameValue LocalDbAsyncSave(const GameState* state, GameValuePar oper1);
 GameValue LocalDbAsyncLoad(const GameState* state, GameValuePar oper1);
 GameValue LocalDbAsyncRemove(const GameState* state, GameValuePar oper1);
@@ -264,6 +270,17 @@ GameValue MakeStringArray(const GameState& state, std::initializer_list<const ch
     return value;
 }
 
+GameValue MakeEventRegistration(const GameState& state, const char* scope, const char* name, const char* code)
+{
+    GameValue value = state.CreateGameValue(GameArray);
+    GameArrayType& array = value;
+    array.Resize(3);
+    array[0] = GameValue(scope);
+    array[1] = GameValue(name);
+    array[2] = GameValue(new GameDataCode(code));
+    return value;
+}
+
 GameValue MakeMissionPhaseRegistration(const GameState& state, const char* phase, const char* code)
 {
     GameValue value = state.CreateGameValue(GameArray);
@@ -388,6 +405,15 @@ TEST_CASE("VBS-derived functions remain registered in GGameState", "[game][gameS
     REQUIRE(ContainsName(functions, "VBS_kills"));
     REQUIRE(ContainsName(functions, "VBS_killed"));
     REQUIRE(ContainsName(functions, "VBS_injuries"));
+    REQUIRE(ContainsName(functions, "eventOn"));
+    REQUIRE(ContainsName(functions, "eventGet"));
+    REQUIRE(ContainsName(nulars, "eventList"));
+    REQUIRE(ContainsName(functions, "eventOff"));
+    REQUIRE(ContainsName(functions, "eventClear"));
+    REQUIRE(ContainsName(functions, "eventEmitLocal"));
+    REQUIRE(ContainsName(functions, "eventEmitGlobal"));
+    REQUIRE(ContainsName(functions, "eventEmitServer"));
+    REQUIRE(ContainsName(functions, "eventEmitTarget"));
     REQUIRE(ContainsName(functions, "dbAsyncSave"));
     REQUIRE(ContainsName(functions, "dbAsyncLoad"));
     REQUIRE(ContainsName(functions, "dbAsyncRemove"));
@@ -414,6 +440,81 @@ TEST_CASE("VBS-derived functions remain registered in GGameState", "[game][gameS
     REQUIRE(ContainsName(operators, "triggerAttachVehicle"));
     REQUIRE(ContainsName(operators, "setEffectCondition"));
     REQUIRE(ContainsName(operators, "addWaypoint"));
+}
+
+TEST_CASE("script event handlers can be inspected by id and listed", "[game][gameStateExt][events]")
+{
+    GGameState.Reset();
+    Poseidon::Foundation::InitModules();
+    Poseidon::ClearScriptEventHandlers();
+
+    GameValue registration = GGameState.CreateGameValue(GameArray);
+    GameArrayType& args = registration;
+    args.Resize(3);
+    args[0] = GameValue("local");
+    args[1] = GameValue("actorLoaded");
+    args[2] = GameValue("events\\on_actor_loaded.sqf");
+
+    GameValue idValue = EventOn(&GGameState, registration);
+    REQUIRE(static_cast<GameScalarType>(idValue) == 1.0f);
+
+    GameValue infoValue = EventGet(&GGameState, idValue);
+    const GameArrayType& info = infoValue;
+    REQUIRE(info.Size() == 5);
+    REQUIRE(static_cast<GameScalarType>(info[0]) == 1.0f);
+    REQUIRE(strcmp(((GameStringType)info[1]).Data(), "local") == 0);
+    REQUIRE(strcmp(((GameStringType)info[2]).Data(), "actorLoaded") == 0);
+    REQUIRE(strcmp(((GameStringType)info[3]).Data(), "script") == 0);
+    REQUIRE(strcmp(((GameStringType)info[4]).Data(), "events\\on_actor_loaded.sqf") == 0);
+
+    GameValue listValue = EventList(&GGameState);
+    const GameArrayType& list = listValue;
+    REQUIRE(list.Size() == 1);
+    const GameArrayType& listedInfo = list[0];
+    REQUIRE(static_cast<GameScalarType>(listedInfo[0]) == 1.0f);
+
+    REQUIRE((bool)EventOff(&GGameState, idValue));
+    GameValue emptyListValue = EventList(&GGameState);
+    const GameArrayType& emptyList = emptyListValue;
+    REQUIRE(emptyList.Size() == 0);
+
+    Poseidon::ClearScriptEventHandlers();
+}
+
+TEST_CASE("script event failed registration does not consume handler ids", "[game][gameStateExt][events]")
+{
+    GGameState.Reset();
+    Poseidon::Foundation::InitModules();
+    Poseidon::ClearScriptEventHandlers();
+
+    GameValue invalid = MakeEventRegistration(GGameState, "local", "empty", "");
+    REQUIRE(static_cast<GameScalarType>(EventOn(&GGameState, invalid)) == -1.0f);
+
+    GameValue valid = MakeEventRegistration(GGameState, "local", "valid", "true");
+    REQUIRE(static_cast<GameScalarType>(EventOn(&GGameState, valid)) == 1.0f);
+
+    Poseidon::ClearScriptEventHandlers();
+}
+
+TEST_CASE("script event dispatch tolerates handler mutation", "[game][gameStateExt][events]")
+{
+    GGameState.Reset();
+    Poseidon::Foundation::InitModules();
+    Poseidon::ClearScriptEventHandlers();
+    GGameState.EvaluateMultiple("triClearRemoteExecLog");
+
+    GameValue first =
+        MakeEventRegistration(GGameState, "local", "mutating", "eventOff 2; triRecordRemoteExec [\"first\"]");
+    GameValue second = MakeEventRegistration(GGameState, "local", "mutating", "triRecordRemoteExec [\"second\"]");
+    REQUIRE(static_cast<GameScalarType>(EventOn(&GGameState, first)) == 1.0f);
+    REQUIRE(static_cast<GameScalarType>(EventOn(&GGameState, second)) == 2.0f);
+
+    GameValue emit = MakeStringArray(GGameState, {"mutating", "payload"});
+    REQUIRE(static_cast<GameScalarType>(EventEmitLocal(&GGameState, emit)) == 2.0f);
+    REQUIRE(strcmp(((GameStringType)GGameState.EvaluateMultiple("triRemoteExecLog")).Data(), "first|second") == 0);
+    REQUIRE(((const GameArrayType&)EventList(&GGameState)).Size() == 1);
+
+    Poseidon::ClearScriptEventHandlers();
 }
 
 TEST_CASE("async local DB save load and remove complete end to end", "[game][gameStateExt][local_db]")

--- a/tests/unit/engine/Poseidon/Network/test_network_server.cpp
+++ b/tests/unit/engine/Poseidon/Network/test_network_server.cpp
@@ -957,6 +957,7 @@ TEST_CASE("remoteExec target resolver -- target 0 includes server and eligible c
     REQUIRE(executedOnServer);
     REQUIRE(result.executedOnServer);
     REQUIRE(result.acceptedClientTarget);
+    REQUIRE(result.sentToClient);
     REQUIRE(sent == std::vector<int>{10, 12});
 }
 
@@ -972,6 +973,7 @@ TEST_CASE("remoteExec target resolver -- target 2 is server only", "[network][re
     REQUIRE(executedOnServer);
     REQUIRE(result.executedOnServer);
     REQUIRE_FALSE(result.acceptedClientTarget);
+    REQUIRE_FALSE(result.sentToClient);
     REQUIRE(sent.empty());
 }
 
@@ -987,6 +989,7 @@ TEST_CASE("remoteExec target resolver -- positive DPID selects one eligible clie
     REQUIRE_FALSE(executedOnServer);
     REQUIRE_FALSE(result.executedOnServer);
     REQUIRE(result.acceptedClientTarget);
+    REQUIRE(result.sentToClient);
     REQUIRE(sent == std::vector<int>{12});
 }
 
@@ -1002,6 +1005,7 @@ TEST_CASE("remoteExec target resolver -- disconnected positive DPID is ignored",
     REQUIRE_FALSE(executedOnServer);
     REQUIRE_FALSE(result.executedOnServer);
     REQUIRE_FALSE(result.acceptedClientTarget);
+    REQUIRE_FALSE(result.sentToClient);
     REQUIRE(sent.empty());
 }
 
@@ -1017,6 +1021,7 @@ TEST_CASE("remoteExec target resolver -- negative DPID excludes that client", "[
     REQUIRE_FALSE(executedOnServer);
     REQUIRE_FALSE(result.executedOnServer);
     REQUIRE(result.acceptedClientTarget);
+    REQUIRE(result.sentToClient);
     REQUIRE(sent == std::vector<int>{10, 12});
 }
 
@@ -1032,6 +1037,7 @@ TEST_CASE("remoteExec target resolver -- -2 targets clients only", "[network][re
     REQUIRE_FALSE(executedOnServer);
     REQUIRE_FALSE(result.executedOnServer);
     REQUIRE(result.acceptedClientTarget);
+    REQUIRE(result.sentToClient);
     REQUIRE(sent == std::vector<int>{10, 11});
 }
 
@@ -1050,6 +1056,7 @@ TEST_CASE("remoteExec target resolver -- object selector targets object owner", 
     REQUIRE_FALSE(executedOnServer);
     REQUIRE_FALSE(result.executedOnServer);
     REQUIRE(result.acceptedClientTarget);
+    REQUIRE(result.sentToClient);
     REQUIRE(sent == std::vector<int>{12});
 }
 
@@ -1068,6 +1075,7 @@ TEST_CASE("remoteExec target resolver -- server-owned object executes on server"
     REQUIRE(executedOnServer);
     REQUIRE(result.executedOnServer);
     REQUIRE_FALSE(result.acceptedClientTarget);
+    REQUIRE_FALSE(result.sentToClient);
     REQUIRE(sent.empty());
 }
 
@@ -1098,6 +1106,7 @@ TEST_CASE("remoteExec target resolver -- array selector flattens and deduplicate
     REQUIRE_FALSE(executedOnServer);
     REQUIRE_FALSE(result.executedOnServer);
     REQUIRE(result.acceptedClientTarget);
+    REQUIRE(result.sentToClient);
     REQUIRE(sent == std::vector<int>{10, 12});
 }
 


### PR DESCRIPTION
## Summary

Adds core scripting support for persistent mission/mod state and script-level event dispatch:

- JSON document helpers for creating, reading, updating, and querying JSON strings
- persistent local DB/cache commands under the active profile `LocalDb` folder
- unit state helpers: `getUnitLoadout`, `setUnitLoadout`, and `lifeState`
- lightweight script event bus commands for local and remote event delivery
- evaluator code block value support used by callback-style command flows

The PR is intentionally kept together because these pieces share scripting/runtime plumbing, but it is split into focused review commits:

1. `Add scripting code block value support`
2. `Add JSON scripting commands`
3. `Add local database scripting commands`
4. `Add unit loadout scripting commands`
5. `Add script event bus commands`

## Validation

- `clang-format --dry-run --Werror` on changed C/C++ files
- Built `PoseidonTests`
- Built `PoseidonEvaluatorTests`
- Ran `PoseidonTests "[local_db]"`
- Ran `PoseidonTests "[events]"`
- Ran `PoseidonEvaluatorTests "[commands][mock]"`

A broader local CTest pass still reports unrelated local-suite issues:
`PoseidonCoreTests_NOT_BUILT` and `FormatTime handles zero and valid timestamps`.

The `FormatTime` failure appears timezone-dependent in my local America/Chicago environment: the test timestamp renders as `2019-12-31 18:00:00` instead of containing `2020`.