### PR TITLE
AIGroupCmd: keep static-weapon crew assigned in AssignVehicles

### DIFF
--- a/engine/Poseidon/AI/AIGroupCmd.cpp
+++ b/engine/Poseidon/AI/AIGroupCmd.cpp
@@ -1487,6 +1487,19 @@ void AIGroup::AssignVehicles()
             {
                 continue;
             }
+            // A driverless vehicle (static weapon) can never satisfy the test
+            // above - GetDriverAssigned() stays null forever - so its crew
+            // would be offered to the assignment loop below on every think.
+            // With two such vehicles in one group they keep stealing each
+            // other's gunner, and the resulting "wrong vehicle" verdict in
+            // GetInVehicles makes him get out and back in once per think.
+            // A unit already sitting in the seat it is assigned to is settled.
+            if (unit->GetVehicle() == veh &&
+                (veh->GetGunnerAssigned() == unit || veh->GetCommanderAssigned() == unit ||
+                 veh->GetDriverAssigned() == unit))
+            {
+                continue;
+            }
             // we need to remove this vehicle
         }
 


### PR DESCRIPTION
AssignVehicles() skips a unit whose assigned vehicle is already crewed only when the vehicle IsAbleToMove() *and* has an assigned driver. A static weapon has no driver position, so GetDriverAssigned() is null forever and the test can never pass: its gunner is handed back to the assignment loop on every AI think.

With a single static weapon this is harmless, but two of them in one group keep claiming the same soldier once the other crew dies: the survivor ends up assigned to the empty gun while sitting in his own, GetInVehicles() sees "wrong vehicle" and orders GetOut, and the next think re-assigns him back. The soldier then mounts and unmounts once per think, indefinitely.

Treat a unit that already occupies the seat it is assigned to as settled.

Repro (Malden/Demo): two grouped M2StaticMGE with a shared SAD waypoint; kill one gunner, the other cycles in/out of his gun at ~1 Hz forever.