### PR TITLE
Let players keep night in color

### DIFF
--- a/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
@@ -164,6 +164,7 @@ GameValue TriShadowDepthProbe(const GameState*, GameValuePar);
 GameValue TriEnableShadowMaps(const GameState*);
 GameValue TriShadowSceneDump(const GameState*, GameValuePar);
 GameValue TriSetAlphaToCoverage(const GameState*, GameValuePar);
+GameValue TriSetNightEye(const GameState*, GameValuePar);
 GameValue TriSetFlatShading(const GameState*, GameValuePar);
 GameValue TriSetRenderScale(const GameState*, GameValuePar);
 GameValue TriSetMsaa(const GameState*, GameValuePar);
@@ -3139,6 +3140,7 @@ INIT_MODULE(GameStateExtTest, 3)
     GGameState.NewNularOp(GameNular(GameString, "triEnableShadowMaps", TriEnableShadowMaps));
     GGameState.NewFunction(GameFunction(GameString, "triShadowSceneDump", TriShadowSceneDump, GameString));
     GGameState.NewFunction(GameFunction(GameString, "triSetAlphaToCoverage", TriSetAlphaToCoverage, GameScalar));
+    GGameState.NewFunction(GameFunction(GameString, "triSetNightEye", TriSetNightEye, GameScalar));
     GGameState.NewFunction(GameFunction(GameString, "triSetFlatShading", TriSetFlatShading, GameScalar));
     GGameState.NewFunction(GameFunction(GameString, "triSetRenderScale", TriSetRenderScale, GameScalar));
     GGameState.NewFunction(GameFunction(GameString, "triSetMsaa", TriSetMsaa, GameScalar));

--- a/engine/Poseidon/Game/Commands/GameStateExtTestGetters.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestGetters.cpp
@@ -216,6 +216,73 @@ GameValue TriGetPixelMaxDiff(const GameState* /*state*/, GameValuePar arg)
     return GameValue(static_cast<float>(mx));
 }
 
+/// triGetRegionChroma [u0, v0, u1, v1, minBrightness] - mean per-pixel chroma
+/// (brightest channel minus darkest) over pixels in the normalized rectangle
+/// at or above minBrightness. Grey reads 0 at any brightness, so this reads
+/// color independently of exposure. -1 when nothing clears the threshold.
+GameValue TriGetRegionChroma(const GameState* /*state*/, GameValuePar arg)
+{
+    if (!GEngine)
+        return GameValue(static_cast<float>(-1));
+    const GameArrayType& a = arg;
+    if (a.Size() < 5)
+        return GameValue(static_cast<float>(-1));
+    const float u0 = static_cast<float>(static_cast<GameScalarType>(a[0]));
+    const float v0 = static_cast<float>(static_cast<GameScalarType>(a[1]));
+    const float u1 = static_cast<float>(static_cast<GameScalarType>(a[2]));
+    const float v1 = static_cast<float>(static_cast<GameScalarType>(a[3]));
+    const int minBright = static_cast<int>(static_cast<GameScalarType>(a[4]));
+
+    const int w = GEngine->Width();
+    const int h = GEngine->Height();
+    if (w <= 0 || h <= 0)
+        return GameValue(static_cast<float>(-1));
+    int x0 = static_cast<int>(u0 * static_cast<float>(w - 1));
+    int x1 = static_cast<int>(u1 * static_cast<float>(w - 1));
+    int y0 = static_cast<int>(v0 * static_cast<float>(h - 1));
+    int y1 = static_cast<int>(v1 * static_cast<float>(h - 1));
+    if (x1 < x0)
+    {
+        const int t = x0;
+        x0 = x1;
+        x1 = t;
+    }
+    if (y1 < y0)
+    {
+        const int t = y0;
+        y0 = y1;
+        y1 = t;
+    }
+
+    double sum = 0;
+    int counted = 0;
+    for (int y = y0; y <= y1; ++y)
+        for (int x = x0; x <= x1; ++x)
+        {
+            uint8_t rgb[3] = {0, 0, 0};
+            if (!GEngine->SamplePixel(x, y, rgb))
+                return GameValue(static_cast<float>(-1));
+            int hi = rgb[0], lo = rgb[0];
+            for (int i = 1; i < 3; i++)
+            {
+                if (rgb[i] > hi)
+                    hi = rgb[i];
+                if (rgb[i] < lo)
+                    lo = rgb[i];
+            }
+            if (hi < minBright)
+                continue;
+            sum += hi - lo;
+            ++counted;
+        }
+    if (counted == 0)
+        return GameValue(static_cast<float>(-1));
+    const float mean = static_cast<float>(sum / counted);
+    LOG_INFO(Core, "[tri] triGetRegionChroma rect=({},{})-({},{}) min={} px={} mean={:.4f}", u0, v0, u1, v1, minBright,
+             counted, mean);
+    return GameValue(mean);
+}
+
 /// triAssertPixelNotWhite [u, v, threshold] — passes when at least one RGB
 /// channel is below threshold. Useful for catching missing white placeholder
 /// textures without depending on the exact face artwork.
