### PR TITLE
Avoid endGame command collision

### DIFF
--- a/apps/cwr/Server/ServerApplication.cpp
+++ b/apps/cwr/Server/ServerApplication.cpp
@@ -495,7 +495,7 @@ void ServerApplication::DedicatedServerLoop()
             }
         }
 
-        // Clean exit on close request — simulate-mode endGame/debriefing, or a harness
+        // Clean exit on close request - simulate-mode triEndGame/debriefing, or a harness
         // "exit"/triEndTest (IsExitRequested -> m_closeRequest above). Honouring it in
         // non-simulate mode too lets the Trident runner shut the server down at test end.
         if (m_closeRequest)

--- a/engine/Poseidon/Foundation/Platform/AppConfig.cpp
+++ b/engine/Poseidon/Foundation/Platform/AppConfig.cpp
@@ -683,7 +683,7 @@ void AppConfig::ParseCommandLine(int argc, char** argv)
 
         showOption(
             debugGroup
-                ->add_option("--duration", _simulateDuration, "Simulation duration in seconds (0 = until endGame)")
+                ->add_option("--duration", _simulateDuration, "Simulation duration in seconds (0 = until triEndGame)")
                 ->check(CLI::NonNegativeNumber),
             CliHelpVisibility::Dev);
 

--- a/engine/Poseidon/Foundation/Platform/AppConfig.hpp
+++ b/engine/Poseidon/Foundation/Platform/AppConfig.hpp
@@ -254,7 +254,7 @@ public:
     /// Simulate mode (--simulate): headless mission execution without players
     bool IsSimulateMode() const { return _simulateMode; }
     
-    /// Simulation duration in seconds (--duration N, 0 = run until endGame or Ctrl+C)
+    /// Simulation duration in seconds (--duration N, 0 = run until triEndGame or Ctrl+C)
     int GetSimulateDuration() const { return _simulateDuration; }
     
     bool LogFileOps() const { return _logFileOps; }

--- a/engine/Poseidon/Game/Commands/GameStateExt.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExt.cpp
@@ -396,7 +396,6 @@ GameValue ConfigListNames(const GameState* state);
 GameValue ConfigNew(const GameState* state);
 GameValue DayTime(const GameState* state);
 GameValue EnableEndDialog(const GameState* state);
-GameValue EndGame(const GameState* state);
 GameValue ForceEnd(const GameState* state);
 GameValue GameTime(const GameState* state);
 GameValue GetAcceleratedTime(const GameState* state);
@@ -883,7 +882,6 @@ static const GameNular* GetExtNular(int& count)
 
         GameNular(GameNothing, "enableEndDialog", EnableEndDialog),
         GameNular(GameNothing, "forceEnd", ForceEnd),
-        GameNular(GameNothing, "endGame", EndGame),
         GameNular(GameScalar, "musicVolume", GetMusicVolume),
         GameNular(GameScalar, "soundVolume", GetSoundVolume),
 

--- a/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
@@ -107,6 +107,7 @@ bool TriNetworkAssetFileExists(const RString& relativePath)
 } // namespace
 
 GameValue TriVersion(const GameState*);
+GameValue TriEndGame(const GameState*);
 GameValue TriGameMode(const GameState*);
 GameValue TriDisplay(const GameState*);
 GameValue TriEditorMode(const GameState*);
@@ -2929,6 +2930,7 @@ INIT_MODULE(GameStateExtTest, 3)
     if (!appConfig.DevMode() && appConfig.GetHarnessPort() < 0 && appConfig.GetTestMissionPath().empty())
         return;
 
+    GGameState.NewNularOp(GameNular(GameNothing, "triEndGame", TriEndGame));
     GGameState.NewNularOp(GameNular(GameString, "triVersion", TriVersion));
     GGameState.NewNularOp(GameNular(GameScalar, "triGameMode", TriGameMode));
     GGameState.NewNularOp(GameNular(GameScalar, "triDisplay", TriDisplay));

--- a/engine/Poseidon/Game/Commands/GameStateExtWorld.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtWorld.cpp
@@ -784,10 +784,10 @@ GameValue ForceEnd(const GameState* state)
     return NOTHING;
 }
 
-GameValue EndGame(const GameState* state)
+GameValue TriEndGame(const GameState* state)
 {
     if (AppConfig::Instance().IsSimulateMode())
-        LOG_INFO(Mission, "[endGame]");
+        LOG_INFO(Mission, "[triEndGame]");
 
     const bool automationMissionExit = AppConfig::Instance().IsSimulateMode() ||
                                        !AppConfig::Instance().GetTestMissionPath().empty() ||
@@ -795,7 +795,7 @@ GameValue EndGame(const GameState* state)
     if (automationMissionExit)
         GStats.OnMPMissionEnd();
 
-    // In mp-assign mode, endGame means the mission completed successfully
+    // In mp-assign mode, triEndGame means the mission completed successfully
     if (!AppConfig::Instance().GetMPAssign().empty())
         GApp->m_exitCode = ResolveMultiplayerAutomationExitCode(GApp->m_exitCode, GApp->m_closeRequest, true);
     GApp->m_closeRequest = true;

--- a/tests/integration/missions/mp_assign_report.Demo/init.sqs
+++ b/tests/integration/missions/mp_assign_report.Demo/init.sqs
@@ -1,3 +1,3 @@
 ~8
-endGame
+triEndGame
 exit

--- a/tests/unit/engine/Poseidon/Game/test_game_state_ext.cpp
+++ b/tests/unit/engine/Poseidon/Game/test_game_state_ext.cpp
@@ -330,6 +330,8 @@ TEST_CASE("VBS-derived functions remain registered in GGameState", "[game][gameS
     GGameState.AppendNularOpList(nulars, AcceptAllNames);
 
     REQUIRE(ContainsName(nulars, "newConfig"));
+    REQUIRE_FALSE(ContainsName(nulars, "endGame"));
+    REQUIRE_FALSE(ContainsName(nulars, "triEndGame"));
     REQUIRE(ContainsName(functions, "loadConfig"));
     REQUIRE(ContainsName(functions, "VBS_addHeader"));
     REQUIRE(ContainsName(functions, "VBS_addEvent"));


### PR DESCRIPTION
Rename the automation command to `triEndGame` and register it only when Trident commands are available. This keeps mission variables named `endgame` from terminating the application.

Fixes for example random "crashes" in MP with Kegetys Spectating script.