### PR TITLE
Tzk cwa ce 203 crash fix

### DIFF
--- a/engine/Poseidon/AI/AISubgroupFSM.cpp
+++ b/engine/Poseidon/AI/AISubgroupFSM.cpp
@@ -1261,7 +1261,7 @@ static void CheckFireFire(AISubgroupContext* context)
                     continue;
                 }
                 EntityAI* vehicle = unit->GetVehicle();
-                if (cmd->_param >= 0)
+                if (cmd->_param >= 0 && cmd->_param < vehicle->NMagazineSlots())
                 {
                     const Magazine* magazine = vehicle->GetMagazineSlot(cmd->_param)._magazine;
                     if (magazine && magazine->_ammo > 0)
@@ -1295,7 +1295,7 @@ static void CheckFireFire(AISubgroupContext* context)
             {
                 continue;
             }
-            if (cmd->_param >= 0)
+            if (cmd->_param >= 0 && cmd->_param < unit->GetVehicle()->NMagazineSlots())
             {
                 EntityAI* vehicle = unit->GetVehicle();
                 const Magazine* magazine = vehicle->GetMagazineSlot(cmd->_param)._magazine;

--- a/engine/Poseidon/AI/VehicleAI.cpp
+++ b/engine/Poseidon/AI/VehicleAI.cpp
@@ -631,6 +631,10 @@ bool EntityAI::CanLock(TargetType* type, int weapon) const
         // FIX
         // if there is no mode, use some other way to check if it is LAW
         // check weapon typical magazine
+        if (weapon >= NMagazineSlots())
+        {
+            return false;
+        }
         const MagazineSlot& slot = GetMagazineSlot(weapon);
         const MuzzleType* muzzle = slot._muzzle;
         if (!muzzle)
@@ -1350,7 +1354,7 @@ int EntityAI::NextWeapon(int weapon) const
     // check max. primary level
     int maxPrimary = MaxPrimaryLevel();
 
-    if (weapon >= 0)
+    if (weapon >= 0 && weapon < NMagazineSlots())
     {
         const MagazineSlot& slot = GetMagazineSlot(weapon);
         if (slot._muzzle->_primary < maxPrimary)
@@ -1401,7 +1405,7 @@ int EntityAI::NextWeapon(int weapon) const
 int EntityAI::PrevWeapon(int weapon) const
 {
     int maxPrimary = MaxPrimaryLevel();
-    if (weapon >= 0)
+    if (weapon >= 0 && weapon < NMagazineSlots())
     {
         const MagazineSlot& slot = GetMagazineSlot(weapon);
         if (slot._muzzle->_primary < maxPrimary)

--- a/engine/Poseidon/AI/VehicleAICombat.cpp
+++ b/engine/Poseidon/AI/VehicleAICombat.cpp
@@ -638,6 +638,11 @@ static Vector3 GetWeaponSoundPos(EntityAI* veh, int weapon)
 */
 bool EntityAI::ReloadMagazine(int slotIndex)
 {
+    if (slotIndex < 0 || slotIndex >= NMagazineSlots())
+    {
+        return false;
+    }
+
     const MagazineSlot& slot = GetMagazineSlot(slotIndex);
     const MuzzleType* muzzle = slot._muzzle;
     Magazine* oldMagazine = slot._magazine;
@@ -744,6 +749,11 @@ bool EntityAI::AutoReload(int weapon)
     //   FireWeapon
     //   AddMagazine ????
     //   AddWeapon ????
+
+    if (weapon < 0 || weapon >= NMagazineSlots())
+    {
+        return false;
+    }
 
     const MagazineSlot& slot = GetMagazineSlot(weapon);
     const MuzzleType* muzzle = slot._muzzle;
@@ -1318,7 +1328,7 @@ void EntityAI::Animate(int level)
     }
 
     // reload animations
-    if (_currentWeapon >= 0)
+    if (_currentWeapon >= 0 && _currentWeapon < NMagazineSlots())
     {
         const MagazineSlot& s = GetMagazineSlot(_currentWeapon);
         const WeaponType* weapon = s._weapon;
@@ -1374,7 +1384,7 @@ void EntityAI::Deanimate(int level)
 
 float EntityAI::GetAimed(int weapon, Target* target) const
 {
-    if (weapon < 0)
+    if (weapon < 0 || weapon >= NMagazineSlots())
     {
         return 0;
     }
@@ -1793,6 +1803,11 @@ bool EntityAI::GetWeaponCartridgePos(int weapon, Matrix4& pos, Vector3& vel) con
 
 bool EntityAI::GetWeaponLoaded(int weapon) const
 {
+    if (weapon < 0 || weapon >= NMagazineSlots())
+    {
+        return true; // bad weapon. Invalid weapon index
+    }
+
     const Magazine* magazine = GetMagazineSlot(weapon)._magazine;
     if (!magazine)
     {
@@ -1925,6 +1940,11 @@ bool EntityAI::FireShell(int weapon, Vector3Par offset, Vector3Par direction, Ta
 
     _fire._nextWeaponSwitch = Glob.time + GetInvAbility() * 0.5;
 
+    if (weapon < 0 || weapon >= NMagazineSlots())
+    {
+        return false;
+    }
+
     const Magazine* magazine = GetMagazineSlot(weapon)._magazine;
     if (!magazine)
     {
@@ -2001,6 +2021,10 @@ bool EntityAI::FireMGun(int weapon, Vector3Par offset, Vector3Par direction, Tar
     }
 
     // fire
+    if (weapon < 0 || weapon >= NMagazineSlots())
+    {
+        return false;
+    }
     const MagazineSlot& slot = GetMagazineSlot(weapon);
     const Magazine* magazine = slot._magazine;
     if (!magazine)

--- a/engine/Poseidon/AI/VehicleAIPilot.cpp
+++ b/engine/Poseidon/AI/VehicleAIPilot.cpp
@@ -1219,6 +1219,11 @@ int EntityAI::FindBestMagazine(const MagazineType* type, int ammo) const
 
 static void GetReloadActions(EntityAI* veh, UIActions& actions, int iSlot, const MuzzleType* currentMuzzle)
 {
+    if (iSlot < 0 || iSlot >= veh->NMagazineSlots())
+    {
+        return;
+    }
+
     const MagazineSlot& slot = veh->GetMagazineSlot(iSlot);
     const Magazine* magazine = slot._magazine;
     const MagazineType* mType = magazine ? magazine->_type : nullptr;
@@ -1383,7 +1388,7 @@ void EntityAI::GetActions(UIActions& actions, AIUnit* unit, bool now)
                 }
             }
             // primary weapon
-            if (_currentWeapon >= 0)
+            if (_currentWeapon >= 0 && _currentWeapon < NMagazineSlots())
             {
                 const MagazineSlot& slot = GetMagazineSlot(_currentWeapon);
                 const MuzzleType* muzzle = slot._muzzle;
@@ -1421,7 +1426,7 @@ void EntityAI::GetActions(UIActions& actions, AIUnit* unit, bool now)
             }
             // magazines
             const MuzzleType* currentMuzzle = nullptr;
-            if (_currentWeapon >= 0)
+            if (_currentWeapon >= 0 && _currentWeapon < NMagazineSlots())
             {
                 currentMuzzle = GetMagazineSlot(_currentWeapon)._muzzle;
                 GetReloadActions(this, actions, _currentWeapon, currentMuzzle);

--- a/engine/Poseidon/Graphics/Rendering/Shape/ShapeFile.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Shape/ShapeFile.cpp
@@ -500,7 +500,7 @@ void Shape::Reverse()
         AnimationPhase& phase = _phase[i];
         for (int p = 0; p < phase.Size(); p++)
         {
-            ReverseVector(phase[i]);
+            ReverseVector(phase[p]);
         }
     }
 }

--- a/engine/Poseidon/Network/NetworkClientOnMessage.cpp
+++ b/engine/Poseidon/Network/NetworkClientOnMessage.cpp
@@ -1292,6 +1292,10 @@ void NetworkClient::OnMessage(int from, NetworkMessage* msg, NetworkMessageType 
             {
                 break;
             }
+            if (ask.weapon < 0 || ask.weapon >= ask.vehicle->NMagazineSlots())
+            {
+                break;
+            }
             Magazine* state = ask.vehicle->GetMagazineSlot(ask.weapon)._magazine;
             if (!state)
             {

--- a/engine/Poseidon/UI/InGame/InGameUI.cpp
+++ b/engine/Poseidon/UI/InGame/InGameUI.cpp
@@ -2396,7 +2396,10 @@ void InGameUI::SendKilled(AIUnit* unit, PackedBoolArray list)
     {
         if (list.Get(i))
         {
-            grp->SendUnitDown(unit, grp->UnitWithID(i + 1));
+            if (AIUnit* down = grp->UnitWithID(i + 1))
+            {
+                grp->SendUnitDown(unit, down);
+            }
         }
     }
 }

--- a/engine/Poseidon/UI/InGame/InGameUI.cpp
+++ b/engine/Poseidon/UI/InGame/InGameUI.cpp
@@ -1284,7 +1284,7 @@ void InGameUI::ResetVehicle(EntityAI* vehicle)
     int weapon = vehicle->FirstWeapon();
     weapon = ValidateWeapon(vehicle, weapon);
     // if the weapon is not weapon, but rather special item, do not select it
-    if (weapon >= 0)
+    if (weapon >= 0 && weapon < vehicle->NMagazineSlots())
     {
         const MagazineSlot& slot = vehicle->GetMagazineSlot(weapon);
         const WeaponType* type = slot._weapon;

--- a/engine/Poseidon/UI/InGame/InGameUIActions.cpp
+++ b/engine/Poseidon/UI/InGame/InGameUIActions.cpp
@@ -813,7 +813,7 @@ void AddDropActions(AIUnit* unit, UIActions& actions)
         if (!findWeapons)
         {
             int index = veh->SelectedWeapon();
-            if (index >= 0)
+            if (index >= 0 && index < veh->NMagazineSlots())
             {
                 const MagazineSlot& slot = veh->GetMagazineSlot(index);
                 if (slot._weapon && slot._weapon->_canDrop)
@@ -825,7 +825,7 @@ void AddDropActions(AIUnit* unit, UIActions& actions)
         if (!findMagazines)
         {
             int index = veh->SelectedWeapon();
-            if (index >= 0)
+            if (index >= 0 && index < veh->NMagazineSlots())
             {
                 const MagazineSlot& slot = veh->GetMagazineSlot(index);
                 if (slot._magazine)

--- a/engine/Poseidon/World/Detection/Target.cpp
+++ b/engine/Poseidon/World/Detection/Target.cpp
@@ -705,7 +705,7 @@ void EntityAI::TrackTargets(TargetList& res, AIUnit* unit, int canSee, bool init
 
     if (canSee & CanSeeOptics)
     {
-        if (_currentWeapon >= 0 && EnableViewThroughOptics())
+        if (_currentWeapon >= 0 && _currentWeapon < NMagazineSlots() && EnableViewThroughOptics())
         {
             const MagazineSlot& slot = GetMagazineSlot(_currentWeapon);
             if (slot._muzzle)
@@ -1553,6 +1553,10 @@ bool EntityAI::WhatShootResult(FireResult& result, const Target& target, int wea
               (const char*)target.type->GetName(), weapon);
 #endif
 
+    if (weapon < 0 || weapon >= NMagazineSlots())
+    {
+        return false;
+    }
     const Magazine* magazine = GetMagazineSlot(weapon)._magazine;
     if (!magazine)
     {

--- a/engine/Poseidon/World/Detection/TargetFire.cpp
+++ b/engine/Poseidon/World/Detection/TargetFire.cpp
@@ -1340,6 +1340,10 @@ bool EntityAI::WhatFireResult(FireResult& result, const Target& target, int weap
 #if DIAG_RESULT
     LOG_DEBUG(AI, " inRange {:.3f}", inRange);
 #endif
+    if (weapon < 0 || weapon >= NMagazineSlots())
+    {
+        return false;
+    }
     const Magazine* magazine = GetMagazineSlot(weapon)._magazine;
     if (!magazine)
     {
@@ -2042,7 +2046,7 @@ void EntityAI::SelectFireWeapon(FireDecision& fire)
     }
     else
     {
-        if (fire._fireMode >= 0)
+        if (fire._fireMode >= 0 && fire._fireMode < NMagazineSlots())
         {
             const Magazine* magazine = GetMagazineSlot(fire._fireMode)._magazine;
             if (!magazine || magazine->_ammo == 0)

--- a/engine/Poseidon/World/Entities/Infantry/Person.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/Person.cpp
@@ -88,7 +88,7 @@ LODShapeWithShadow* Person::GetOpticsModel(Person* person)
 {
     PoseidonAssert(person == this);
 
-    if (_currentWeapon < 0)
+    if (_currentWeapon < 0 || _currentWeapon >= NMagazineSlots())
     {
         return nullptr;
     }
@@ -104,7 +104,7 @@ bool Person::GetForceOptics(Person* person) const
 {
     PoseidonAssert(person == this);
 
-    if (_currentWeapon < 0)
+    if (_currentWeapon < 0 || _currentWeapon >= NMagazineSlots())
     {
         return false;
     }

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldAI.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldAI.cpp
@@ -86,6 +86,11 @@ void Man::AimWeaponAI(int weapon, Vector3Par direction, float deltaT)
     SelectWeapon(weapon);
     Vector3 relDir(VMultiply, DirWorldToModel(), direction);
 
+    if (weapon < 0 || weapon >= NMagazineSlots())
+    {
+        return;
+    }
+
     const Magazine* magazine = GetMagazineSlot(weapon)._magazine;
     if (!magazine)
     {
@@ -326,7 +331,7 @@ bool Man::AimWeaponForceFire(int weapon)
 
 bool Man::CalculateAimWeapon(int weapon, Vector3& dir, Target* target)
 {
-    if (weapon < 0)
+    if (weapon < 0 || weapon >= NMagazineSlots())
     {
         return false;
     }
@@ -1635,9 +1640,9 @@ void Soldier::AIPilot(float deltaT, SimulationImportance prec)
     {
         speedWanted = 0;
     }
-    else if (_fire._fireMode >= 0 && (!_fire._firePrepareOnly || !unit->IsKeepingFormation()) &&
-             _fireState != FireDone && _fire._fireTarget && _fire._fireTarget->IsKnownBy(unit) &&
-             _fire._fireTarget->idExact && // ???
+    else if (_fire._fireMode >= 0 && _fire._fireMode < NMagazineSlots() &&
+             (!_fire._firePrepareOnly || !unit->IsKeepingFormation()) && _fireState != FireDone && _fire._fireTarget &&
+             _fire._fireTarget->IsKnownBy(unit) && _fire._fireTarget->idExact && // ???
              unit->IsFireEnabled(_fire._fireTarget) && GetMagazineSlot(_fire._fireMode)._magazine &&
              GetMagazineSlot(_fire._fireMode)._magazine->_reloadMagazine <= 1)
     {

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldActions.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldActions.cpp
@@ -203,7 +203,7 @@ void Soldier::KeyboardPilot(float deltaT, SimulationImportance prec)
                 FireAttemptWhenNotPossible();
             }
         }
-        else if (_currentWeapon >= 0 && EnableWeaponManipulation())
+        else if (_currentWeapon >= 0 && _currentWeapon < NMagazineSlots() && EnableWeaponManipulation())
         {
             const MagazineSlot& slot = GetMagazineSlot(_currentWeapon);
             const Magazine* magazine = slot._magazine;

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldMove.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldMove.cpp
@@ -579,6 +579,9 @@ bool Man::IsActionInProgress(MoveFinishF action) const
 
 bool Man::ReloadMagazine(int slotIndex, int iMagazine)
 {
+    if (slotIndex < 0 || slotIndex >= NMagazineSlots())
+        return false;
+
     const MagazineSlot& slot = GetMagazineSlot(slotIndex);
     const MuzzleType* muzzle = slot._muzzle;
 
@@ -1374,6 +1377,13 @@ const WeaponModeType* Man::GetCurrentWeaponMode() const
         return mode;
     }
     // fall back to first mode of the first typical magazine (LAW-style weapons have no direct mode)
+
+    // Logic will continue if GetWeaponMode above returns NULL thus it can't guarantee _currentWeapon is valid
+    if (_currentWeapon >= NMagazineSlots())
+    {
+        return nullptr;
+    }
+
     const MagazineSlot& slot = GetMagazineSlot(_currentWeapon);
     const MuzzleType* muzzle = slot._muzzle;
     if (!muzzle)

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldSimProxy.cpp
@@ -71,7 +71,7 @@ Object* Man::GetProxy(LODShapeWithShadow*& shape, int level, Matrix4& transform,
         {
             weapon = GetWeaponSystem(index);
             pshape = weapon->_model;
-            if (_currentWeapon >= 0)
+            if (_currentWeapon >= 0 && _currentWeapon < NMagazineSlots())
             {
                 const MagazineSlot& slot = GetMagazineSlot(_currentWeapon);
                 if (slot._weapon == weapon && slot._magazine && slot._magazine->_ammo > 0)
@@ -98,7 +98,7 @@ Object* Man::GetProxy(LODShapeWithShadow*& shape, int level, Matrix4& transform,
         {
             weapon = GetWeaponSystem(index);
             pshape = weapon->_model;
-            if (_currentWeapon >= 0)
+            if (_currentWeapon >= 0 && _currentWeapon < NMagazineSlots())
             {
                 const MagazineSlot& slot = GetMagazineSlot(_currentWeapon);
                 if (slot._weapon == weapon && slot._magazine && slot._magazine->_ammo > 0)
@@ -225,7 +225,7 @@ void Man::DrawProxies(int level, ClipFlags clipFlags, const Matrix4& transform, 
                 weapon = GetWeaponSystem(index);
                 pshape = weapon->_model;
                 animFire = &weapon->_animFire;
-                if (_currentWeapon >= 0)
+                if (_currentWeapon >= 0 && _currentWeapon < NMagazineSlots())
                 {
                     const MagazineSlot& slot = GetMagazineSlot(_currentWeapon);
                     if (slot._weapon == weapon && slot._magazine && slot._magazine->_ammo > 0)
@@ -254,7 +254,7 @@ void Man::DrawProxies(int level, ClipFlags clipFlags, const Matrix4& transform, 
                 weapon = GetWeaponSystem(index);
                 pshape = weapon->_model;
                 animFire = &weapon->_animFire;
-                if (_currentWeapon >= 0)
+                if (_currentWeapon >= 0 && _currentWeapon < NMagazineSlots())
                 {
                     const MagazineSlot& slot = GetMagazineSlot(_currentWeapon);
                     if (slot._weapon == weapon && slot._magazine && slot._magazine->_ammo > 0)
@@ -304,7 +304,7 @@ void Man::DrawProxies(int level, ClipFlags clipFlags, const Matrix4& transform, 
                 {
                     pshape = weapon->_model;
                     animFire = &weapon->_animFire;
-                    if (_currentWeapon >= 0)
+                    if (_currentWeapon >= 0 && _currentWeapon < NMagazineSlots())
                     {
                         const MagazineSlot& slot = GetMagazineSlot(_currentWeapon);
                         if (slot._weapon == weapon && slot._magazine && slot._magazine->_ammo > 0)
@@ -523,7 +523,7 @@ void Man::Draw(int level, ClipFlags clipFlags, const FrameBase& pos)
 #endif
     if (GWorld->GetCameraType() == CamGunner && GWorld->CameraOn() == this)
     {
-        if (_currentWeapon >= 0)
+        if (_currentWeapon >= 0 && _currentWeapon < NMagazineSlots())
         {
             WeaponType* weapon = GetMagazineSlot(_currentWeapon)._weapon;
             MuzzleType* muzzle = GetMagazineSlot(_currentWeapon)._muzzle;

--- a/engine/Poseidon/World/Entities/Vehicles/Air/AirplaneAI.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/Air/AirplaneAI.cpp
@@ -103,6 +103,10 @@ bool AirplaneAuto::CalculateAimWeapon(int weapon, Vector3& dir, Target* target)
         }
         weapon = 0;
     }
+    else if (weapon >= NMagazineSlots())
+    {
+        return false;
+    }
     _fire.SetTarget(CommanderUnit(), target);
     Vector3 tgtPos = target->AimingPosition();
     Vector3 weaponPos = Type()->_gunPos;
@@ -1106,6 +1110,11 @@ bool AirplaneAuto::FireWeapon(int weapon, TargetType* target)
 
 void AirplaneAuto::FireWeaponEffects(int weapon, const Magazine* magazine, EntityAI* target)
 {
+    if (weapon < 0 || weapon >= NMagazineSlots())
+    {
+        return;
+    }
+
     const MagazineSlot& slot = GetMagazineSlot(weapon);
     if (!magazine || slot._magazine != magazine)
     {

--- a/engine/Poseidon/World/Entities/Vehicles/Air/HelicopterAI.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/Air/HelicopterAI.cpp
@@ -55,6 +55,10 @@ bool HelicopterAuto::AimWeapon(int weapon, Vector3Par direction)
         }
         weapon = 0;
     }
+    else if (weapon >= NMagazineSlots())
+    {
+        return false;
+    }
     SelectWeapon(weapon);
     Vector3 relDir(VMultiply, DirWorldToModel(), direction);
 
@@ -74,6 +78,10 @@ bool HelicopterAuto::AimWeapon(int weapon, Target* target)
             return false;
         }
         weapon = 0;
+    }
+    else if (weapon >= NMagazineSlots())
+    {
+        return false;
     }
     _fire.SetTarget(CommanderUnit(), target);
     Vector3 tgtPos = target->AimingPosition();
@@ -964,6 +972,11 @@ bool HelicopterAuto::FireWeapon(int weapon, TargetType* target)
 
 void HelicopterAuto::FireWeaponEffects(int weapon, const Magazine* magazine, EntityAI* target)
 {
+    if (weapon < 0 || weapon >= NMagazineSlots())
+    {
+        return;
+    }
+
     const MagazineSlot& slot = GetMagazineSlot(weapon);
     if (!magazine || slot._magazine != magazine)
     {

--- a/engine/Poseidon/World/Entities/Vehicles/Ground/Car.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/Ground/Car.cpp
@@ -2053,6 +2053,11 @@ void Car::FireWeaponEffects(int weapon, const Magazine* magazine, EntityAI* targ
 {
     if (HasTurret())
     {
+        if (weapon < 0 || weapon >= NMagazineSlots())
+        {
+            return;
+        }
+
         const MagazineSlot& slot = GetMagazineSlot(weapon);
         if (!magazine || slot._magazine != magazine)
         {
@@ -2129,6 +2134,10 @@ bool Car::AimWeapon(int weapon, Vector3Par direction)
             return false;
         }
         weapon = 0;
+    }
+    else if (weapon >= NMagazineSlots())
+    {
+        return false;
     }
     SelectWeapon(weapon);
     Vector3 relDir(VMultiply, DirWorldToModel(), direction);

--- a/engine/Poseidon/World/Entities/Vehicles/Ground/Motorcycle.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/Ground/Motorcycle.cpp
@@ -2072,6 +2072,11 @@ void Motorcycle::FireWeaponEffects(int weapon, const Magazine* magazine, EntityA
 {
     if (HasTurret())
     {
+        if (weapon < 0 || weapon >= NMagazineSlots())
+        {
+            return;
+        }
+
         const MagazineSlot& slot = GetMagazineSlot(weapon);
         if (!magazine || slot._magazine != magazine)
         {
@@ -2144,6 +2149,10 @@ bool Motorcycle::AimWeapon(int weapon, Vector3Par direction)
             return false;
         }
         weapon = 0;
+    }
+    else if (weapon >= NMagazineSlots())
+    {
+        return false;
     }
     SelectWeapon(weapon);
     // move turret/gun accordingly to direction

--- a/engine/Poseidon/World/Entities/Vehicles/Ground/TankWithAI.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/Ground/TankWithAI.cpp
@@ -124,6 +124,11 @@ bool Tank::FireWeapon(int weapon, TargetType* target)
 
 void Tank::FireWeaponEffects(int weapon, const Magazine* magazine, EntityAI* target)
 {
+    if (weapon < 0 || weapon >= NMagazineSlots())
+    {
+        return;
+    }
+
     const MagazineSlot& slot = GetMagazineSlot(weapon);
     if (!magazine || slot._magazine != magazine)
     {
@@ -244,6 +249,10 @@ bool Tank::CalculateAimWeapon(int weapon, Vector3& dir, Target* target)
             return false;
         }
         weapon = 0;
+    }
+    else if (weapon >= NMagazineSlots())
+    {
+        return false;
     }
     _fire.SetTarget(CommanderUnit(), target);
     const Magazine* magazine = GetMagazineSlot(weapon)._magazine;

--- a/engine/Poseidon/World/Entities/Vehicles/Misc/Ship.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/Misc/Ship.cpp
@@ -1628,6 +1628,11 @@ bool Ship::FireWeapon(int weapon, TargetType* target)
 
 void Ship::FireWeaponEffects(int weapon, const Magazine* magazine, EntityAI* target)
 {
+    if (weapon < 0 || weapon >= NMagazineSlots())
+    {
+        return;
+    }
+
     const MagazineSlot& slot = GetMagazineSlot(weapon);
     if (!magazine || slot._magazine != magazine)
     {
@@ -1677,6 +1682,10 @@ bool Ship::AimWeapon(int weapon, Vector3Par direction)
             return false;
         }
         weapon = 0;
+    }
+    else if (weapon >= NMagazineSlots())
+    {
+        return false;
     }
     SelectWeapon(weapon);
     Vector3 relDir(VMultiply, DirWorldToModel(), direction);

--- a/engine/Poseidon/World/Entities/Vehicles/Transport.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/Transport.cpp
@@ -1123,7 +1123,7 @@ void ResourceSupply::GetActions(UIActions& actions, AIUnit* unit, bool now)
         }
         {
             int index = veh->SelectedWeapon();
-            if (index >= 0 && !_parent->GetType()->_showWeaponCargo)
+            if (index >= 0 && index < veh->NMagazineSlots() && !_parent->GetType()->_showWeaponCargo)
             {
                 const MagazineSlot& slot = veh->GetMagazineSlot(index);
                 if (GetFreeWeaponCargo() > 0 && slot._weapon && slot._weapon->_canDrop)


### PR DESCRIPTION
These fixes are based on crash dump files collected over one year of TZK MP games on CWA-CE 2.03. They include one null check for a AIUnit, one index variable error, and extensive bounds checks on NMagazineSlots (similar to what was done in 7f67f0a, which checks whether the index is less than NMagazineSlots).