@@ -557,6 +624,7 @@ INIT_MODULE(GameStateExtTestGetters, 3)
     // Pixel
     GGameState.NewFunction(GameFunction(GameScalar, "triGetPixelMaxChannel", TriGetPixelMaxChannel, GameArray));
     GGameState.NewFunction(GameFunction(GameScalar, "triGetPixelMaxDiff", TriGetPixelMaxDiff, GameArray));
+    GGameState.NewFunction(GameFunction(GameScalar, "triGetRegionChroma", TriGetRegionChroma, GameArray));
     GGameState.NewFunction(GameFunction(GameString, "triAssertPixelNotWhite", TriAssertPixelNotWhite, GameArray));
 
     // UI / controls

--- a/engine/Poseidon/Game/Commands/GameStateExtTestRender.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestRender.cpp
@@ -372,6 +372,19 @@ GameValue TriSetAlphaToCoverage(const GameState* /*state*/, GameValuePar arg)
     return GameValue("OK");
 }
 
+/// triSetNightEye <0|1> - toggle the scotopic night pass that blends lit
+/// geometry towards its own luminance after dark. On by default via
+/// GraphicsConfig; tests toggle it to capture colored-vs-grey pairs from one
+/// camera. Returns "OK".
+GameValue TriSetNightEye(const GameState* /*state*/, GameValuePar arg)
+{
+    const bool enable = static_cast<float>(arg) != 0.0f;
+    if (GEngine)
+        GEngine->SetNightEyeEnabled(enable);
+    LOG_INFO(Core, "[tri] triSetNightEye {}", enable ? 1 : 0);
+    return GameValue("OK");
+}
+
 /// triSetFlatShading <0|1> — replace all object shading with solid red, keeping
 /// the alpha-test silhouette + cutout holes.  Diagnostic for highlight bugs: a
 /// bright pixel that vanishes under flat colour is a shading/texture artifact;

--- a/engine/Poseidon/Graphics/Core/Engine.cpp
+++ b/engine/Poseidon/Graphics/Core/Engine.cpp
@@ -32,7 +32,7 @@ int gShadowFrozenRouted = 0;
 
 Engine::Engine()
     : _showTextFont(nullptr), _showTextColor(Color(HBlack)), _showTextSize(0), _showFps(0), _messageHandle(-1),
-      _multitexturing(true), _nightVision(false), _accomodateEye(HWhite), _shadowFactor(0),
+      _multitexturing(true), _nightEyeEnabled(true), _nightVision(false), _accomodateEye(HWhite), _shadowFactor(0),
 
       _usrBrightness(1),
 
@@ -88,6 +88,11 @@ DWORD Engine::GetAvgFrameDuration(int nFrames) const
 void Engine::SetMultitexturing(bool set)
 {
     _multitexturing = set;
+}
+
+void Engine::SetNightEyeEnabled(bool set)
+{
+    _nightEyeEnabled = set;
 }
 
 void Engine::FontDestroyed(Font* font)

--- a/engine/Poseidon/Graphics/Core/Engine.hpp
+++ b/engine/Poseidon/Graphics/Core/Engine.hpp
@@ -292,6 +292,7 @@ class Engine : public IGraphicsEngine
     float _avgBrightness; // average screen brightness
     bool _nightVision;
     bool _multitexturing;
+    bool _nightEyeEnabled;
     render::PassKindHint _passKindHint = render::PassKindHint::None; // explicit cockpit pass routing
     int _showFps;
     AspectSettings _aspectSettings;
@@ -341,6 +342,10 @@ class Engine : public IGraphicsEngine
     virtual void SetWBuffer(bool val) {}
 
     ColorVal GetAccomodateEye() const { return _accomodateEye; } // color filter
+
+    // Gates the scotopic night pass, which blends unlit geometry towards its
+    // own luminance so that night reads grey rather than colored.
+    void SetNightEyeEnabled(bool set);
 
     virtual void EnableNightEye(float night) {}
 

