### PR TITLE
AISubgroupFSM: drop invalid assignment assert in GetIn point helpers

### DIFF
--- a/engine/Poseidon/AI/AISubgroupFSM.cpp
+++ b/engine/Poseidon/AI/AISubgroupFSM.cpp
@@ -1623,9 +1623,17 @@ static AISubgroupFSM::StateInfo joinStates[] = {
 
 // Command GetIn FSM
 
+// Note: the unit's assignment is deliberately NOT asserted here. A GetIn
+// command outlives the assignment it was issued for - when the target vehicle
+// is destroyed, AIGroup::GetInVehicles() drops the assignment (a wreck fails
+// IsAbleToMove()) while the queued command still points at it - and a
+// player-led subgroup boards vehicles it was never assigned to at all. Both
+// cases are caught one step later by CheckGetInDone(); computing a position
+// for the command's target in the meantime is harmless.
 static Vector3 GetGetInPoint(AIUnit* unit, Transport* veh)
 {
-    AI_ERROR(veh == unit->VehicleAssigned());
+    AI_ERROR(unit);
+    AI_ERROR(veh);
     Vector3 pos = veh->GetUnitGetInPos(unit);
     pos[1] = GLandscape->RoadSurfaceYAboveWater(pos[0], pos[2]);
     return pos;
@@ -1635,7 +1643,8 @@ static Vector3 GetGetInPointFar(AIUnit* unit, Transport* veh)
 {
     Vector3 res;
 
-    AI_ERROR(veh == unit->VehicleAssigned());
+    AI_ERROR(unit);
+    AI_ERROR(veh);
 
     if (veh->IsStopped())
     {


### PR DESCRIPTION
GetGetInPoint()/GetGetInPointFar() assert that the vehicle carried by the GetIn command is the one the unit is assigned to. That is not an invariant:

- when the target vehicle is destroyed it stops being able to move, so AIGroup::GetInVehicles() calls UnassignVehicle() on its would-be crew, while the GetIn command already queued in the subgroup FSM still points at the wreck;
- a player-led subgroup (HasAI() false) boards vehicles without any assignment at all, and CheckGetInDone() only tests the assignment when the subgroup has AI.

The command is rejected properly one step later - CheckGetInDone() fails it on !IsPossibleToGetIn() or on the assignment mismatch - so the only effect of the assert is a spurious ERROR in the log during ordinary play.

Instrumented run of a 200-unit mission, 10 occurrences across three headless sims: every one had targetCanGetIn=0, and 9 of 10 had no assignment left:

  GETIN-DIAG GetGetInPointFar: unit=EAST Kilo Red:5 target=<bmp>
      assigned=<null> in=self free=1 life=0 targetCanGetIn=0
  FSM: EAST Kilo Red:5 GetIn - state INIT -> MOVE   (assert fires in MOVE,
                                                     CheckGetInDone fails it)

Assert what the helpers actually require instead: a unit and a vehicle.