### PR TITLE
Fix nested UI keyboard input

### DIFF
--- a/engine/Poseidon/Game/Commands/GameStateExtTest.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTest.cpp
@@ -1115,6 +1115,23 @@ GameValue TriSelectListByData(const GameState* /*state*/, GameValuePar arg)
     return GameValue(false);
 }
 
+GameValue TriRemoveNestedControl(const GameState* /*state*/, GameValuePar arg)
+{
+    const int idc = static_cast<int>(static_cast<GameScalarType>(arg));
+    auto* display = GetActiveDisplayForSQF();
+    if (!display)
+        return GameValue(false);
+
+    const auto& objects = display->GetObjects();
+    for (int i = 0; i < objects.Size(); ++i)
+    {
+        auto* container = dynamic_cast<ControlObjectContainer*>(objects[i].operator->());
+        if (container && container->GetCtrl(idc))
+            return GameValue(container->RemoveControl(idc));
+    }
+    return GameValue(false);
+}
+
 static GameValue TriSendKeyImpl(int sc, int mods)
 {
     LOG_INFO(Core, "[tri] triSendKey scancode=0x{:x} mods=0x{:x}", sc, mods);

--- a/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
@@ -141,6 +141,7 @@ GameValue TriSelectList(const GameState*, GameValuePar);
 GameValue TriSelectListByData(const GameState*, GameValuePar);
 GameValue TriListSel(const GameState*, GameValuePar);
 GameValue TriAssertListSelAtLeast(const GameState*, GameValuePar);
+GameValue TriRemoveNestedControl(const GameState*, GameValuePar);
 GameValue TriSendKey(const GameState*, GameValuePar);
 GameValue TriSendKeyArr(const GameState*, GameValuePar);
 GameValue TriSendText(const GameState*, GameValuePar);
@@ -2987,6 +2988,7 @@ INIT_MODULE(GameStateExtTest, 3)
     GGameState.NewFunction(GameFunction(GameBool, "triSelectList", TriSelectList, GameArray));
     GGameState.NewFunction(GameFunction(GameBool, "triSelectListByData", TriSelectListByData, GameArray));
     GGameState.NewFunction(GameFunction(GameScalar, "triListSel", TriListSel, GameScalar));
+    GGameState.NewFunction(GameFunction(GameBool, "triRemoveNestedControl", TriRemoveNestedControl, GameScalar));
     GGameState.NewFunction(GameFunction(GameBool, "triSendKey", TriSendKey, GameScalar));
     GGameState.NewFunction(GameFunction(GameBool, "triSendKey", TriSendKeyArr, GameArray));
     GGameState.NewFunction(GameFunction(GameString, "triEndMission", TriEndMission, GameString));

--- a/engine/Poseidon/UI/Controls/UIControlsBase.cpp
+++ b/engine/Poseidon/UI/Controls/UIControlsBase.cpp
@@ -761,6 +761,16 @@ int ControlObjectContainer::GetFocusedIdc()
     return ctrl ? ctrl->IDC() : IDC();
 }
 
+bool ControlObjectContainer::WantsTextInput() const
+{
+    if (_indexFocused < 0 || _indexFocused >= _controls.Size())
+    {
+        return false;
+    }
+    IControl* ctrl = _controls[_indexFocused]._control;
+    return ctrl && ctrl->WantsTextInput();
+}
+
 bool ControlObjectContainer::CanBeDefault() const
 {
     int n = _controls.Size();
@@ -853,6 +863,7 @@ bool ControlObjectContainer::RemoveControl(int idc)
     {
         if (_controls[i]._control && _controls[i]._control->IDC() == idc)
         {
+            const bool removedFocused = _indexFocused == i;
             // Drop tracking indices that point at (or past) this slot
             // so input dispatch doesn't read a stale pointer or address
             // the wrong neighbour after the array shifts.
@@ -873,6 +884,8 @@ bool ControlObjectContainer::RemoveControl(int idc)
             else if (_indexMove > i)
                 _indexMove--;
             _controls.Delete(i);
+            if (removedFocused)
+                UpdateTextInputState();
             return true;
         }
     }
@@ -1158,6 +1171,18 @@ void ControlObjectContainer::SetFocus(int i, bool def)
         _controls[i]._control->OnSetFocus(true, def);
     }
     _indexFocused = i;
