### PR TITLE
Support versioned workshop mods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "unicode-normalization",
  "ureq",
  "zstd",
 ]

--- a/mserver/CLI/Cargo.toml
+++ b/mserver/CLI/Cargo.toml
@@ -25,6 +25,7 @@ ureq = { version = "2", default-features = false, features = ["native-tls", "jso
 # zstdmt: multi-threaded compression so large mods (rcwc is 11 GB) pack in minutes, not ~30.
 zstd = { version = "0.13", features = ["zstdmt"] }
 tempfile = "3"
+unicode-normalization = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/mserver/CLI/src/main.rs
+++ b/mserver/CLI/src/main.rs
@@ -64,9 +64,9 @@ enum Command {
     /// Print the entries and properties of a PBO archive.
     Info(InfoArgs),
     /// Publish a mod (a folder to pack, or an already-packed .pbo) to a workshop.
-    Publish(PublishArgs),
-    /// Upload a new immutable revision of an existing workshop mod.
-    Update(UpdateArgs),
+    Publish(Box<PublishArgs>),
+    /// Set the game versions that can use one package revision.
+    Compatibility(CompatibilityArgs),
     /// List the mods on a remote workshop.
     List,
     /// Download + unpack mods from a workshop into a mods directory (for servers).
@@ -106,16 +106,31 @@ struct InfoArgs {
     file: String,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Clone, Debug)]
 struct PublishArgs {
     /// A folder to pack, or an already-packed `.pbo` to upload as-is.
     source: String,
     /// Admin API key (also read from `PAPA_ADMIN_KEY`).
     #[arg(long, env = "PAPA_ADMIN_KEY")]
     admin_key: String,
-    /// Display name of the mod.
+    /// Stable workshop identity. Defaults to `modId` in the source `mod.json`.
     #[arg(long)]
-    name: String,
+    mod_id: Option<String>,
+    /// Display name of the mod. Defaults to the source `mod.json`.
+    #[arg(long)]
+    name: Option<String>,
+    /// Game application identifier, e.g. `CWR`.
+    #[arg(long)]
+    app: Option<String>,
+    /// Compatible game data version, e.g. `305`.
+    #[arg(long)]
+    actver: Option<i32>,
+    /// Additional compatible game data version (repeatable).
+    #[arg(long = "compatible-actver")]
+    compatible_actvers: Vec<i32>,
+    /// Compatible build tag.
+    #[arg(long = "vertag", visible_alias = "version-tag")]
+    version_tag: Option<String>,
     /// Explicit version; defaults to the artifact content hash on the server.
     #[arg(long)]
     version: Option<String>,
@@ -138,35 +153,17 @@ struct PublishArgs {
 }
 
 #[derive(Args, Debug)]
-struct UpdateArgs {
-    /// Stable workshop mod identifier to update.
+struct CompatibilityArgs {
+    /// Stable workshop identity.
     mod_id: String,
-    /// A folder to pack, or an already-packed `.pbo` to upload as-is.
-    source: String,
+    /// Package revision to expose.
+    revision: u64,
+    /// Compatible game data version (repeatable).
+    #[arg(long = "actver", required = true)]
+    compatible_actvers: Vec<i32>,
     /// Admin API key (also read from `PAPA_ADMIN_KEY`).
     #[arg(long, env = "PAPA_ADMIN_KEY")]
     admin_key: String,
-    /// Replacement display name; omitted values inherit the current metadata.
-    #[arg(long)]
-    name: Option<String>,
-    /// Replacement author-facing version.
-    #[arg(long)]
-    version: Option<String>,
-    /// Replacement short description.
-    #[arg(long)]
-    description: Option<String>,
-    /// Replacement author list.
-    #[arg(long = "author")]
-    authors: Vec<String>,
-    /// Replacement project homepage URL.
-    #[arg(long)]
-    homepage_url: Option<String>,
-    /// Replacement canonical install folder name.
-    #[arg(long)]
-    folder_name: Option<String>,
-    /// Addon prefix property baked into the PBO.
-    #[arg(long)]
-    prefix: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -230,12 +227,51 @@ fn main() -> Result<()> {
         Command::Unpack(args) => run_unpack(args),
         Command::Info(args) => run_info(args),
         Command::Publish(args) => run_publish(args, &cli.master, cli.insecure),
-        Command::Update(args) => run_update(args, &cli.master, cli.insecure),
+        Command::Compatibility(args) => run_compatibility(args, &cli.master, cli.insecure),
         Command::List => run_list(&cli.master, cli.insecure),
         Command::Install(args) => run_install(args, &cli.master, cli.insecure),
         Command::Query(args) => run_query(args),
         Command::Servers(args) => run_servers(args, &cli.master, cli.insecure),
         Command::Server(args) => run_server(args, &cli.master, cli.insecure),
+    }
+}
+
+fn run_compatibility(args: &CompatibilityArgs, master: &str, insecure: bool) -> Result<()> {
+    let base = master.trim_end_matches('/');
+    let url = format!(
+        "{base}/v1/mods/{}/revisions/{}/compatibility",
+        args.mod_id, args.revision
+    );
+    let body = serde_json::to_string(&serde_json::json!({
+        "compatibleActvers": args.compatible_actvers
+    }))?;
+    let response = http_agent(insecure)?
+        .put(&url)
+        .set("x-api-key", &args.admin_key)
+        .set("content-type", "application/json")
+        .send_string(&body);
+    match response {
+        Ok(_) => {
+            println!(
+                "set {} revision {} compatibility to {}",
+                args.mod_id,
+                args.revision,
+                args.compatible_actvers
+                    .iter()
+                    .map(i32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+            Ok(())
+        }
+        Err(ureq::Error::Status(code, response)) => {
+            let detail = response.into_string().unwrap_or_default();
+            bail!(
+                "compatibility update rejected: HTTP {code}: {}",
+                detail.trim()
+            );
+        }
+        Err(error) => bail!("compatibility update failed: {error}"),
     }
 }
 
@@ -281,22 +317,42 @@ fn run_info(args: &InfoArgs) -> Result<()> {
 }
 
 fn run_publish(args: &PublishArgs, master: &str, insecure: bool) -> Result<()> {
-    run_upload(args, None, master, insecure)
+    let args = publish_args_with_manifest(args)?;
+    let mod_id = args.mod_id.as_deref();
+    if let Some(mod_id) = mod_id {
+        if mod_id.is_empty()
+            || mod_id.contains('/')
+            || mod_id.contains('\\')
+            || mod_id.contains("..")
+        {
+            bail!("invalid mod id '{mod_id}'");
+        }
+    }
+    let existing = mod_id
+        .map(|id| remote_mod_exists(master, id, insecure))
+        .transpose()?
+        .unwrap_or(false);
+    let name = args.name.as_deref().unwrap_or("");
+    if !existing && name.is_empty() {
+        bail!("new packages require --name or a name in the source mod.json");
+    }
+    run_upload(&args, mod_id.filter(|_| existing), master, insecure)
 }
 
-fn run_update(args: &UpdateArgs, master: &str, insecure: bool) -> Result<()> {
-    let publish = PublishArgs {
-        source: args.source.clone(),
-        admin_key: args.admin_key.clone(),
-        name: args.name.clone().unwrap_or_default(),
-        version: args.version.clone(),
-        description: args.description.clone(),
-        authors: args.authors.clone(),
-        homepage_url: args.homepage_url.clone(),
-        folder_name: args.folder_name.clone(),
-        prefix: args.prefix.clone(),
-    };
-    run_upload(&publish, Some(&args.mod_id), master, insecure)
+fn remote_mod_exists(master: &str, mod_id: &str, insecure: bool) -> Result<bool> {
+    let base = master.trim_end_matches('/');
+    match http_agent(insecure)?
+        .get(&format!("{base}/v1/mods/{mod_id}"))
+        .call()
+    {
+        Ok(_) => Ok(true),
+        Err(ureq::Error::Status(404, _)) => Ok(false),
+        Err(ureq::Error::Status(code, response)) => {
+            let detail = response.into_string().unwrap_or_default();
+            bail!("catalog lookup failed: HTTP {code}: {}", detail.trim());
+        }
+        Err(error) => bail!("catalog lookup failed: {error}"),
+    }
 }
 
 fn run_upload(
@@ -342,6 +398,7 @@ fn run_upload(
         Ok(ok) => {
             let entry: serde_json::Value = ok.into_json().context("parsing publish response")?;
             let response_mod_id = entry["modId"].as_str().unwrap_or("?");
+            let response_name = upload_result_name(&entry, args.name.as_deref().unwrap_or(""));
             let version = entry["version"].as_str().unwrap_or("?");
             let revision = entry["packageRevision"].as_u64().unwrap_or(1);
             let download = entry["downloadUrl"].as_str().unwrap_or("?");
@@ -351,8 +408,7 @@ fn run_upload(
                 "published"
             };
             println!(
-                "{action} '{}' as {response_mod_id}, version {version}, package revision {revision} ({artifact_len} bytes compressed) -> {base}{download}",
-                args.name
+                "{action} '{response_name}' as {response_mod_id}, version {version}, package revision {revision} ({artifact_len} bytes compressed) -> {base}{download}"
             );
             Ok(())
         }
@@ -362,6 +418,115 @@ fn run_upload(
         }
         Err(error) => bail!("publish request failed: {error}"),
     }
+}
+
+fn upload_result_name<'a>(entry: &'a serde_json::Value, requested_name: &'a str) -> &'a str {
+    entry["name"].as_str().unwrap_or(requested_name)
+}
+
+fn publish_args_with_manifest(args: &PublishArgs) -> Result<PublishArgs> {
+    let manifest = read_source_manifest(Path::new(&args.source))?;
+    let mut resolved = args.clone();
+    if let Some(manifest) = manifest {
+        resolved.mod_id = resolved.mod_id.or_else(|| json_string(&manifest, "modId"));
+        resolved.name = resolved.name.or_else(|| json_string(&manifest, "name"));
+        resolved.app = resolved.app.or_else(|| json_string(&manifest, "app"));
+        resolved.actver = resolved.actver.or_else(|| {
+            manifest["actver"]
+                .as_i64()
+                .and_then(|value| i32::try_from(value).ok())
+        });
+        if resolved.compatible_actvers.is_empty() {
+            resolved.compatible_actvers = manifest["compatibleActvers"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(serde_json::Value::as_i64)
+                .filter_map(|value| i32::try_from(value).ok())
+                .collect();
+        }
+        resolved.version_tag = resolved
+            .version_tag
+            .or_else(|| json_string(&manifest, "vertag"));
+        resolved.version = resolved
+            .version
+            .or_else(|| json_string(&manifest, "version"));
+        resolved.description = resolved
+            .description
+            .or_else(|| json_string(&manifest, "description"));
+        resolved.homepage_url = resolved
+            .homepage_url
+            .or_else(|| json_string(&manifest, "homepageUrl"));
+        resolved.folder_name = resolved
+            .folder_name
+            .or_else(|| json_string(&manifest, "folderName"));
+        if resolved.authors.is_empty() {
+            resolved.authors = manifest["authors"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|author| author.as_str().map(str::to_string))
+                .collect();
+        }
+    }
+    if resolved.mod_id.is_none() {
+        resolved.mod_id = resolved
+            .name
+            .as_deref()
+            .map(workshop_slug)
+            .filter(|value| !value.is_empty());
+    }
+    Ok(resolved)
+}
+
+fn read_source_manifest(source: &Path) -> Result<Option<serde_json::Value>> {
+    let bytes = if source.is_dir() {
+        let path = source.join("mod.json");
+        match fs::read(&path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error).with_context(|| format!("reading {}", path.display())),
+        }
+    } else if source.is_file() {
+        Pbo::read_path(source)
+            .with_context(|| format!("'{}' is not a valid PBO", source.display()))?
+            .read("mod.json")
+            .transpose()?
+    } else {
+        None
+    };
+    bytes
+        .map(|bytes| {
+            serde_json::from_slice(&bytes)
+                .with_context(|| format!("parsing mod.json in {}", source.display()))
+        })
+        .transpose()
+}
+
+fn json_string(value: &serde_json::Value, key: &str) -> Option<String> {
+    value[key]
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn workshop_slug(name: &str) -> String {
+    use unicode_normalization::UnicodeNormalization;
+    let mut out = String::new();
+    let mut pending_dash = false;
+    for ch in name.nfkd() {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !out.is_empty() {
+                out.push('-');
+            }
+            pending_dash = false;
+            out.push(ch.to_ascii_lowercase());
+        } else if !('\u{0300}'..='\u{036f}').contains(&ch) {
+            pending_dash = true;
+        }
+    }
+    out
 }
 
 /// A streaming reader for the raw PBO. A folder is packed into memory (addon folders are small);
@@ -1099,24 +1264,39 @@ fn session_flags(s: &serde_json::Value) -> String {
 /// The multipart body up to (but excluding) the file bytes: the metadata fields plus the
 /// `file` part header. The caller streams the artifact bytes after this, then the trailer.
 fn build_multipart_prelude(boundary: &str, args: &PublishArgs) -> Vec<u8> {
-    let mut fields: Vec<(&str, &str)> = Vec::new();
-    if !args.name.trim().is_empty() {
-        fields.push(("name", args.name.as_str()));
+    let mut fields: Vec<(&str, String)> = Vec::new();
+    if let Some(mod_id) = &args.mod_id {
+        fields.push(("modId", mod_id.clone()));
+    }
+    if let Some(name) = &args.name {
+        fields.push(("name", name.clone()));
+    }
+    if let Some(app) = &args.app {
+        fields.push(("app", app.clone()));
+    }
+    if let Some(actver) = args.actver {
+        fields.push(("actver", actver.to_string()));
+    }
+    for actver in &args.compatible_actvers {
+        fields.push(("compatibleActver", actver.to_string()));
+    }
+    if let Some(version_tag) = &args.version_tag {
+        fields.push(("vertag", version_tag.clone()));
     }
     if let Some(version) = &args.version {
-        fields.push(("version", version));
+        fields.push(("version", version.clone()));
     }
     if let Some(folder_name) = &args.folder_name {
-        fields.push(("folderName", folder_name));
+        fields.push(("folderName", folder_name.clone()));
     }
     if let Some(description) = &args.description {
-        fields.push(("description", description));
+        fields.push(("description", description.clone()));
     }
     if let Some(homepage) = &args.homepage_url {
-        fields.push(("homepageUrl", homepage));
+        fields.push(("homepageUrl", homepage.clone()));
     }
     for author in &args.authors {
-        fields.push(("author", author));
+        fields.push(("author", author.clone()));
     }
 
     let mut body = Vec::new();
@@ -1140,9 +1320,10 @@ fn build_multipart_prelude(boundary: &str, args: &PublishArgs) -> Vec<u8> {
 mod tests {
     use super::{
         build_multipart_prelude, compress_artifact, decode_and_unpack, difficulty_flag_names,
-        install_is_current, replace_install, with_default_port, write_installed_mod_manifest,
-        PublishArgs,
+        install_is_current, publish_args_with_manifest, replace_install, upload_result_name,
+        with_default_port, workshop_slug, write_installed_mod_manifest, Cli, Command, PublishArgs,
     };
+    use clap::Parser;
     use papa_bear_archive::Pbo;
     use std::io::Cursor;
     use tempfile::tempdir;
@@ -1269,11 +1450,16 @@ mod tests {
     }
 
     #[test]
-    fn update_multipart_omits_inherited_metadata() {
+    fn publish_multipart_omits_unspecified_metadata() {
         let args = PublishArgs {
             source: "fixture.pbo".to_string(),
             admin_key: "key".to_string(),
-            name: String::new(),
+            mod_id: None,
+            name: None,
+            app: None,
+            actver: None,
+            compatible_actvers: Vec::new(),
+            version_tag: None,
             version: None,
             description: None,
             authors: Vec::new(),
@@ -1283,7 +1469,244 @@ mod tests {
         };
         let body = String::from_utf8(build_multipart_prelude("boundary", &args)).unwrap();
         assert!(!body.contains("name=\"name\""));
+        assert!(!body.contains("name=\"app\""));
+        assert!(!body.contains("name=\"actver\""));
+        assert!(!body.contains("name=\"vertag\""));
         assert!(body.contains("name=\"file\""));
+    }
+
+    #[test]
+    fn publish_multipart_includes_game_compatibility() {
+        let args = PublishArgs {
+            source: "fixture.pbo".to_string(),
+            admin_key: "key".to_string(),
+            mod_id: Some("fixture".to_string()),
+            name: Some("Fixture".to_string()),
+            app: Some("CWR".to_string()),
+            actver: Some(305),
+            compatible_actvers: vec![303, 305],
+            version_tag: Some("release".to_string()),
+            version: Some("1.0".to_string()),
+            description: None,
+            authors: Vec::new(),
+            homepage_url: None,
+            folder_name: None,
+            prefix: None,
+        };
+
+        let body = String::from_utf8(build_multipart_prelude("boundary", &args)).unwrap();
+        assert!(body.contains("name=\"app\"\r\n\r\nCWR"));
+        assert!(body.contains("name=\"modId\"\r\n\r\nfixture"));
+        assert!(body.contains("name=\"actver\"\r\n\r\n305"));
+        assert!(body.contains("name=\"compatibleActver\"\r\n\r\n303"));
+        assert!(body.contains("name=\"compatibleActver\"\r\n\r\n305"));
+        assert!(body.contains("name=\"vertag\"\r\n\r\nrelease"));
+    }
+
+    #[test]
+    fn publish_accepts_identity_and_game_compatibility_flags() {
+        let publish = Cli::try_parse_from([
+            "papa",
+            "publish",
+            "--admin-key",
+            "key",
+            "--name",
+            "Fixture",
+            "--mod-id",
+            "fixture",
+            "--app",
+            "CWR",
+            "--actver",
+            "305",
+            "--vertag",
+            "release",
+            "fixture.pbo",
+        ])
+        .unwrap();
+        let Command::Publish(publish) = publish.command else {
+            panic!("expected publish command");
+        };
+        assert_eq!(publish.app.as_deref(), Some("CWR"));
+        assert_eq!(publish.actver, Some(305));
+        assert_eq!(publish.version_tag.as_deref(), Some("release"));
+        assert_eq!(publish.mod_id.as_deref(), Some("fixture"));
+    }
+
+    #[test]
+    fn source_manifest_supplies_publish_identity_and_metadata() {
+        let source = tempdir().unwrap();
+        std::fs::write(
+            source.path().join("mod.json"),
+            r#"{
+                "modId":"csla-2.2",
+                "name":"CSLA",
+                "app":"CWR",
+                "actver":305,
+                "compatibleActvers":[303,305],
+                "vertag":"release",
+                "version":"2.2",
+                "folderName":"CSLA",
+                "description":"fixture",
+                "authors":["Author One","Author Two"],
+                "homepageUrl":"https://example.invalid"
+            }"#,
+        )
+        .unwrap();
+        let args = PublishArgs {
+            source: source.path().to_string_lossy().into_owned(),
+            admin_key: "key".to_string(),
+            mod_id: None,
+            name: None,
+            app: None,
+            actver: None,
+            compatible_actvers: Vec::new(),
+            version_tag: None,
+            version: None,
+            description: None,
+            authors: Vec::new(),
+            homepage_url: None,
+            folder_name: None,
+            prefix: None,
+        };
+
+        let resolved = publish_args_with_manifest(&args).unwrap();
+        assert_eq!(resolved.mod_id.as_deref(), Some("csla-2.2"));
+        assert_eq!(resolved.name.as_deref(), Some("CSLA"));
+        assert_eq!(resolved.app.as_deref(), Some("CWR"));
+        assert_eq!(resolved.actver, Some(305));
+        assert_eq!(resolved.compatible_actvers, [303, 305]);
+        assert_eq!(resolved.version_tag.as_deref(), Some("release"));
+        assert_eq!(resolved.version.as_deref(), Some("2.2"));
+        assert_eq!(resolved.folder_name.as_deref(), Some("CSLA"));
+        assert_eq!(resolved.authors, ["Author One", "Author Two"]);
+    }
+
+    #[test]
+    fn packed_source_manifest_supplies_publish_identity() {
+        let work = tempdir().unwrap();
+        let source = work.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        std::fs::write(
+            source.join("mod.json"),
+            r#"{"modId":"packed-fixture","name":"Packed Fixture"}"#,
+        )
+        .unwrap();
+        std::fs::write(source.join("config.cpp"), b"class CfgPatches {};").unwrap();
+        let packed = work.path().join("fixture.pbo");
+        Pbo::pack_dir(&source, None)
+            .unwrap()
+            .write_path(&packed)
+            .unwrap();
+        let args = PublishArgs {
+            source: packed.to_string_lossy().into_owned(),
+            admin_key: "key".to_string(),
+            mod_id: None,
+            name: None,
+            app: None,
+            actver: None,
+            compatible_actvers: Vec::new(),
+            version_tag: None,
+            version: None,
+            description: None,
+            authors: Vec::new(),
+            homepage_url: None,
+            folder_name: None,
+            prefix: None,
+        };
+
+        let resolved = publish_args_with_manifest(&args).unwrap();
+        assert_eq!(resolved.mod_id.as_deref(), Some("packed-fixture"));
+        assert_eq!(resolved.name.as_deref(), Some("Packed Fixture"));
+    }
+
+    #[test]
+    fn command_line_metadata_overrides_source_manifest() {
+        let source = tempdir().unwrap();
+        std::fs::write(
+            source.path().join("mod.json"),
+            r#"{"modId":"old-id","name":"Old","actver":303}"#,
+        )
+        .unwrap();
+        let args = PublishArgs {
+            source: source.path().to_string_lossy().into_owned(),
+            admin_key: "key".to_string(),
+            mod_id: Some("new-id".to_string()),
+            name: Some("New".to_string()),
+            app: Some("CWR".to_string()),
+            actver: Some(305),
+            compatible_actvers: Vec::new(),
+            version_tag: None,
+            version: None,
+            description: None,
+            authors: Vec::new(),
+            homepage_url: None,
+            folder_name: None,
+            prefix: None,
+        };
+
+        let resolved = publish_args_with_manifest(&args).unwrap();
+        assert_eq!(resolved.mod_id.as_deref(), Some("new-id"));
+        assert_eq!(resolved.name.as_deref(), Some("New"));
+        assert_eq!(resolved.actver, Some(305));
+    }
+
+    #[test]
+    fn name_supplies_stable_identity_without_manifest() {
+        let source = tempdir().unwrap();
+        let args = PublishArgs {
+            source: source.path().to_string_lossy().into_owned(),
+            admin_key: "key".to_string(),
+            mod_id: None,
+            name: Some("FDF Mod".to_string()),
+            app: None,
+            actver: None,
+            compatible_actvers: Vec::new(),
+            version_tag: None,
+            version: None,
+            description: None,
+            authors: Vec::new(),
+            homepage_url: None,
+            folder_name: None,
+            prefix: None,
+        };
+
+        let resolved = publish_args_with_manifest(&args).unwrap();
+        assert_eq!(resolved.mod_id.as_deref(), Some("fdf-mod"));
+    }
+
+    #[test]
+    fn workshop_slug_matches_server_identity_rules() {
+        assert_eq!(workshop_slug("FDF Mod"), "fdf-mod");
+        assert_eq!(workshop_slug("\u{010c}SLA"), "csla");
+    }
+
+    #[test]
+    fn compatibility_command_accepts_repeated_versions() {
+        let cli = Cli::try_parse_from([
+            "papa",
+            "compatibility",
+            "fixture",
+            "1",
+            "--actver",
+            "303",
+            "--actver",
+            "305",
+            "--admin-key",
+            "key",
+        ])
+        .unwrap();
+        let Command::Compatibility(args) = cli.command else {
+            panic!("expected compatibility command");
+        };
+        assert_eq!(args.mod_id, "fixture");
+        assert_eq!(args.revision, 1);
+        assert_eq!(args.compatible_actvers, [303, 305]);
+    }
+
+    #[test]
+    fn publish_result_uses_server_name() {
+        let response = serde_json::json!({"name": "Fixture"});
+        assert_eq!(upload_result_name(&response, ""), "Fixture");
     }
 
     #[test]

--- a/mserver/MasterService/src/dev_seed.rs
+++ b/mserver/MasterService/src/dev_seed.rs
@@ -229,6 +229,7 @@ pub async fn seed_dev_mods(store: &ModStore) -> Result<usize> {
             mod_id: row.mod_id,
             app_name: Some("CWR".to_string()),
             actver: Some(303),
+            compatible_actvers: Vec::new(),
             version_tag: None,
             compatible: false,
             name: row.name,

--- a/mserver/MasterService/src/http.rs
+++ b/mserver/MasterService/src/http.rs
@@ -9,7 +9,7 @@ use axum::http::header::{CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE, LOCA
 use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::response::{Html, IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use utoipa::OpenApi;
 
@@ -18,6 +18,7 @@ use crate::model::{
     ModUsageServer, ObserveServerRequest, PruneServersRequest, PruneServersResponse,
     RegisterServerRequest, ServerDetail, ServerModReference, ServerPlayer, ServerPopulationSample,
     ServerRecentSession, ServerVersionGroup, ServiceMetadata, ServiceSummary,
+    SetModCompatibilityRequest,
 };
 use crate::mods::ModUploadMeta;
 use crate::repository::{SqliteServerDirectory, TokenRelocation};
@@ -56,6 +57,7 @@ fn max_mod_upload_bytes() -> usize {
         get_mod,
         list_mod_revisions,
         get_mod_revision,
+        set_mod_revision_compatibility,
         download_mod_revision,
         list_mod_versions,
         list_mod_servers,
@@ -81,6 +83,7 @@ fn max_mod_upload_bytes() -> usize {
         ModUsageServer,
         ModCatalogEntry,
         ModPackage,
+        SetModCompatibilityRequest,
         PruneServersRequest,
         PruneServersResponse,
         ServiceMetadata,
@@ -190,6 +193,10 @@ fn build_router_for_service(
         .route(
             "/v1/mods/:mod_id/revisions/:revision",
             get(get_mod_revision),
+        )
+        .route(
+            "/v1/mods/:mod_id/revisions/:revision/compatibility",
+            put(set_mod_revision_compatibility),
         )
         .route(
             "/v1/mods/:mod_id/revisions/:revision/download",
@@ -610,6 +617,38 @@ async fn get_mod_revision(
 }
 
 #[utoipa::path(
+    put,
+    path = "/v1/mods/{modId}/revisions/{revision}/compatibility",
+    request_body = SetModCompatibilityRequest,
+    params(
+        ("modId" = String, Path, description = "Stable mod identifier"),
+        ("revision" = u64, Path, description = "Package revision")
+    ),
+    responses(
+        (status = 200, description = "Updated revision compatibility", body = ModCatalogEntry),
+        (status = 401, description = "Missing or invalid administrator key"),
+        (status = 404, description = "Revision not found")
+    )
+)]
+async fn set_mod_revision_compatibility(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((mod_id, revision)): Path<(String, u64)>,
+    payload: Result<Json<SetModCompatibilityRequest>, JsonRejection>,
+) -> Result<Json<ModCatalogEntry>, (StatusCode, String)> {
+    require_admin_api_key(&state, &headers)?;
+    let Json(request) = payload.map_err(|rejection| (rejection.status(), rejection.body_text()))?;
+    let entry = state
+        .service
+        .set_mod_revision_compatibility(&mod_id, revision, &request.compatible_actvers)
+        .await
+        .map_err(|error| (StatusCode::BAD_REQUEST, error.to_string()))?;
+    entry
+        .map(Json)
+        .ok_or_else(|| (StatusCode::NOT_FOUND, "revision not found".to_string()))
+}
+
+#[utoipa::path(
     get,
     path = "/v1/mods/{modId}/servers",
     params(
@@ -679,8 +718,10 @@ async fn upload_mod(
     };
 
     let mut name: Option<String> = None;
+    let mut mod_id: Option<String> = None;
     let mut app_name: Option<String> = None;
     let mut actver: Option<String> = None;
+    let mut compatible_actvers: Vec<String> = Vec::new();
     let mut version_tag: Option<String> = None;
     let mut version: Option<String> = None;
     let mut folder_name: Option<String> = None;
@@ -697,8 +738,10 @@ async fn upload_mod(
         let field_name = field.name().map(str::to_string);
         match field_name.as_deref() {
             Some("name") => name = Some(read_text_field(field).await?),
+            Some("modId") => mod_id = Some(read_text_field(field).await?),
             Some("app") => app_name = Some(read_text_field(field).await?),
             Some("actver") => actver = Some(read_text_field(field).await?),
+            Some("compatibleActver") => compatible_actvers.push(read_text_field(field).await?),
             Some("vertag") => version_tag = Some(read_text_field(field).await?),
             Some("version") => version = Some(read_text_field(field).await?),
             Some("folderName") => folder_name = Some(read_text_field(field).await?),
@@ -737,10 +780,28 @@ async fn upload_mod(
         ));
     }
 
+    let compatible_actvers = compatible_actvers
+        .into_iter()
+        .map(|value| {
+            value
+                .trim()
+                .parse::<i32>()
+                .ok()
+                .filter(|value| *value > 0)
+                .ok_or_else(|| {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        format!("invalid compatibleActver '{value}'"),
+                    )
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
     let meta = ModUploadMeta {
+        mod_id: mod_id.filter(|value| !value.trim().is_empty()),
         name: name.unwrap_or_default(),
         app_name: app_name.filter(|value| !value.trim().is_empty()),
         actver: actver.and_then(|value| value.trim().parse().ok()),
+        compatible_actvers,
         version_tag: version_tag.filter(|value| !value.trim().is_empty()),
         version: version.filter(|value| !value.trim().is_empty()),
         folder_name: folder_name.filter(|value| !value.trim().is_empty()),

--- a/mserver/MasterService/src/lib.rs
+++ b/mserver/MasterService/src/lib.rs
@@ -1194,6 +1194,7 @@ mod tests {
             multipart_body(
                 boundary,
                 &[
+                    ("modId", "synthetic-upload-1.0"),
                     ("name", "Synthetic Upload"),
                     ("app", "CWR"),
                     ("actver", "302"),
@@ -1255,7 +1256,7 @@ mod tests {
         let entry: ModCatalogEntry =
             serde_json::from_slice(&to_bytes(ok.into_body(), usize::MAX).await.unwrap()).unwrap();
         assert_eq!(entry.name, "Synthetic Upload");
-        assert_eq!(entry.mod_id, "synthetic-upload");
+        assert_eq!(entry.mod_id, "synthetic-upload-1.0");
         assert_eq!(entry.package_revision, 1);
         assert_eq!(entry.version.len(), 8); // default version = sha256[..8] hex
         assert_eq!(entry.app_name.as_deref(), Some("CWR"));
@@ -1328,7 +1329,14 @@ mod tests {
         let publish_body = |artifact: &'static [u8]| {
             multipart_body(
                 "revisionboundary",
-                &[("name", "Revision Fixture"), ("version", "1.0")],
+                &[
+                    ("name", "Revision Fixture"),
+                    ("version", "1.0"),
+                    ("app", "CWR"),
+                    ("actver", "303"),
+                    ("compatibleActver", "303"),
+                    ("compatibleActver", "305"),
+                ],
                 Some(("file", artifact)),
             )
         };
@@ -1364,7 +1372,11 @@ mod tests {
             .unwrap();
         assert_eq!(collision.status(), StatusCode::CONFLICT);
 
-        let update = multipart_body("revisionboundary", &[], Some(("file", b"revision-two")));
+        let update = multipart_body(
+            "revisionboundary",
+            &[("actver", "305")],
+            Some(("file", b"revision-two")),
+        );
         let updated = app
             .clone()
             .oneshot(request("/v1/mods/revision-fixture/revisions", update))
@@ -1376,6 +1388,28 @@ mod tests {
                 .unwrap();
         assert_eq!(updated.package_revision, 2);
         assert_eq!(updated.version, "1.0");
+
+        let catalog = |actver| {
+            Request::builder()
+                .uri(format!("/v1/mods?app=CWR&actver={actver}"))
+                .body(Body::empty())
+                .unwrap()
+        };
+        let for_303 = app.clone().oneshot(catalog(303)).await.unwrap();
+        let for_303: Vec<ModCatalogEntry> =
+            serde_json::from_slice(&to_bytes(for_303.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(for_303[0].package_revision, 1);
+        assert_eq!(
+            for_303[0].download_url.as_deref(),
+            Some("/v1/mods/revision-fixture/revisions/1/download")
+        );
+
+        let for_305 = app.clone().oneshot(catalog(305)).await.unwrap();
+        let for_305: Vec<ModCatalogEntry> =
+            serde_json::from_slice(&to_bytes(for_305.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(for_305[0].package_revision, 2);
 
         let history = app
             .clone()
@@ -1397,6 +1431,57 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![2, 1]
         );
+
+        let unauthorised = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/v1/mods/revision-fixture/revisions/1/compatibility")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"compatibleActvers":[303,305]}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unauthorised.status(), StatusCode::UNAUTHORIZED);
+
+        let compatibility = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/v1/mods/revision-fixture/revisions/1/compatibility")
+                    .header("content-type", "application/json")
+                    .header("x-api-key", "secret-key")
+                    .body(Body::from(r#"{"compatibleActvers":[305,303,305]}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(compatibility.status(), StatusCode::OK);
+        let compatibility: ModCatalogEntry = serde_json::from_slice(
+            &to_bytes(compatibility.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(compatibility.compatible_actvers, [303, 305]);
+
+        let persisted = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/mods/revision-fixture/revisions/1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let persisted: ModCatalogEntry =
+            serde_json::from_slice(&to_bytes(persisted.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(persisted.compatible_actvers, [303, 305]);
 
         let latest_download = app
             .oneshot(

--- a/mserver/MasterService/src/model.rs
+++ b/mserver/MasterService/src/model.rs
@@ -286,6 +286,12 @@ pub struct ModCatalogEntry {
     pub app_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub actver: Option<i32>,
+    #[serde(
+        rename = "compatibleActvers",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub compatible_actvers: Vec<i32>,
     #[serde(rename = "vertag", default, skip_serializing_if = "Option::is_none")]
     pub version_tag: Option<String>,
     #[serde(default)]
@@ -320,6 +326,12 @@ pub struct ModCatalogEntry {
     pub download_url: Option<String>,
     #[serde(rename = "sizeBytes", default)]
     pub size_bytes: Option<u64>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, ToSchema)]
+pub struct SetModCompatibilityRequest {
+    #[serde(rename = "compatibleActvers")]
+    pub compatible_actvers: Vec<i32>,
 }
 
 pub(crate) const fn default_package_revision() -> u64 {

--- a/mserver/MasterService/src/mods.rs
+++ b/mserver/MasterService/src/mods.rs
@@ -70,6 +70,7 @@ pub struct PublishModInput {
     pub name: String,
     pub app_name: Option<String>,
     pub actver: Option<i32>,
+    pub compatible_actvers: Vec<i32>,
     pub version_tag: Option<String>,
     pub version: Option<String>,
     pub description: Option<String>,
@@ -83,9 +84,11 @@ pub struct PublishModInput {
 /// `ModCatalogEntry`.
 #[derive(Default)]
 pub struct ModUploadMeta {
+    pub mod_id: Option<String>,
     pub name: String,
     pub app_name: Option<String>,
     pub actver: Option<i32>,
+    pub compatible_actvers: Vec<i32>,
     pub version_tag: Option<String>,
     pub version: Option<String>,
     pub folder_name: Option<String>,
@@ -94,7 +97,7 @@ pub struct ModUploadMeta {
     pub homepage_url: Option<String>,
 }
 
-/// Object-store-backed mod artifact store. Immutable artifacts and metadata live under
+/// Object-store-backed mod artifact store. Immutable artifacts and revision metadata live under
 /// `<modId>/revisions/<revision>/`, with a conditional `current` object selecting the catalog
 /// entry. The local filesystem backend serves development and S3 lets stateless replicas share
 /// one store.
@@ -281,6 +284,7 @@ impl ModStore {
             mod_id: slug.clone(),
             app_name: input.app_name.clone(),
             actver: input.actver,
+            compatible_actvers: normalize_actvers(&input.compatible_actvers),
             version_tag: input.version_tag.clone(),
             compatible: false,
             name: input.name.clone(),
@@ -486,14 +490,11 @@ impl ModStore {
             .await
             .with_context(|| format!("finishing upload {temp}"))?;
 
-        let slug = slugify(&meta.name);
-        if slug.is_empty() || size == 0 {
+        let slug = meta.mod_id.unwrap_or_else(|| slugify(&meta.name));
+        if !is_safe_segment(&slug) || size == 0 {
             let _ = self.store.delete(&temp).await;
-            if slug.is_empty() {
-                bail!(
-                    "mod name '{}' has no usable characters for an id",
-                    meta.name
-                );
+            if !is_safe_segment(&slug) {
+                bail!("invalid mod id '{slug}'");
             }
             bail!("mod artifact is empty");
         }
@@ -524,6 +525,7 @@ impl ModStore {
             mod_id: slug.clone(),
             app_name: meta.app_name,
             actver: meta.actver,
+            compatible_actvers: normalize_actvers(&meta.compatible_actvers),
             version_tag: meta.version_tag,
             compatible: false,
             name: meta.name,
@@ -622,6 +624,13 @@ impl ModStore {
             mod_id: mod_id.to_string(),
             app_name: meta.app_name.or(latest.app_name),
             actver: meta.actver.or(latest.actver),
+            compatible_actvers: if !meta.compatible_actvers.is_empty() {
+                normalize_actvers(&meta.compatible_actvers)
+            } else if let Some(actver) = meta.actver {
+                vec![actver]
+            } else {
+                latest.compatible_actvers
+            },
             version_tag: meta.version_tag.or(latest.version_tag),
             compatible: false,
             name: if meta.name.trim().is_empty() {
@@ -786,7 +795,7 @@ impl ModStore {
     }
 
     pub async fn list_mods(&self, query: &ListModsQuery) -> Result<Vec<ModCatalogEntry>> {
-        let mut mods = self.read_all().await?;
+        let mut mods = self.read_all(query).await?;
         apply_mod_filters(&mut mods, query);
         Ok(mods)
     }
@@ -848,7 +857,38 @@ impl ModStore {
         Ok(revisions)
     }
 
-    async fn read_all(&self) -> Result<Vec<ModCatalogEntry>> {
+    pub async fn set_revision_compatibility(
+        &self,
+        mod_id: &str,
+        revision: u64,
+        compatible_actvers: &[i32],
+    ) -> Result<Option<ModCatalogEntry>> {
+        if compatible_actvers.is_empty() || compatible_actvers.iter().any(|value| *value <= 0) {
+            bail!("at least one positive compatible game version is required");
+        }
+        let Some(mut entry) = self.get_revision(mod_id, revision).await? else {
+            return Ok(None);
+        };
+        entry.compatible_actvers = normalize_actvers(compatible_actvers);
+        let revision_path = self.store_path(Self::revision_metadata_path(mod_id, revision));
+        let metadata_path = match self.store.head(&revision_path).await {
+            Ok(_) => revision_path,
+            Err(object_store::Error::NotFound { .. }) if revision == 1 => {
+                self.store_path(Self::metadata_path(mod_id))
+            }
+            Err(error) => return Err(error.into()),
+        };
+        self.store
+            .put(
+                &metadata_path,
+                Bytes::from(serde_json::to_vec_pretty(&entry)?).into(),
+            )
+            .await
+            .with_context(|| format!("updating revision {revision} metadata for {mod_id}"))?;
+        Ok(Some(entry))
+    }
+
+    async fn read_all(&self, query: &ListModsQuery) -> Result<Vec<ModCatalogEntry>> {
         let mut mod_ids = std::collections::BTreeSet::new();
         let mut listing = self.store.list(self.list_prefix());
         while let Some(meta) = listing.next().await {
@@ -865,7 +905,12 @@ impl ModStore {
 
         let mut mods = Vec::with_capacity(mod_ids.len());
         for mod_id in mod_ids {
-            if let Some(entry) = self.get_mod(&mod_id).await? {
+            let entry = if has_compatibility_filter(query) {
+                self.latest_compatible_revision(&mod_id, query).await?
+            } else {
+                self.get_mod(&mod_id).await?
+            };
+            if let Some(entry) = entry {
                 mods.push(entry);
             }
         }
@@ -877,6 +922,24 @@ impl ModStore {
                 .then_with(|| lhs.mod_id.cmp(&rhs.mod_id))
         });
         Ok(mods)
+    }
+
+    async fn latest_compatible_revision(
+        &self,
+        mod_id: &str,
+        query: &ListModsQuery,
+    ) -> Result<Option<ModCatalogEntry>> {
+        let Some(current) = self.current_state(mod_id).await? else {
+            return Ok(None);
+        };
+        for revision in (1..=current.revision).rev() {
+            if let Some(entry) = self.get_revision(mod_id, revision).await? {
+                if is_mod_compatible(&entry, query) {
+                    return Ok(Some(entry));
+                }
+            }
+        }
+        Ok(None)
     }
 
     async fn parse_metadata(
@@ -904,27 +967,21 @@ impl ModStore {
         } else {
             Self::revision_artifact_path(&metadata.mod_id, revision)
         };
+        let stored_artifact_path = self.store_path(artifact_path);
+        let artifact_head = match self.store.head(&stored_artifact_path).await {
+            Ok(head) => Some(head),
+            Err(object_store::Error::NotFound { .. }) => None,
+            Err(error) => return Err(error.into()),
+        };
         if metadata.size_bytes.unwrap_or(0) == 0 {
-            if let Ok(head) = self
-                .store
-                .head(&self.store_path(artifact_path.clone()))
-                .await
-            {
+            if let Some(head) = &artifact_head {
                 metadata.size_bytes = Some(head.size as u64);
                 changed = true;
             }
         }
-        if metadata.sha256.is_none() {
-            if let Ok(result) = self.store.get(&self.store_path(artifact_path)).await {
-                metadata.sha256 = Some(sha256_stream(result.into_stream()).await?);
-                changed = true;
-            }
-        }
-        if metadata.download_url.is_none() {
-            metadata.download_url = Some(format!(
-                "/v1/mods/{}/revisions/{revision}/download",
-                metadata.mod_id
-            ));
+        if metadata.sha256.is_none() && artifact_head.is_some() {
+            let result = self.store.get(&stored_artifact_path).await?;
+            metadata.sha256 = Some(sha256_stream(result.into_stream()).await?);
             changed = true;
         }
         if legacy && changed {
@@ -935,6 +992,12 @@ impl ModStore {
                 )
                 .await
                 .with_context(|| format!("updating legacy metadata for {dir_id}"))?;
+        }
+        if artifact_head.is_some() {
+            metadata.download_url = Some(format!(
+                "/v1/mods/{}/revisions/{revision}/download",
+                metadata.mod_id
+            ));
         }
 
         Ok(metadata)
@@ -1004,6 +1067,21 @@ fn hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
+fn normalize_actvers(values: &[i32]) -> Vec<i32> {
+    let mut values = values
+        .iter()
+        .copied()
+        .filter(|value| *value > 0)
+        .collect::<Vec<_>>();
+    values.sort_unstable();
+    values.dedup();
+    values
+}
+
+fn has_compatibility_filter(query: &ListModsQuery) -> bool {
+    query.app_name.is_some() || query.actver.is_some() || query.version_tag.is_some()
+}
+
 fn apply_mod_filters(mods: &mut Vec<ModCatalogEntry>, query: &ListModsQuery) {
     let text_filter = query.q.as_ref().map(|value| value.to_lowercase());
 
@@ -1043,10 +1121,15 @@ fn is_mod_compatible(entry: &ModCatalogEntry, query: &ListModsQuery) -> bool {
         }
     }
     if let Some(actver) = query.actver {
-        if let Some(entry_actver) = entry.actver {
-            if entry_actver != actver {
+        if !entry.compatible_actvers.is_empty() {
+            if !entry.compatible_actvers.contains(&actver) {
                 return false;
             }
+        } else if entry
+            .actver
+            .is_some_and(|entry_actver| entry_actver != actver)
+        {
+            return false;
         }
     }
     if let Some(version_tag) = query
@@ -1064,7 +1147,7 @@ fn is_mod_compatible(entry: &ModCatalogEntry, query: &ListModsQuery) -> bool {
             }
         }
     }
-    query.app_name.is_some() || query.actver.is_some() || query.version_tag.is_some()
+    has_compatibility_filter(query)
 }
 
 #[cfg(test)]
@@ -1077,7 +1160,7 @@ mod tests {
     use sha2::{Digest, Sha256};
 
     use super::{sha256_stream, ArtifactStream, ModStore, ModUploadMeta};
-    use crate::model::ListModsQuery;
+    use crate::model::{ListModsQuery, ModCatalogEntry};
     use tempfile::tempdir;
 
     struct TrackedChunk {
@@ -1171,6 +1254,7 @@ mod tests {
                 name: "Synthetic Core Pack".to_string(),
                 app_name: Some("CWR".to_string()),
                 actver: Some(302),
+                compatible_actvers: Vec::new(),
                 version_tag: Some("rc1".to_string()),
                 version: Some("1.0".to_string()),
                 description: Some("demo".to_string()),
@@ -1302,6 +1386,7 @@ mod tests {
                 name: "Temp Mod".to_string(),
                 app_name: None,
                 actver: None,
+                compatible_actvers: Vec::new(),
                 version_tag: None,
                 version: Some("1.0".to_string()),
                 description: None,
@@ -1344,6 +1429,7 @@ mod tests {
                 name: "Stable Mod".to_string(),
                 app_name: Some("CWR".to_string()),
                 actver: Some(302),
+                compatible_actvers: Vec::new(),
                 version_tag: Some("rc1".to_string()),
                 version: Some("1.0".to_string()),
                 description: Some("first".to_string()),
@@ -1410,6 +1496,112 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn catalog_selects_latest_compatible_revision() {
+        let root = tempdir().unwrap();
+        let store = ModStore::local(root.path()).unwrap();
+        store
+            .publish_mod(&super::PublishModInput {
+                name: "Compatible Mod".to_string(),
+                app_name: Some("CWR".to_string()),
+                actver: Some(303),
+                compatible_actvers: vec![303, 305],
+                version_tag: None,
+                version: Some("1.0".to_string()),
+                description: None,
+                authors: Vec::new(),
+                homepage_url: None,
+                file: vec![1, 2, 3],
+            })
+            .await
+            .unwrap();
+        store
+            .add_revision(
+                "compatible-mod",
+                vec![4, 5, 6],
+                super::ModUploadMeta {
+                    actver: Some(305),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let for_303 = store
+            .list_mods(&ListModsQuery {
+                app_name: Some("CWR".to_string()),
+                actver: Some(303),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(for_303.len(), 1);
+        assert_eq!(for_303[0].package_revision, 1);
+        assert_eq!(
+            for_303[0].download_url.as_deref(),
+            Some("/v1/mods/compatible-mod/revisions/1/download")
+        );
+
+        let for_305 = store
+            .list_mods(&ListModsQuery {
+                app_name: Some("CWR".to_string()),
+                actver: Some(305),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(for_305.len(), 1);
+        assert_eq!(for_305[0].package_revision, 2);
+        assert_eq!(for_305[0].compatible_actvers, [305]);
+
+        let for_306 = store
+            .list_mods(&ListModsQuery {
+                app_name: Some("CWR".to_string()),
+                actver: Some(306),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert!(for_306.is_empty());
+    }
+
+    #[tokio::test]
+    async fn legacy_revision_compatibility_updates_metadata() {
+        let root = tempdir().unwrap();
+        let mod_dir = root.path().join("legacy-compatible");
+        std::fs::create_dir_all(&mod_dir).unwrap();
+        std::fs::write(
+            mod_dir.join("mod.json"),
+            r#"{"modId":"legacy-compatible","app":"CWR","actver":303,"name":"Legacy Compatible","version":"1.0","description":"fixture","downloadUrl":"/v1/mods/legacy-compatible/download"}"#,
+        )
+        .unwrap();
+        std::fs::write(mod_dir.join("legacy-compatible.pbo.zst"), [1, 2, 3]).unwrap();
+
+        let store = ModStore::local(root.path()).unwrap();
+        let query = ListModsQuery {
+            app_name: Some("CWR".to_string()),
+            actver: Some(305),
+            ..Default::default()
+        };
+        assert!(store.list_mods(&query).await.unwrap().is_empty());
+
+        let migrated = store
+            .set_revision_compatibility("legacy-compatible", 1, &[305, 303, 305])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(migrated.compatible_actvers, [303, 305]);
+        assert_eq!(
+            store.list_mods(&query).await.unwrap()[0]
+                .download_url
+                .as_deref(),
+            Some("/v1/mods/legacy-compatible/revisions/1/download")
+        );
+        let metadata: ModCatalogEntry =
+            serde_json::from_slice(&std::fs::read(mod_dir.join("mod.json")).unwrap()).unwrap();
+        assert_eq!(metadata.compatible_actvers, [303, 305]);
+    }
+
+    #[tokio::test]
     async fn identical_current_upload_is_idempotent() {
         let root = tempdir().unwrap();
         let store = ModStore::local(root.path()).unwrap();
@@ -1418,6 +1610,7 @@ mod tests {
                 name: "Idempotent Mod".to_string(),
                 app_name: None,
                 actver: None,
+                compatible_actvers: Vec::new(),
                 version_tag: None,
                 version: Some("1.0".to_string()),
                 description: None,
@@ -1452,6 +1645,7 @@ mod tests {
                 name: "Concurrent Mod".to_string(),
                 app_name: None,
                 actver: None,
+                compatible_actvers: Vec::new(),
                 version_tag: None,
                 version: Some("1.0".to_string()),
                 description: None,

--- a/mserver/MasterService/src/service.rs
+++ b/mserver/MasterService/src/service.rs
@@ -224,6 +224,22 @@ impl PapaBearService {
         }
     }
 
+    pub async fn set_mod_revision_compatibility(
+        &self,
+        mod_id: &str,
+        revision: u64,
+        compatible_actvers: &[i32],
+    ) -> Result<Option<ModCatalogEntry>> {
+        match &self.mod_store {
+            Some(store) => {
+                store
+                    .set_revision_compatibility(mod_id, revision, compatible_actvers)
+                    .await
+            }
+            None => Ok(None),
+        }
+    }
+
     /// Delete a mod (its catalog entry + artifact) from the store. Returns `true` if it
     /// existed, `false` if there was nothing to delete or mods are disabled.
     pub async fn delete_mod(&self, mod_id: &str) -> Result<bool> {


### PR DESCRIPTION
Keep stable workshop IDs across package revisions and select the newest revision compatible with each game version. Allow existing metadata to be migrated without rewriting package artifacts.