### PR TITLE
Add extreme terrain detail

### DIFF
--- a/engine/Poseidon/UI/Options/GraphicsPage.cpp
+++ b/engine/Poseidon/UI/Options/GraphicsPage.cpp
@@ -30,7 +30,8 @@ const GraphicsRowText kRows[] = {
     {"STR_DISP_MAIN_OPT_GRAPHICS_QUALITY_PRESET", "STR_DISP_MAIN_OPT_GRAPHICS_QUALITY_PRESET_DESC", "Quality Preset",
      "Sets the four quality tiers below to a known bundle. Touching any tier row drops the preset to Custom."},
     {"STR_DISP_MAIN_OPT_GRAPHICS_TERRAIN_DETAIL", "STR_DISP_MAIN_OPT_GRAPHICS_TERRAIN_DETAIL_DESC", "Terrain Detail",
-     "Terrain mesh density. Lower means a coarser ground silhouette but cheaper rendering."},
+     "Terrain mesh density. Lower means a coarser ground silhouette but cheaper rendering. Extreme is not recommended "
+     "and is not fully compatible with the original game."},
     {"STR_DISP_MAIN_OPT_GRAPHICS_OBJECT_LOD", "STR_DISP_MAIN_OPT_GRAPHICS_OBJECT_LOD_DESC", "Object LOD",
      "Bias for entity LOD selection. Higher means finer geometry at the same distance."},
     {"STR_DISP_MAIN_OPT_GRAPHICS_SHADOW_QUALITY", "STR_DISP_MAIN_OPT_GRAPHICS_SHADOW_QUALITY_DESC", "Shadow Quality",
@@ -201,7 +202,7 @@ OptionsScrollList::RowDef GraphicsPage::GraphicsProvider::RowFor(int row) const
         case kRowPreset:
             return {502, m_page->m_presetCStrs.data(), 5};
         case kRowTerrain:
-            return {512, m_page->m_tierFourCStrs.data(), 4};
+            return {512, m_page->m_terrainCStrs.data(), 5};
         case kRowObjectLod:
             return {522, m_page->m_tierFourCStrs.data(), 4};
         case kRowShadow:
@@ -249,7 +250,6 @@ int GraphicsPage::GraphicsProvider::RowValue(int row) const
                        ? (int)c.qualityPreset
                        : (int)GraphicsConfig::PresetCustom;
         case kRowTerrain:
-            // Map TierLow..TierUltra (1..4) to options-array index 0..3.
             return (int)c.terrainDetail - (int)GraphicsConfig::TierLow;
         case kRowObjectLod:
             return (int)c.objectLod - (int)GraphicsConfig::TierLow;
@@ -322,7 +322,7 @@ void GraphicsPage::GraphicsProvider::SetRowValue(int row, int v)
             }
             break;
         case kRowTerrain:
