### PR TITLE
Fix link to Windows install guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In short: the code is free software, the name is not, and the game data comes se
 ### Step-by-step Guides
 
 There are installation/build guides for [Linux](docs/build/linux.md) and
-[Windows](docs/build/windows.md).
+[Windows](docs/build/win.md).
 
 ### Development Builds
 


### PR DESCRIPTION
This was pointing to `windows.md` before, when the file is named `win.md` (which I named because it seemed to fit our conventions better).