+    UpdateTextInputState();
+}
+
+void ControlObjectContainer::UpdateTextInputState()
+{
+    if (IsFocused() && GEngine)
+    {
+        if (WantsTextInput())
+            GEngine->StartTextInput();
+        else
+            GEngine->StopTextInput();
+    }
 }
 
 bool ControlObjectContainer::NextCtrl()

--- a/engine/Poseidon/UI/Controls/UIControlsBase.hpp
+++ b/engine/Poseidon/UI/Controls/UIControlsBase.hpp
@@ -293,6 +293,7 @@ public:
 
 	IControl *GetFocused() override;
 	bool OnSetFocus(bool up = true, bool def = false) override;
+	bool WantsTextInput() const override;
 	bool CanBeDefault() const override;
 
 	void OnLButtonDown(float x, float y) override;
@@ -320,6 +321,7 @@ public:
 protected:
 	void LoadControls(const ParamEntry &cls);
 	int FindControl(float x, float y);
+	void UpdateTextInputState();
 
 	void SetFocus(int i, bool def = false);
 	bool NextCtrl();

--- a/engine/Poseidon/UI/Controls/UIControlsTree.cpp
+++ b/engine/Poseidon/UI/Controls/UIControlsTree.cpp
@@ -583,6 +583,14 @@ bool CTree::OnKeyDown(unsigned nChar, unsigned nRepCnt, unsigned nFlags)
 
     switch (nChar)
     {
+        case SDLK_PLUS:
+        case SDLK_KP_PLUS:
+            Expand(_selected, true);
+            return true;
+        case SDLK_MINUS:
+        case SDLK_KP_MINUS:
+            Expand(_selected, false);
+            return true;
         case SDLK_UP:
             if (_selected != firstVisible)
             {

--- a/tests/integration/ui/main_menu/custom_arcade_tree_shortcuts.test.sqf
+++ b/tests/integration/ui/main_menu/custom_arcade_tree_shortcuts.test.sqf
@@ -1,0 +1,18 @@
+triSetLanguage "English"
+triAssertEq [(triDisplay), 0]
+
+triClick 104
+triAssertEq [(triDisplay), 25]
+triAssertEq [(triTextInputActive), 0]
+
+triSendKey 87
+triSendKey 81
+triSimFrames 2
+triAssert [(triGetControlVisible 103)]
+
+triSendKey 82
+triSendKey 86
+triSendKey 81
+triSimFrames 2
+triRefute [(triGetControlVisible 103)]
+triEndTest

--- a/tests/integration/ui/main_menu/custom_arcade_tree_shortcuts.test.toml
+++ b/tests/integration/ui/main_menu/custom_arcade_tree_shortcuts.test.toml
@@ -1,0 +1,3 @@
+tags = ["ui", "main-menu", "input"]
+timeout = 120
+script = "tests/integration/ui/main_menu/custom_arcade_tree_shortcuts.test.sqf"

--- a/tests/integration/ui/main_menu/profile_name_text_input.test.sqf
+++ b/tests/integration/ui/main_menu/profile_name_text_input.test.sqf
@@ -1,0 +1,18 @@
+triSetLanguage "English"
+triAssertEq [(triDisplay), 0]
+
+triClick 109
+triAssertEq [(triDisplay), 31]
+triClick 102
+triAssertEq [(triDisplay), 42]
+
+triCursorMoveControl 101
+triMouseLeft 1
+triSimFrames 2
+triMouseLeft 0
+triSimFrames 2
+triAssertEq [(triTextInputActive), 1]
+
+triAssertEq [triRemoveNestedControl 101, true]
+triAssertEq [(triTextInputActive), 0]
+triEndTest

--- a/tests/integration/ui/main_menu/profile_name_text_input.test.toml
+++ b/tests/integration/ui/main_menu/profile_name_text_input.test.toml
@@ -1,0 +1,3 @@
+binary = "PoseidonGame"
+timeout = 60
+tags = ["headless"]


### PR DESCRIPTION
Track text-input state through focused nested controls and handle tree expansion shortcuts directly from key events.

regression of #155, fixes https://github.com/ofpisnotdead-com/CWR-CE/issues/211 :pray: 