--- a/engine/Poseidon/UI/Options/GraphicsPage.cpp
+++ b/engine/Poseidon/UI/Options/GraphicsPage.cpp
@@ -55,6 +55,9 @@ const GraphicsRowText kRows[] = {
     {"STR_DISP_MAIN_OPT_GRAPHICS_MULTITEXTURING", "STR_DISP_MAIN_OPT_GRAPHICS_MULTITEXTURING_DESC", "Multitexturing",
      "Detail and specular texture stages on terrain and objects. Off falls back to the base texture like the "
      "original compatibility switch."},
+    {"STR_DISP_MAIN_OPT_GRAPHICS_NIGHT_EYE", "STR_DISP_MAIN_OPT_GRAPHICS_NIGHT_EYE_DESC", "Night Color Loss",
+     "Simulates night vision by draining color from unlit surfaces after dark. Off keeps night scenes in full "
+     "color but renders them darker."},
 };
 constexpr int kFpsCapValues[] = {0, 30, 60, 90, 120, 144, 240};
 constexpr int kMsaaValues[] = {0, 2, 4, 8};
@@ -225,6 +228,8 @@ OptionsScrollList::RowDef GraphicsPage::GraphicsProvider::RowFor(int row) const
             return {612, m_page->m_renderScaleCStrs.data(), 5};
         case kRowMultitexturing:
             return {622, m_page->m_offOnCStrs.data(), 2};
+        case kRowNightEye:
+            return {632, m_page->m_offOnCStrs.data(), 2};
     }
     return {-1, nullptr, 0};
 }
@@ -233,7 +238,7 @@ OptionsScrollList::Kind GraphicsPage::GraphicsProvider::RowKind(int row) const
 {
     if (row == kRowAdvanced)
         return OptionsScrollList::KindHeader;
-    if (row == kRowMultitexturing)
+    if (row == kRowMultitexturing || row == kRowNightEye)
         return OptionsScrollList::KindBoolean;
     return OptionsScrollList::Provider::RowKind(row);
 }
@@ -277,6 +282,8 @@ int GraphicsPage::GraphicsProvider::RowValue(int row) const
             return GraphicsPage::RenderScaleToIndex(c.renderScale);
         case kRowMultitexturing:
             return c.multitexturing ? 1 : 0;
+        case kRowNightEye:
+            return c.nightEye ? 1 : 0;
         case kRowVsync:
             return (int)c.vsync;
         case kRowFpsCap:
@@ -369,6 +376,9 @@ void GraphicsPage::GraphicsProvider::SetRowValue(int row, int v)
             break;
         case kRowMultitexturing:
             c.multitexturing = v != 0;
+            break;
+        case kRowNightEye:
+            c.nightEye = v != 0;
             break;
         case kRowVsync:
             if (v >= 0 && v <= 2)

--- a/engine/Poseidon/UI/Options/GraphicsPage.hpp
+++ b/engine/Poseidon/UI/Options/GraphicsPage.hpp
@@ -70,7 +70,8 @@ private:
 			kRowAntiAliasing   = 10,
 			kRowSupersampling  = 11,
 			kRowMultitexturing = 12,
-			kRowCount          = 13,
+			kRowNightEye       = 13,
+			kRowCount          = 14,
 		};
 
 		void SetPage(class GraphicsPage* page) { m_page = page; }

--- a/engine/Poseidon/UI/Settings/GraphicsApply.cpp
+++ b/engine/Poseidon/UI/Settings/GraphicsApply.cpp
@@ -96,6 +96,7 @@ void ApplyGraphicsConfigToEngine(const GraphicsConfig& cfg)
         GEngine->SetRenderScale(cfg.renderScale);
         GEngine->SetMsaaSamples(cfg.msaaSamples);
         GEngine->SetMultitexturing(cfg.multitexturing);
+        GEngine->SetNightEyeEnabled(cfg.nightEye);
     }
     gUserFpsCap = cfg.fpsCap;
 }

--- a/engine/Poseidon/UI/Settings/GraphicsConfig.cpp
+++ b/engine/Poseidon/UI/Settings/GraphicsConfig.cpp
@@ -256,6 +256,8 @@ bool GraphicsConfig::Load(const std::string& path)
         msaaSamples = (int)*e;
     if (auto* e = cfg.FindEntry("multitexturing"))
         multitexturing = (int)*e != 0;
+    if (auto* e = cfg.FindEntry("nightEye"))
+        nightEye = (int)*e != 0;
     if (auto* e = cfg.FindEntry("brightness"))
         brightness = (float)*e;
     if (auto* e = cfg.FindEntry("gamma"))
@@ -278,6 +280,7 @@ bool GraphicsConfig::Save(const std::string& path) const
     cfg.Add("renderScale", renderScale);
     cfg.Add("msaaSamples", msaaSamples);
     cfg.Add("multitexturing", multitexturing ? 1 : 0);
+    cfg.Add("nightEye", nightEye ? 1 : 0);
     cfg.Add("brightness", brightness);
     cfg.Add("gamma", gamma);
     cfg.Add("version", version);

