### PR TITLE
Windows temp-path fixes for World state and PreviewImage tests

### DIFF
--- a/tests/unit/engine/Poseidon/Asset/Probes/test_asset_preview.cpp
+++ b/tests/unit/engine/Poseidon/Asset/Probes/test_asset_preview.cpp
@@ -224,7 +224,7 @@ TEST_CASE("PreviewImage::saveToFile writes PNG", "[tools-preview][save]")
     img.height = 2;
     img.data.assign(2 * 2 * 4, 0xAA);
 
-    std::string path = std::string(std::getenv("TMPDIR") ? std::getenv("TMPDIR") : "/tmp") + "/test_save.png";
+    std::string path = TestFixtures::GetTempFilePath("test_save.png");
     REQUIRE(img.saveToFile(path));
 
     // Verify file exists and has PNG signature
@@ -235,7 +235,7 @@ TEST_CASE("PreviewImage::saveToFile writes PNG", "[tools-preview][save]")
     CHECK(sig[1] == 'P');
     CHECK(sig[2] == 'N');
     CHECK(sig[3] == 'G');
-    std::remove(path.c_str());
+    TestFixtures::CleanupTempFile(path.c_str());
 }
 
 TEST_CASE("PreviewImage::saveToFile writes BMP", "[tools-preview][save]")
@@ -245,7 +245,7 @@ TEST_CASE("PreviewImage::saveToFile writes BMP", "[tools-preview][save]")
     img.height = 2;
     img.data.assign(2 * 2 * 4, 0xBB);
 
-    std::string path = std::string(std::getenv("TMPDIR") ? std::getenv("TMPDIR") : "/tmp") + "/test_save.bmp";
+    std::string path = TestFixtures::GetTempFilePath("test_save.bmp");
     REQUIRE(img.saveToFile(path));
 
     std::ifstream f(path, std::ios::binary);
@@ -254,7 +254,7 @@ TEST_CASE("PreviewImage::saveToFile writes BMP", "[tools-preview][save]")
     f.read(sig, 2);
     CHECK(sig[0] == 'B');
     CHECK(sig[1] == 'M');
-    std::remove(path.c_str());
+    TestFixtures::CleanupTempFile(path.c_str());
 }
 
 TEST_CASE("PreviewImage::saveToFile writes TGA", "[tools-preview][save]")
@@ -264,7 +264,7 @@ TEST_CASE("PreviewImage::saveToFile writes TGA", "[tools-preview][save]")
     img.height = 2;
     img.data.assign(2 * 2 * 4, 0xCC);
 
-    std::string path = std::string(std::getenv("TMPDIR") ? std::getenv("TMPDIR") : "/tmp") + "/test_save.tga";
+    std::string path = TestFixtures::GetTempFilePath("test_save.tga");
     REQUIRE(img.saveToFile(path));
 
     std::ifstream f(path, std::ios::binary);
@@ -273,7 +273,7 @@ TEST_CASE("PreviewImage::saveToFile writes TGA", "[tools-preview][save]")
     uint8_t hdr[3];
     f.read(reinterpret_cast<char*>(hdr), 3);
     CHECK(hdr[2] == 10);
-    std::remove(path.c_str());
+    TestFixtures::CleanupTempFile(path.c_str());
 }
 
 TEST_CASE("PreviewImage::saveToFile rejects unknown extension", "[tools-preview][save]")
@@ -299,7 +299,7 @@ TEST_CASE("PreviewImageRGB::saveToFile writes PNG", "[tools-preview][save]")
     img.height = 4;
     img.data.assign(4 * 4 * 3, 0x55);
 
-    std::string path = std::string(std::getenv("TMPDIR") ? std::getenv("TMPDIR") : "/tmp") + "/test_save_rgb.png";
+    std::string path = TestFixtures::GetTempFilePath("test_save_rgb.png");
     REQUIRE(img.saveToFile(path));
 
     std::ifstream f(path, std::ios::binary);
@@ -309,5 +309,5 @@ TEST_CASE("PreviewImageRGB::saveToFile writes PNG", "[tools-preview][save]")
     CHECK(sig[1] == 'P');
     CHECK(sig[2] == 'N');
     CHECK(sig[3] == 'G');
-    std::remove(path.c_str());
+    TestFixtures::CleanupTempFile(path.c_str());
 }

--- a/tests/unit/engine/Poseidon/Network/test_network_server.cpp
+++ b/tests/unit/engine/Poseidon/Network/test_network_server.cpp
@@ -26,6 +26,7 @@
 #include <Poseidon/Foundation/Containers/Array.hpp>
 #include <Poseidon/Foundation/Strings/RString.hpp>
 #include <Poseidon/Foundation/Types/Pointers.hpp>