-            if (v >= 0 && v < 4)
+            if (v >= 0 && v < 5)
             {
                 c.terrainDetail = static_cast<GraphicsConfig::Tier>((int)GraphicsConfig::TierLow + v);
                 tierTouched = true;
@@ -429,6 +429,14 @@ void GraphicsPage::RefreshLocalizedChoices()
     m_presetLabels[4] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_CUSTOM");
     for (size_t i = 0; i < m_presetLabels.size(); ++i)
         m_presetCStrs[i] = m_presetLabels[i].c_str();
+
+    m_terrainLabels[0] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_LOW");
+    m_terrainLabels[1] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_MEDIUM");
+    m_terrainLabels[2] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_HIGH");
+    m_terrainLabels[3] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_ULTRA");
+    m_terrainLabels[4] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_EXTREME");
+    for (size_t i = 0; i < m_terrainLabels.size(); ++i)
+        m_terrainCStrs[i] = m_terrainLabels[i].c_str();
 
     m_tierFourLabels[0] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_LOW");
     m_tierFourLabels[1] = LocalizeString("STR_DISP_MAIN_OPT_VALUE_MEDIUM");

--- a/engine/Poseidon/UI/Options/GraphicsPage.hpp
+++ b/engine/Poseidon/UI/Options/GraphicsPage.hpp
@@ -95,6 +95,8 @@ private:
 
 	std::array<std::string, 5>      m_presetLabels;
 	std::array<const char*, 5>      m_presetCStrs{};
+	std::array<std::string, 5>      m_terrainLabels;
+	std::array<const char*, 5>      m_terrainCStrs{};
 	std::array<std::string, 4>      m_tierFourLabels;
 	std::array<const char*, 4>      m_tierFourCStrs{};
 	std::array<std::string, 4>      m_shadowLabels;

--- a/engine/Poseidon/UI/Settings/GraphicsApply.cpp
+++ b/engine/Poseidon/UI/Settings/GraphicsApply.cpp
@@ -13,12 +13,9 @@ namespace Poseidon
 {
 using Poseidon::gUserFpsCap;
 
-namespace
+float TerrainGridForTier(GraphicsConfig::Tier tier)
 {
-// Tier → grid metres (Terrain Detail).
-float TerrainTierToGrid(GraphicsConfig::Tier t)
-{
-    switch (t)
+    switch (tier)
     {
         case GraphicsConfig::TierLow:
             return 50.0f;
@@ -28,11 +25,15 @@ float TerrainTierToGrid(GraphicsConfig::Tier t)
             return 12.5f;
         case GraphicsConfig::TierUltra:
             return 6.25f;
+        case GraphicsConfig::TierExtreme:
+            return 3.125f;
         default:
             return 6.25f;
     }
 }
 
+namespace
+{
 // Tier → projected-screen-size multiplier for LOD selection.  Low
 // halves the apparent size (picks coarser LOD); Ultra doubles
 // (picks finer LOD).  Range matches Scene::SetObjectLODBias clamp
@@ -74,7 +75,7 @@ void ApplyGraphicsConfigToEngine(const GraphicsConfig& cfg)
 {
     if (GScene)
     {
-        GScene->SetPreferredTerrainGrid(TerrainTierToGrid(cfg.terrainDetail));
+        GScene->SetPreferredTerrainGrid(TerrainGridForTier(cfg.terrainDetail));
         GScene->SetObjectLODBias(ObjectLodTierToBias(cfg.objectLod));
         // Shadow tier — Off → both off; Low+ → both on.  Low/Med/High
         // discrimination is UI-only until a shadow-distance bias hook

--- a/engine/Poseidon/UI/Settings/GraphicsApply.hpp
+++ b/engine/Poseidon/UI/Settings/GraphicsApply.hpp
@@ -21,6 +21,7 @@
 
 namespace Poseidon
 {
+float TerrainGridForTier(GraphicsConfig::Tier tier);
 void ApplyGraphicsConfigToEngine(const GraphicsConfig& cfg);
 
 } // namespace Poseidon

--- a/engine/Poseidon/UI/Settings/GraphicsConfig.cpp
+++ b/engine/Poseidon/UI/Settings/GraphicsConfig.cpp
@@ -169,7 +169,7 @@ bool GraphicsConfig::Normalize(const Environment& /*env*/)
     }
 
     // Tier rows.  Off allowed only for Shadow + Particles.
-    if (!IsValidTier(terrainDetail, /*allowOff=*/false))
+    if (terrainDetail != TierExtreme && !IsValidTier(terrainDetail, /*allowOff=*/false))
     {
         terrainDetail = TierUltra;
         changed = true;

--- a/engine/Poseidon/UI/Settings/GraphicsConfig.hpp
+++ b/engine/Poseidon/UI/Settings/GraphicsConfig.hpp
@@ -45,8 +45,8 @@ public:
 		PresetCustom = 4,   // sentinel — UI shows "Custom" when the four tier rows
 		                     // don't match any of Low/Medium/High/Ultra's bundle
 	};
-	// Terrain / Object / Shadow / Particles share the same Off-to-Ultra
-	// shape.  Off only legal where called out (Shadow, Particles).
+	// Extreme is legal only for Terrain. Off is legal only for Shadow and
+	// Particles.
 	enum Tier
 	{
 		TierOff    = 0,
@@ -54,6 +54,7 @@ public:
 		TierMedium = 2,
 		TierHigh   = 3,
 		TierUltra  = 4,
+		TierExtreme = 5,
 	};
 	enum VsyncMode
 	{

--- a/tests/integration/ui/options/graphics/new_graphics_apply_persist.test.sqf
+++ b/tests/integration/ui/options/graphics/new_graphics_apply_persist.test.sqf
@@ -27,7 +27,7 @@ triSimFrames 5;
 // One Down → Terrain Detail (row 1).
 triSendKey 81;
 triSimFrames 1;
-// Right wraps the 4-entry stepper from idx 3 (Ultra) to idx 0 (Low).
+// Right advances from Ultra to the manual Extreme tier.
 triSendKey 79;
 triSimFrames 2;
 

--- a/tests/integration/ui/options/graphics/new_graphics_apply_persist.test.toml
+++ b/tests/integration/ui/options/graphics/new_graphics_apply_persist.test.toml
@@ -1,4 +1,3 @@
 binary = "PoseidonGame"
 no_menu = false
 timeout = 30
-tags = ["headless"]

--- a/tests/smoke/graphics_apply_persist.tests.ps1
+++ b/tests/smoke/graphics_apply_persist.tests.ps1
@@ -57,7 +57,7 @@ Describe "graphics.cfg persistence through live UI flow" {
 
             Test-Path $cfgPath | Should -BeTrue -Because "GraphicsPage::Unmount should write graphics.cfg"
             $kv = Read-CfgFile $cfgPath
-            $kv['terrainDetail'] | Should -Be '1' -Because "tri cycled Terrain stepper from Ultra (4) to Low (1)"
+            $kv['terrainDetail'] | Should -Be '5' -Because "tri advanced Terrain Detail from Ultra to Extreme"
             $kv['qualityPreset'] | Should -Be '4' -Because "touching a tier row drops Quality Preset to Custom (4)"
         } finally {
             Remove-EphemeralGamePaths $eph

--- a/tests/unit/engine/Poseidon/UI/Settings/test_graphicsConfig.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_graphicsConfig.cpp
@@ -6,6 +6,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <Poseidon/UI/Settings/GraphicsConfig.hpp>
+#include <Poseidon/UI/Settings/GraphicsApply.hpp>
 
 #include <filesystem>
 #include <fstream>
@@ -298,6 +299,33 @@ TEST_CASE("GraphicsConfig: DerivePresetFromTiers returns Custom when tiers diver
     c.ApplyPresetToTiers(GraphicsConfig::PresetHigh);
     c.objectLod = GraphicsConfig::TierLow; // High preset has objectLod=High; mismatch
     CHECK(c.DerivePresetFromTiers() == GraphicsConfig::PresetCustom);
+}
+
+TEST_CASE("GraphicsConfig: the manual terrain tier stays outside every preset", "[Settings][GraphicsConfig]")
+{
+    constexpr auto manualTerrainTier = GraphicsConfig::TierExtreme;
+    FakeEnvironment env;
+    GraphicsConfig c;
+
+    c.terrainDetail = manualTerrainTier;
+    CHECK_FALSE(c.Normalize(env));
+    CHECK(c.terrainDetail == manualTerrainTier);
+    CHECK(c.DerivePresetFromTiers() == GraphicsConfig::PresetCustom);
+
+    for (int value = GraphicsConfig::PresetLow; value <= GraphicsConfig::PresetUltra; ++value)
+    {
+        c.ApplyPresetToTiers(static_cast<GraphicsConfig::Preset>(value));
+        CHECK(c.terrainDetail != manualTerrainTier);
+    }
+
+    c.objectLod = manualTerrainTier;
+    c.shadowQuality = manualTerrainTier;
+    c.particlesQuality = manualTerrainTier;
+    REQUIRE(c.Normalize(env));
+    CHECK(c.objectLod == GraphicsConfig::TierUltra);
+    CHECK(c.shadowQuality == GraphicsConfig::TierHigh);
+    CHECK(c.particlesQuality == GraphicsConfig::TierHigh);
+    CHECK(Poseidon::TerrainGridForTier(manualTerrainTier) == 3.125f);
 }
 
 TEST_CASE("GraphicsConfig: Normalize is a no-op when every field is valid", "[Settings][GraphicsConfig]")

--- a/tests/unit/engine/Poseidon/UI/test_graphics_page.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_graphics_page.cpp
@@ -128,6 +128,23 @@ TEST_CASE("GraphicsPage anti-aliasing rows round-trip through the provider", "[U
     CHECK(p.RowValue(11) == 4);
 }
 
+TEST_CASE("GraphicsPage offers the manual terrain tier last", "[UI][GraphicsPage]")
+{
+    TestableGraphicsPage page;
+    auto& p = page.Provider();
+
+    CHECK(p.RowFor(1).count == 5);
+    CHECK(p.RowFor(2).count == 4);
+
+    p.SetRowValue(1, 4);
+    CHECK(p.RowValue(1) == 4);
+    CHECK(p.RowValue(0) == GraphicsConfig::PresetCustom);
+
+    const std::string description = p.RowDescription(1);
+    CHECK(description.find("not recommended") != std::string::npos);
+    CHECK(description.find("not fully compatible with the original game") != std::string::npos);
+}
+
 TEST_CASE("GraphicsPage multitexturing row is a boolean defaulting to on", "[UI][GraphicsPage]")
 {
     TestableGraphicsPage page;


### PR DESCRIPTION
Expose a manual Extreme terrain tier at 3.125 m while keeping all preset bundles capped at Ultra. Before the fix, tier 5 normalized to 4 and the terrain row exposed four choices.

Some peeps requested this IMHO non-playable setup. :pray: 