--- a/engine/Poseidon/UI/Settings/GraphicsConfig.hpp
+++ b/engine/Poseidon/UI/Settings/GraphicsConfig.hpp
@@ -81,6 +81,9 @@ public:
 	int       msaaSamples      = 0;             // MSAA on the frame target: 0 (off) / 2 / 4 / 8
 	bool      multitexturing   = true;          // Detail-texture / specular second stage on terrain and
 	                                             // objects.  Off drops those draws to the base texture
+	bool      nightEye         = true;          // Scotopic night rendering: unlit surfaces blend towards
+	                                             // their own luminance after dark, so night reads grey.
+	                                             // Off leaves night in color
 	float     brightness       = 1.6f;          // 0.4..1.8
 	float     gamma            = 1.2f;          // 0.5..2.3
 

--- a/engine/PoseidonGL33/EngineGL33_Shaders.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Shaders.cpp
@@ -1801,7 +1801,7 @@ void EngineGL33::DoSelectPixelShader(PixelShaderID ps, PixelShaderMode mode, Pix
 
 void EngineGL33::EnableNightEye(float night)
 {
-    if (_nightVision)
+    if (_nightVision || !_nightEyeEnabled)
         night = 0;
     if (fabs(_nightEye - night) < 0.01f)
         return;

--- a/tests/integration/missions/night_color_loss.Demo/mission.sqm
+++ b/tests/integration/missions/night_color_loss.Demo/mission.sqm
@@ -1,0 +1,59 @@
+version=11;
+class Mission
+{
+	randomSeed=42;
+	class Intel
+	{
+		year=1985;
+		month=6;
+		day=21;
+		hour=1;
+		minute=0;
+		startWeather=0.000000;
+		forecastWeather=0.000000;
+	};
+	class Groups
+	{
+		items=1;
+		class Item0
+		{
+			side="WEST";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={6710.527832,82.907585,5408.891602};
+					azimut=280.0;
+					id=0;
+					side="WEST";
+					vehicle="SoldierWB";
+					player="PLAYER COMMANDER";
+					leader=1;
+					skill=1.0;
+				};
+			};
+		};
+	};
+};
+class Intro
+{
+	randomSeed=1;
+	class Intel
+	{
+	};
+};
+class OutroWin
+{
+	randomSeed=2;
+	class Intel
+	{
+	};
+};
+class OutroLoose
+{
+	randomSeed=3;
+	class Intel
+	{
+	};
+};

--- a/tests/integration/rendering/night_color_loss.test.sqf
+++ b/tests/integration/rendering/night_color_loss.test.sqf
@@ -1,0 +1,21 @@
+// The scotopic night pass must be optional, and must leave the sky alone:
+// EnableNightEye is armed only after the sky draw, which is what the sky
+// samples pin. Both readings come from one camera in one run, so only the
+// pass differs between them.
+
+triSetLanguage "English"
+
+triAssertMissionPlayable
+triSetView [6706.5, 85.68, 5408.9, 1.0, -0.25, 0.0]
+triSimFrames 120
+
+triAssertLt [(triGetRegionChroma [0.10, 0.55, 0.90, 0.95, 5]), 0.20]
+triAssertGt [(triGetRegionChroma [0.10, 0.02, 0.90, 0.20, 5]), 3.00]
+
+triSetNightEye 0
+triSimFrames 60
+
+triAssertGt [(triGetRegionChroma [0.10, 0.55, 0.90, 0.95, 5]), 0.30]
+triAssertGt [(triGetRegionChroma [0.10, 0.02, 0.90, 0.20, 5]), 3.00]
+
+triEndTest

--- a/tests/integration/rendering/night_color_loss.test.toml
+++ b/tests/integration/rendering/night_color_loss.test.toml
@@ -1,0 +1,7 @@
+tags = ["headless", "rendering", "ci-host-blocked"]
+binary = "PoseidonGame"
+mission = "tests/integration/missions/night_color_loss.Demo"
+data_dir = "packages/Demo"
+timeout = 120
+assert_timeout = 40
+extra_args = ["--dev", "--no-splash"]


### PR DESCRIPTION
The scotopic night pass blends unlit geometry towards its own luminance, so after dark the ground reads grey and nothing offers a way out. Gate it on a nightEye graphics setting that defaults on, leaving the shipped look unchanged.

adds experimental switch, more info at https://steamcommunity.com/app/65790/discussions/0/585057417507845288/?tscn=1787154763

<img width="797" height="629" alt="image" src="https://github.com/user-attachments/assets/74ab9207-df85-49d8-874c-2f58e6ed8dae" />
