### PR TITLE
Fix music fades and offsets

### DIFF
--- a/engine/PoseidonOpenAL/WaveOAL.cpp
+++ b/engine/PoseidonOpenAL/WaveOAL.cpp
@@ -10,6 +10,7 @@
 #include <Poseidon/Dev/Diag/ScopedTimer.hpp>
 #include <Poseidon/Core/TaskPool.hpp>
 #include <PoseidonOpenAL/OpenALRuntime.hpp>
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <thread>
@@ -374,8 +375,9 @@ void WaveOAL::OpenStreaming()
     }
 
     _streaming.chunkBytes = chunkBytes;
-    _streaming.decodeOffsetBytes.store(0, std::memory_order_release);
-    _streaming.consumedBytes.store(0, std::memory_order_release);
+    const int64_t initialOffset = std::max(_state.curPosition, 0);
+    _streaming.decodeOffsetBytes.store(initialOffset, std::memory_order_release);
+    _streaming.consumedBytes.store(initialOffset, std::memory_order_release);
     _streaming.eofReached.store(false, std::memory_order_release);
     _streaming.decodeInFlight.store(false, std::memory_order_release);
     _streaming.aborted.store(false, std::memory_order_release);
@@ -845,15 +847,12 @@ void WaveOAL::ApplyVolume()
     static const float minRelDiff = 1e-2f;
     if (_playing)
     {
-        if (std::fabs(gain - _gainSet) > minRelDiff * gain)
-        {
-            alSourcef(_alSource, AL_GAIN, gain);
-            // Level-comparison line — same shape as the DX8-ref's per-update
-            // `audio play ... volume_db100=` log so A/B runs diff directly.
-            LOG_DEBUG(Audio, "audio gain sound={} gain={:.4f} db={:.0f} 3d={} kind={} vol={:.3f} adj={:.3f}",
-                      static_cast<const char*>(Name()), gain, gain > 0.f ? 2000.f * std::log10(gain) : -10000.f,
-                      _is3D ? 1 : 0, static_cast<int>(_kind), _volume, _volumeAdjust);
-        }
+        if (std::fabs(gain - _gainSet) <= minRelDiff * gain)
+            return;
+        alSourcef(_alSource, AL_GAIN, gain);
+        LOG_DEBUG(Audio, "audio gain sound={} gain={:.4f} db={:.0f} 3d={} kind={} vol={:.3f} adj={:.3f}",
+                  static_cast<const char*>(Name()), gain, gain > 0.f ? 2000.f * std::log10(gain) : -10000.f,
+                  _is3D ? 1 : 0, static_cast<int>(_kind), _volume, _volumeAdjust);
     }
     else
     {
@@ -1390,7 +1389,7 @@ void WaveOAL::Skip(float deltaT)
     if (_state.frequency <= 0 || _state.sSize <= 0)
         return;
 
-    int skip = WaveLogic::TimeToPosition(deltaT, _state.frequency, _state.sSize);
+    int skip = WaveLogic::TimeToPosition(deltaT, _state.frequency, _state.sSize * std::max(_state.nChannel, 1));
     _state.curPosition += skip;
 
     // Delay/pause wave: size == 0 means there's no PCM to play, only a
@@ -1577,6 +1576,15 @@ float WaveOAL::AppliedPitchForTest() const
     ALfloat pitch = 1.0f;
     alGetSourcef(_alSource, AL_PITCH, &pitch);
     return pitch;
+}
+
+float WaveOAL::AppliedGainForTest() const
+{
+    if (!_alSource)
+        return 1.0f;
+    ALfloat gain = 1.0f;
+    alGetSourcef(_alSource, AL_GAIN, &gain);
+    return gain;
 }
 
 void WaveOAL::ApplyPitch()

--- a/engine/PoseidonOpenAL/WaveOAL.hpp
+++ b/engine/PoseidonOpenAL/WaveOAL.hpp
@@ -232,6 +232,8 @@ class WaveOAL : public IWave
     bool PumpDrainUpload();
     void DecodeQueuedChunk();
 
+    float AppliedGainForTest() const;
+
     // Test-only: the AL_PITCH currently applied to the source (1.0 if no
     // source).  Lets a test prove SetVolume's freq->pitch mapping reaches
     // the real OpenAL source.

--- a/tests/unit/engine/Poseidon/Audio/test_mixing_parity.cpp
+++ b/tests/unit/engine/Poseidon/Audio/test_mixing_parity.cpp
@@ -921,6 +921,65 @@ TEST_CASE("OAL: streamed OGG can restart after reload", "[Audio][parity][oal][st
     delete sys;
 }
 
+TEST_CASE("OAL - streamed wave starts from the requested offset", "[Audio][parity][oal][streaming][seek]")
+{
+    auto* sys = dynamic_cast<SoundSystemOAL*>(CreateSoundSystemOAL());
+    if (!sys)
+        SKIP("OpenAL not available");
+
+    const std::string ogg = GET_FIXTURE("audio/stream_loop.ogg");
+    auto* wave = dynamic_cast<WaveOAL*>(sys->CreateWave(ogg.c_str(), false, true));
+    if (!wave)
+    {
+        delete sys;
+        SKIP("Cannot create streamed OGG fixture wave");
+    }
+    REQUIRE(wave->IsStreamed());
+
+    wave->Repeat(1);
+    wave->Skip(0.5f);
+    wave->OpenStreamingForTest();
+
+    CHECK(wave->GetCurrentOffsetSeconds() == Approx(0.5f).margin(0.01f));
+    wave->DecodeOneChunkForTest();
+    ::Poseidon::Audio::DecodedChunk chunk;
+    REQUIRE(wave->StreamingState().queue.TryPop(chunk));
+    CHECK(chunk.streamOffset > 0);
+
+    wave->Release();
+    delete sys;
+}
+
+TEST_CASE("OAL - music gain accumulates filtered fade steps", "[Audio][parity][oal][music][fade]")
+{
+    auto* sys = dynamic_cast<SoundSystemOAL*>(CreateSoundSystemOAL());
+    if (!sys)
+        SKIP("OpenAL not available");
+
+    const std::string wav = GET_FIXTURE("audio/tone.wav");
+    auto* wave = dynamic_cast<WaveOAL*>(sys->CreateWave(wav.c_str(), false, true));
+    if (!wave)
+    {
+        delete sys;
+        SKIP("Cannot create WAV fixture wave");
+    }
+
+    wave->SetKind(WaveMusic);
+    wave->SetVolume(1.0f, 1.0f, false);
+    wave->Play();
+    sys->Commit();
+    REQUIRE(wave->State() == WaveState::Playing);
+    REQUIRE(wave->AppliedGainForTest() == Approx(1.0f));
+
+    for (int i = 1; i <= 20; ++i)
+        wave->SetVolume(1.0f - 0.001f * i, 1.0f, false);
+    CHECK(wave->AppliedGainForTest() < 0.995f);
+    CHECK(wave->AppliedGainForTest() >= 0.98f);
+
+    wave->Release();
+    delete sys;
+}
+
 // End-to-end wiring: SetVolume's freq argument (the engine's pitch ratio,
 // e.g. a vehicle engine sound at rpm*1.2) must reach the real AL source as
 // AL_PITCH via the 1:1 DirectSound mapping — NOT floored at 0.5x.  Broken


### PR DESCRIPTION
Keep the OpenAL gain cache tied to values actually sent to the source so small fade steps accumulate. Preserve requested stream positions and include every channel when converting time to bytes.

closes https://github.com/ofpisnotdead-com/CWR-CE/issues/196