+#include "test_fixtures.hpp"
 
 namespace
 {
@@ -1637,7 +1638,7 @@ static const int32_t JIPS_VERSION = 1;
 
 TEST_CASE("World state file format -- valid header round-trip", "[network][jip][worldstate]")
 {
-    const char* tmpfile = "/tmp/jip_test_worldstate_valid.jips";
+    const char* tmpfile = TestFixtures::GetTempFilePath("jip_test_worldstate_valid.jips");
 
     // Write valid header
     FILE* f = fopen(tmpfile, "wb");
@@ -1671,12 +1672,12 @@ TEST_CASE("World state file format -- valid header round-trip", "[network][jip][
     REQUIRE(rObj == 15);
     REQUIRE(rJip == 8);
 
-    remove(tmpfile);
+    TestFixtures::CleanupTempFile(tmpfile);
 }
 
 TEST_CASE("World state file format -- wrong magic rejected", "[network][jip][worldstate]")
 {
-    const char* tmpfile = "/tmp/jip_test_worldstate_badmagic.jips";
+    const char* tmpfile = TestFixtures::GetTempFilePath("jip_test_worldstate_badmagic.jips");
 
     FILE* f = fopen(tmpfile, "wb");
     REQUIRE(f != nullptr);
@@ -1696,12 +1697,12 @@ TEST_CASE("World state file format -- wrong magic rejected", "[network][jip][wor
 
     REQUIRE(rMagic != JIPS_MAGIC);
 
-    remove(tmpfile);
+    TestFixtures::CleanupTempFile(tmpfile);
 }
 
 TEST_CASE("World state file format -- wrong version rejected", "[network][jip][worldstate]")
 {
-    const char* tmpfile = "/tmp/jip_test_worldstate_badversion.jips";
+    const char* tmpfile = TestFixtures::GetTempFilePath("jip_test_worldstate_badversion.jips");
 
     FILE* f = fopen(tmpfile, "wb");
     REQUIRE(f != nullptr);
@@ -1721,12 +1722,12 @@ TEST_CASE("World state file format -- wrong version rejected", "[network][jip][w
     REQUIRE(rMagic == JIPS_MAGIC);
     REQUIRE(rVersion != JIPS_VERSION);
 
-    remove(tmpfile);
+    TestFixtures::CleanupTempFile(tmpfile);
 }
 
 TEST_CASE("World state file format -- truncated header detected", "[network][jip][worldstate]")
 {
-    const char* tmpfile = "/tmp/jip_test_worldstate_truncated.jips";
+    const char* tmpfile = TestFixtures::GetTempFilePath("jip_test_worldstate_truncated.jips");
 
     // Write only magic (incomplete header)
     FILE* f = fopen(tmpfile, "wb");
@@ -1744,12 +1745,12 @@ TEST_CASE("World state file format -- truncated header detected", "[network][jip
     REQUIRE(read == 0); // truncated -- can't read version
     fclose(f);
 
-    remove(tmpfile);
+    TestFixtures::CleanupTempFile(tmpfile);
 }
 
 TEST_CASE("World state file format -- empty file detected", "[network][jip][worldstate]")
 {
-    const char* tmpfile = "/tmp/jip_test_worldstate_empty.jips";
+    const char* tmpfile = TestFixtures::GetTempFilePath("jip_test_worldstate_empty.jips");
 
     FILE* f = fopen(tmpfile, "wb");
     REQUIRE(f != nullptr);
@@ -1762,12 +1763,12 @@ TEST_CASE("World state file format -- empty file detected", "[network][jip][worl
     REQUIRE(read == 0); // empty
     fclose(f);
 
-    remove(tmpfile);
+    TestFixtures::CleanupTempFile(tmpfile);
 }
 
 TEST_CASE("World state file format -- zero time and counts valid", "[network][jip][worldstate]")
 {
-    const char* tmpfile = "/tmp/jip_test_worldstate_zeros.jips";
+    const char* tmpfile = TestFixtures::GetTempFilePath("jip_test_worldstate_zeros.jips");
 
     FILE* f = fopen(tmpfile, "wb");
     REQUIRE(f != nullptr);
@@ -1797,12 +1798,12 @@ TEST_CASE("World state file format -- zero time and counts valid", "[network][ji
     REQUIRE(rObj == 0);
     REQUIRE(rJip == 0);
 
-    remove(tmpfile);
+    TestFixtures::CleanupTempFile(tmpfile);
 }
 
 TEST_CASE("World state file format -- large counts preserved", "[network][jip][worldstate]")
 {
-    const char* tmpfile = "/tmp/jip_test_worldstate_large.jips";
+    const char* tmpfile = TestFixtures::GetTempFilePath("jip_test_worldstate_large.jips");
 
     FILE* f = fopen(tmpfile, "wb");
     REQUIRE(f != nullptr);
@@ -1834,12 +1835,12 @@ TEST_CASE("World state file format -- large counts preserved", "[network][jip][w
     REQUIRE(rObj == 50000);
     REQUIRE(rJip == 100000);
 
-    remove(tmpfile);
+    TestFixtures::CleanupTempFile(tmpfile);
 }
 
 TEST_CASE("World state file format -- partial data truncation detected", "[network][jip][worldstate]")
 {
-    const char* tmpfile = "/tmp/jip_test_worldstate_partdata.jips";
+    const char* tmpfile = TestFixtures::GetTempFilePath("jip_test_worldstate_partdata.jips");
 
     // Write magic + version + timeElapsed (missing objectCount and jipCount)
     FILE* f = fopen(tmpfile, "wb");
@@ -1862,7 +1863,7 @@ TEST_CASE("World state file format -- partial data truncation detected", "[netwo
     REQUIRE(read == 0); // truncated at data section
     fclose(f);
 
-    remove(tmpfile);
+    TestFixtures::CleanupTempFile(tmpfile);
 }
 
 // JIP queue pattern tests -- simulating server message queueing behavior


### PR DESCRIPTION
## Summary

- Fix Windows-incompatible `/tmp` paths in `World state file format` tests.
- Fix Windows-incompatible `/tmp` paths in `PreviewImage` save-to-file tests.
- Use the shared `TestFixtures::GetTempFilePath()` and `TestFixtures::CleanupTempFile()` helpers.

## Testing

Run the world state tests:
-  `ctest --test-dir build/win-x64-clang-rwdi -R "World state file format" --output-on-failure` 
- All 8 `World state file format` tests passed.

Run the PreviewImage save-to-file tests:
- `ctest --test-dir build/win-x64-clang-rwdi -R "PreviewImage.*saveToFile|PreviewImageRGB.*saveToFile" --output-on-failure`
- All 6 `PreviewImage` save-to-file tests passed.