### PR TITLE
Expose map wheel bindings

### DIFF
--- a/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestAudio.cpp
@@ -203,6 +203,7 @@ GameValue TriOpenMap(const GameState*);
 GameValue TriShowMap(const GameState*, GameValuePar);
 GameValue TriMapSetScale(const GameState*, GameValuePar);
 GameValue TriMapGetScale(const GameState*);
+GameValue TriMapWheel(const GameState*, GameValuePar);
 GameValue TriBindAction(const GameState*, GameValuePar);
 GameValue TriShowVoiceOverlay(const GameState*, GameValuePar);
 GameValue TriClickBriefingLink(const GameState*, GameValuePar);
@@ -3268,6 +3269,7 @@ INIT_MODULE(GameStateExtTest, 3)
     GGameState.NewNularOp(GameNular(GameString, "triUnpauseGame", TriUnpauseGame));
     GGameState.NewNularOp(GameNular(GameString, "triOpenMap", TriOpenMap));
     GGameState.NewNularOp(GameNular(GameScalar, "triMapGetScale", TriMapGetScale));
+    GGameState.NewFunction(GameFunction(GameString, "triMapWheel", TriMapWheel, GameScalar));
     GGameState.NewFunction(GameFunction(GameString, "triBindAction", TriBindAction, GameArray));
     GGameState.NewFunction(GameFunction(GameString, "triShowMap", TriShowMap, GameScalar));
     GGameState.NewFunction(GameFunction(GameString, "triMapSetScale", TriMapSetScale, GameScalar));

--- a/engine/Poseidon/Game/Commands/GameStateExtTestMap.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTestMap.cpp
@@ -7,8 +7,6 @@
 #include <Poseidon/Input/InputSubsystem.hpp>
 #include <Poseidon/Input/UserActionDesc.hpp>
 
-#include <SDL3/SDL_scancode.h>
-
 #include <cstdio>
 
 using namespace Poseidon;
@@ -61,8 +59,19 @@ GameValue TriMapGetScale(const GameState* /*state*/)
     return GameValue((GameScalarType)map->GetMap()->GetScale());
 }
 
-/// triBindAction ["<ActionName>", <scancode>] -> "OK" / "FAIL:<reason>". Replaces
-/// the action's binding with a single keyboard key in every context; a rebind hook.
+GameValue TriMapWheel(const GameState* /*state*/, GameValuePar arg)
+{
+    if (!GWorld)
+        return GameValue("FAIL:no_world");
+    auto* map = dynamic_cast<DisplayMap*>(GWorld->Map());
+    if (!map || !map->GetMap())
+        return GameValue("FAIL:no_map");
+    map->GetMap()->OnMouseZChanged((float)arg);
+    return GameValue("OK");
+}
+
+/// triBindAction ["<ActionName>", <packed-code>] -> "OK" / "FAIL:<reason>". Replaces
+/// the action's binding with one input code in every context.
 GameValue TriBindAction(const GameState* /*state*/, GameValuePar arg)
 {
     if (arg.GetType() != GameArray)
@@ -89,7 +98,7 @@ GameValue TriBindAction(const GameState* /*state*/, GameValuePar arg)
     {
         InputProfile& p = input.GetProfile(static_cast<InputContext>(c));
         p.ClearBindings(static_cast<UserAction>(action));
-        p.Bind(static_cast<UserAction>(action), InputCode::Key(static_cast<SDL_Scancode>(sc)));
+        p.Bind(static_cast<UserAction>(action), InputCode::FromLegacy(sc));
     }
     LOG_INFO(Core, "[tri] triBindAction {} sc=0x{:x}", (const char*)name, sc);
     return GameValue("OK");

--- a/engine/Poseidon/Input/InputCode.hpp
+++ b/engine/Poseidon/Input/InputCode.hpp
@@ -8,15 +8,16 @@ namespace Poseidon
 
 enum class InputDevice : uint32_t
 {
-    Keyboard      = 0x00000000,
-    Mouse         = 0x00010000,
+    Keyboard = 0x00000000,
+    Mouse = 0x00010000,
     GamepadButton = 0x00020000,
-    GamepadAxis   = 0x00030000,
-    GamepadPOV    = 0x00040000,
+    GamepadAxis = 0x00030000,
+    GamepadPOV = 0x00040000,
+    MouseAxis = 0x00100000,
 };
 
 constexpr uint32_t INPUT_CODE_DEVICE_MASK = 0x00ff0000;
-constexpr uint32_t INPUT_CODE_VALUE_MASK  = 0x0000ffff;
+constexpr uint32_t INPUT_CODE_VALUE_MASK = 0x0000ffff;
 
 // Typed input code — packs device type + code index into a single value.
 // Compatible with existing INPUT_DEVICE_* | code integers used in KeyList.
@@ -27,11 +28,28 @@ struct InputCode
     constexpr InputCode() = default;
     constexpr explicit InputCode(uint32_t packed) : raw(packed) {}
 
-    static constexpr InputCode Key(SDL_Scancode sc) { return InputCode(static_cast<uint32_t>(InputDevice::Keyboard) | static_cast<uint32_t>(sc)); }
-    static constexpr InputCode MouseButton(int btn) { return InputCode(static_cast<uint32_t>(InputDevice::Mouse) | static_cast<uint32_t>(btn)); }
-    static constexpr InputCode GamepadBtn(int btn) { return InputCode(static_cast<uint32_t>(InputDevice::GamepadButton) | static_cast<uint32_t>(btn)); }
-    static constexpr InputCode GamepadAx(int axis) { return InputCode(static_cast<uint32_t>(InputDevice::GamepadAxis) | static_cast<uint32_t>(axis)); }
-    static constexpr InputCode GamepadPov(int pov) { return InputCode(static_cast<uint32_t>(InputDevice::GamepadPOV) | static_cast<uint32_t>(pov)); }
+    static constexpr InputCode Key(SDL_Scancode sc)
+    {
+        return InputCode(static_cast<uint32_t>(InputDevice::Keyboard) | static_cast<uint32_t>(sc));
+    }
+    static constexpr InputCode MouseButton(int btn)
+    {
+        return InputCode(static_cast<uint32_t>(InputDevice::Mouse) | static_cast<uint32_t>(btn));
+    }
+    static constexpr InputCode MouseWheelUp() { return InputCode(static_cast<uint32_t>(InputDevice::MouseAxis) | 4); }
+    static constexpr InputCode MouseWheelDown() { return InputCode(static_cast<uint32_t>(InputDevice::MouseAxis) | 5); }
+    static constexpr InputCode GamepadBtn(int btn)
+    {
+        return InputCode(static_cast<uint32_t>(InputDevice::GamepadButton) | static_cast<uint32_t>(btn));
+    }
+    static constexpr InputCode GamepadAx(int axis)
+    {
+        return InputCode(static_cast<uint32_t>(InputDevice::GamepadAxis) | static_cast<uint32_t>(axis));
+    }
+    static constexpr InputCode GamepadPov(int pov)
+    {
+        return InputCode(static_cast<uint32_t>(InputDevice::GamepadPOV) | static_cast<uint32_t>(pov));
+    }
 
     static constexpr InputCode FromLegacy(int packed) { return InputCode(static_cast<uint32_t>(packed)); }
 
@@ -45,4 +63,3 @@ struct InputCode
     constexpr bool operator<(InputCode other) const { return raw < other.raw; }
 };
 } // namespace Poseidon
-

--- a/engine/Poseidon/Input/InputDeviceConstants.hpp
+++ b/engine/Poseidon/Input/InputDeviceConstants.hpp
@@ -14,6 +14,10 @@ namespace Poseidon
 #define INPUT_DEVICE_STICK 0x00020000
 #define INPUT_DEVICE_STICK_AXIS 0x00030000
 #define INPUT_DEVICE_STICK_POV 0x00040000
+#define INPUT_DEVICE_MOUSE_AXIS 0x00100000
+
+#define INPUT_MOUSE_WHEEL_UP 4
+#define INPUT_MOUSE_WHEEL_DOWN 5
 
 // Binding mode bits live below INPUT_DEVICE_MASK so the existing packed
 // device class stays stable on disk and in conflict checks.

--- a/engine/Poseidon/Input/InputSubsystem.cpp
+++ b/engine/Poseidon/Input/InputSubsystem.cpp
@@ -781,6 +781,17 @@ const InputProfile& InputSubsystem::GetProfile(InputContext ctx) const
     return profiles_[static_cast<int>(ctx)];
 }
 
+bool InputSubsystem::IsBindingActive(UserAction action, InputCode code, bool checkFocus) const
+{
+    const InputProfile& profile = GetProfile(context_);
+    for (const InputBinding& binding : profile.GetBindingEntries(action))
+    {
+        if (binding.code == code && ProfileModifierHeld(GInput, binding.modifier, checkFocus))
+            return true;
+    }
+    return false;
+}
+
 void InputSubsystem::ResetLookAroundToggle()
 {
     lookAroundToggled_ = false;
@@ -1267,8 +1278,10 @@ UserActionDesc* InputSubsystem::GetUserActionDesc()
         UserActionDesc("AimDown", IDS_USRACT_AIM_DOWN, -1),
         UserActionDesc("AimLeft", IDS_USRACT_AIM_LEFT, -1),
         UserActionDesc("AimRight", IDS_USRACT_AIM_RIGHT, -1),
-        UserActionDesc("MapZoomIn", IDS_USRACT_MAP_ZOOM_IN, SDL_SCANCODE_KP_PLUS, -1),
-        UserActionDesc("MapZoomOut", IDS_USRACT_MAP_ZOOM_OUT, SDL_SCANCODE_KP_MINUS, -1),
+        UserActionDesc("MapZoomIn", IDS_USRACT_MAP_ZOOM_IN, SDL_SCANCODE_KP_PLUS,
+                       INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_DOWN, -1),
+        UserActionDesc("MapZoomOut", IDS_USRACT_MAP_ZOOM_OUT, SDL_SCANCODE_KP_MINUS,
+                       INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_UP, -1),
         UserActionDesc("CheatEntry", IDS_USRACT_CHEAT_ENTRY, SDL_SCANCODE_KP_MINUS, -1),
 #if _ENABLE_CHEATS
         UserActionDesc("Cheat1", IDS_USRACT_CHEAT_1, SDL_SCANCODE_RGUI, -1),

--- a/engine/Poseidon/Input/InputSubsystem.hpp
+++ b/engine/Poseidon/Input/InputSubsystem.hpp
@@ -207,9 +207,7 @@ class InputSubsystem
     // both code AND modifier match, so "Ctrl+W" doesn't conflict with bare
     // "W".  Returns UAN if no conflict.  Pass excludeSlot = -1 to scan
     // every slot of excludeAction too.  modifier = -1 means "no modifier".
-    UserAction FindBindingConflict(int packedCode,
-                                   UserAction excludeAction = UAN,
-                                   int excludeSlot = -1,
+    UserAction FindBindingConflict(int packedCode, UserAction excludeAction = UAN, int excludeSlot = -1,
                                    int modifier = -1) const;
 
     // Restore the engine defaults (UserActionDesc[i].keys) for every
@@ -237,6 +235,7 @@ class InputSubsystem
     // Profile management
     InputProfile& GetProfile(InputContext ctx);
     const InputProfile& GetProfile(InputContext ctx) const;
+    bool IsBindingActive(UserAction action, InputCode code, bool checkFocus = true) const;
 
   private:
     InputSubsystem();
@@ -270,4 +269,3 @@ class InputSubsystem
     float syntheticLeftStickY_ = 0.0f;
 };
 } // namespace Poseidon
-

--- a/engine/Poseidon/UI/DisplayUI.cpp
+++ b/engine/Poseidon/UI/DisplayUI.cpp
@@ -486,6 +486,10 @@ RString GetKeyName(int dikCode)
             return LocalizeString(IDS_INPUT_DEVICE_MOUSE_6);
         case INPUT_DEVICE_MOUSE + 7:
             return LocalizeString(IDS_INPUT_DEVICE_MOUSE_7);
+        case INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_UP:
+            return LocalizeStringWithFallback("STR_INPUT_DEVICE_MOUSE_WHEEL_UP", "Mouse wheel up");
+        case INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_DOWN:
+            return LocalizeStringWithFallback("STR_INPUT_DEVICE_MOUSE_WHEEL_DOWN", "Mouse wheel down");
 
         case INPUT_DEVICE_STICK:
             return LocalizeString(IDS_INPUT_DEVICE_STICK_0);

--- a/engine/Poseidon/UI/Map/UIMap.cpp
+++ b/engine/Poseidon/UI/Map/UIMap.cpp
@@ -2362,7 +2362,14 @@ void CStaticMap::OnMouseZChanged(float dz)
         return;
     }
     _moveKey = 0;
-    float scale = exp(0.1 * dz) * _scaleX;
+    auto& input = InputSubsystem::Instance();
+    const InputCode wheel = dz > 0 ? InputCode::MouseWheelUp() : InputCode::MouseWheelDown();
+    const bool zoomIn = input.IsBindingActive(UAMapZoomIn, wheel, false);
+    const bool zoomOut = input.IsBindingActive(UAMapZoomOut, wheel, false);
+    if (zoomIn == zoomOut)
+        return;
+
+    float scale = exp(0.1 * std::abs(dz) * (zoomIn ? -1.0f : 1.0f)) * _scaleX;
     saturate(scale, _scaleMin, _scaleMax);
     SetScale(scale);
 }

--- a/engine/Poseidon/UI/Options/BindingsPage.cpp
+++ b/engine/Poseidon/UI/Options/BindingsPage.cpp
@@ -212,7 +212,7 @@ void BindingsPage::ResetCurrentCategoryToDefaults()
         const KeyList& keys = descs[action].keys;
         for (int i = 0; i < keys.Size(); ++i)
         {
-            if (DeviceFilter(keys[i]) && keys[i] < INPUT_DEVICE_STICK)
+            if (DeviceFilter(keys[i]))
                 defaults.push_back(MakeBinding(keys[i], DefaultModifierForDefaultKey(action, keys[i])));
         }
 
@@ -503,8 +503,8 @@ void BindingsPage::Provider::OnBindingClicked(int row, int slot, Display& host)
         return UAN;
     };
 
-    shell->PushPage(m_owner->MakeCaptureModal(ControlActionLabel((UserAction)actionIdx), slot == 0 ? "Primary" : "Alt",
-                                              std::move(onSave), std::move(onConflict)));
+    shell->PushPage(m_owner->MakeCaptureModal((UserAction)actionIdx, ControlActionLabel((UserAction)actionIdx),
+                                              slot == 0 ? "Primary" : "Alt", std::move(onSave), std::move(onConflict)));
 }
 
 void BindingsPage::Provider::OnBindingCleared(int row, int slot)

--- a/engine/Poseidon/UI/Options/BindingsPage.hpp
+++ b/engine/Poseidon/UI/Options/BindingsPage.hpp
@@ -30,7 +30,6 @@
 #include <memory>
 #include <string>
 
-
 namespace Poseidon
 {
 class BindingsPage : public ScrollListPage
@@ -38,7 +37,7 @@ class BindingsPage : public ScrollListPage
   public:
     BindingsPage() = default;
 
-    using SaveCallback     = std::function<void(int packedCode, int modifier, bool replaceConflict)>;
+    using SaveCallback = std::function<void(int packedCode, int modifier, bool replaceConflict)>;
     using ConflictCallback = std::function<UserAction(int packedCode, int modifier)>;
 
     void RefreshAfterCapture();
@@ -50,18 +49,13 @@ class BindingsPage : public ScrollListPage
     virtual bool IsActionVisible(UserAction action, ControlsCategory category) const;
     virtual const char* ActionLabelOverride(UserAction action, ControlsCategory category) const;
     virtual const char* BindingDisplayOverride(UserAction action, ControlsCategory category, int slot) const;
-    virtual bool ApplyCaptureOverride(ControlsCategory category,
-                                      UserAction action,
-                                      int slot,
-                                      int packedCode,
+    virtual bool ApplyCaptureOverride(ControlsCategory category, UserAction action, int slot, int packedCode,
                                       int modifier);
     virtual bool ClearCaptureOverride(ControlsCategory category, UserAction action, int slot);
     virtual bool ResetCategoryOverride(ControlsCategory category);
-    virtual std::unique_ptr<OptionsPage> MakeCaptureModal(
-        std::string actionLabel,
-        std::string slotName,
-        SaveCallback onSave,
-        ConflictCallback onConflict) = 0;
+    virtual std::unique_ptr<OptionsPage> MakeCaptureModal(UserAction action, std::string actionLabel,
+                                                          std::string slotName, SaveCallback onSave,
+                                                          ConflictCallback onConflict) = 0;
 
     OptionsScrollList::Provider& ProviderRef() override final { return m_withClose; }
 
@@ -99,10 +93,7 @@ class BindingsPage : public ScrollListPage
         const char* RowLabel(int row) const override;
         const char* RowDescription(int row) const override;
         OptionsScrollList::RowDef RowFor(int row) const override;
-        int RowValue(int row) const override
-        {
-            return (row == 0) ? (int)m_owner->m_category : 0;
-        }
+        int RowValue(int row) const override { return (row == 0) ? (int)m_owner->m_category : 0; }
         void SetRowValue(int row, int value) override;
         OptionsScrollList::Kind RowKind(int row) const override;
         const char* BindingPrimary(int row) const override;
@@ -110,15 +101,10 @@ class BindingsPage : public ScrollListPage
         void OnBindingClicked(int row, int slot, Display& host) override;
         void OnBindingCleared(int row, int slot) override;
         void OnRowAction(int row, Display& host) override;
-        const char* FindBindingConflict(const char* formatted,
-                                        int excludeRow,
-                                        int excludeSlot) const override;
+        const char* FindBindingConflict(const char* formatted, int excludeRow, int excludeSlot) const override;
 
       private:
-        bool IsActionRow(int row) const
-        {
-            return row >= 1 && row <= VisibleActionCount();
-        }
+        bool IsActionRow(int row) const { return row >= 1 && row <= VisibleActionCount(); }
         int ActionIndex(int row) const
         {
             // Returns the UserAction enum value for a given row, or UAN if
@@ -138,10 +124,7 @@ class BindingsPage : public ScrollListPage
             }
             return UAN;
         }
-        bool IsResetRow(int row) const
-        {
-            return row == 1 + VisibleActionCount();
-        }
+        bool IsResetRow(int row) const { return row == 1 + VisibleActionCount(); }
         int VisibleActionCount() const;
 
         // Buffer for the most recently formatted Primary / Alt cells —

--- a/engine/Poseidon/UI/Options/GamepadPage.cpp
+++ b/engine/Poseidon/UI/Options/GamepadPage.cpp
@@ -175,11 +175,8 @@ bool GamepadPage::DeviceFilter(int packedCode) const
 {
     if (packedCode < 0)
         return false;
-    // Show only joystick-class entries: STICK buttons, STICK_AXIS,
-    // STICK_POV.  Keyboard scancodes and mouse buttons live below
-    // INPUT_DEVICE_STICK and are filtered out so the Gamepad page only
-    // surfaces / edits gamepad bindings.
-    return (packedCode >= INPUT_DEVICE_STICK);
+    const int device = InputBindingDevice(packedCode);
+    return device == INPUT_DEVICE_STICK || device == INPUT_DEVICE_STICK_AXIS || device == INPUT_DEVICE_STICK_POV;
 }
 
 bool GamepadPage::IsActionVisible(UserAction action, ControlsCategory category) const
@@ -284,7 +281,7 @@ bool GamepadPage::ResetCategoryOverride(ControlsCategory category)
     return true;
 }
 
-std::unique_ptr<OptionsPage> GamepadPage::MakeCaptureModal(std::string actionLabel, std::string slotName,
+std::unique_ptr<OptionsPage> GamepadPage::MakeCaptureModal(UserAction, std::string actionLabel, std::string slotName,
                                                            SaveCallback onSave, ConflictCallback onConflict)
 {
     return std::make_unique<PressButtonPage>(std::move(actionLabel), std::move(slotName), std::move(onSave),

--- a/engine/Poseidon/UI/Options/GamepadPage.hpp
+++ b/engine/Poseidon/UI/Options/GamepadPage.hpp
@@ -8,7 +8,6 @@
 
 #include <Poseidon/UI/Options/BindingsPage.hpp>
 
-
 namespace Poseidon
 {
 class GamepadPage : public BindingsPage
@@ -22,17 +21,11 @@ class GamepadPage : public BindingsPage
     bool IsActionVisible(UserAction action, ControlsCategory category) const override;
     const char* ActionLabelOverride(UserAction action, ControlsCategory category) const override;
     const char* BindingDisplayOverride(UserAction action, ControlsCategory category, int slot) const override;
-    bool ApplyCaptureOverride(ControlsCategory category,
-                              UserAction action,
-                              int slot,
-                              int packedCode,
+    bool ApplyCaptureOverride(ControlsCategory category, UserAction action, int slot, int packedCode,
                               int modifier) override;
     bool ResetCategoryOverride(ControlsCategory category) override;
-    std::unique_ptr<OptionsPage> MakeCaptureModal(
-        std::string actionLabel,
-        std::string slotName,
-        SaveCallback onSave,
-        ConflictCallback onConflict) override;
+    std::unique_ptr<OptionsPage> MakeCaptureModal(UserAction action, std::string actionLabel, std::string slotName,
+                                                  SaveCallback onSave, ConflictCallback onConflict) override;
 };
 
 } // namespace Poseidon

--- a/engine/Poseidon/UI/Options/KbmPage.cpp
+++ b/engine/Poseidon/UI/Options/KbmPage.cpp
@@ -25,12 +25,8 @@ bool KbmPage::DeviceFilter(int packedCode) const
 {
     if (packedCode < 0)
         return false;
-    // Keyboard scancodes occupy 0..0xFFFF; mouse buttons live above
-    // INPUT_DEVICE_MOUSE.  Joystick / stick / pov / axis use higher
-    // device offsets (INPUT_DEVICE_STICK / STICK_POV / STICK_AXIS) —
-    // those are filtered out so the KB&M page only shows / writes
-    // keyboard + mouse entries.
-    return (packedCode < INPUT_DEVICE_STICK);
+    const int device = InputBindingDevice(packedCode);
+    return device == INPUT_DEVICE_KEYBOARD || device == INPUT_DEVICE_MOUSE || device == INPUT_DEVICE_MOUSE_AXIS;
 }
 
 bool KbmPage::IsActionVisible(UserAction action, ControlsCategory category) const
@@ -38,11 +34,11 @@ bool KbmPage::IsActionVisible(UserAction action, ControlsCategory category) cons
     return IsActionVisibleOnKeyboard(action, category);
 }
 
-std::unique_ptr<OptionsPage> KbmPage::MakeCaptureModal(std::string actionLabel, std::string slotName,
+std::unique_ptr<OptionsPage> KbmPage::MakeCaptureModal(UserAction action, std::string actionLabel, std::string slotName,
                                                        SaveCallback onSave, ConflictCallback onConflict)
 {
     return std::make_unique<PressKeyPage>(std::move(actionLabel), std::move(slotName), std::move(onSave),
-                                          std::move(onConflict));
+                                          std::move(onConflict), action == UAMapZoomIn || action == UAMapZoomOut);
 }
 
 } // namespace Poseidon

--- a/engine/Poseidon/UI/Options/KbmPage.hpp
+++ b/engine/Poseidon/UI/Options/KbmPage.hpp
@@ -7,7 +7,6 @@
 
 #include <Poseidon/UI/Options/BindingsPage.hpp>
 
-
 namespace Poseidon
 {
 class KbmPage : public BindingsPage
@@ -19,11 +18,8 @@ class KbmPage : public BindingsPage
     const char* DeviceNoun() const override;
     bool DeviceFilter(int packedCode) const override;
     bool IsActionVisible(UserAction action, ControlsCategory category) const override;
-    std::unique_ptr<OptionsPage> MakeCaptureModal(
-        std::string actionLabel,
-        std::string slotName,
-        SaveCallback onSave,
-        ConflictCallback onConflict) override;
+    std::unique_ptr<OptionsPage> MakeCaptureModal(UserAction action, std::string actionLabel, std::string slotName,
+                                                  SaveCallback onSave, ConflictCallback onConflict) override;
 };
 
 } // namespace Poseidon

--- a/engine/Poseidon/UI/Options/PressKeyPage.cpp
+++ b/engine/Poseidon/UI/Options/PressKeyPage.cpp
@@ -121,6 +121,18 @@ bool PressKeyPage::OnKeyDown(OptionsShell& shell, unsigned nChar)
 
 void PressKeyPage::OnSimulate(OptionsShell& shell)
 {
+    auto& input = InputSubsystem::Instance();
+    const float wheel = input.GetMouseWheel();
+    if (m_allowMouseWheel && IsListening() && wheel != 0.0f)
+    {
+        input.ConsumeCursorScroll();
+        TryCapture(shell,
+                   wheel > 0.0f ? INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_UP
+                                : INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_DOWN,
+                   -1);
+        return;
+    }
+
     const int mouse = CapturedMouseButtonInput();
     if (mouse < 0)
         return;

--- a/engine/Poseidon/UI/Options/PressKeyPage.hpp
+++ b/engine/Poseidon/UI/Options/PressKeyPage.hpp
@@ -1,27 +1,17 @@
 #pragma once
 
-// Keyboard / mouse capture modal — captures one SDL scancode (or a
-// mouse button packed via INPUT_DEVICE_MOUSE+N) and stores the packed
-// int directly.  A modifier pressed on its own binds standalone; a real
-// key pressed while a modifier is held binds as a "Mod+Key" combo.
-
 #include <Poseidon/UI/Options/CapturePage.hpp>
-
 
 namespace Poseidon
 {
 class PressKeyPage : public CapturePage
 {
   public:
-    PressKeyPage(std::string actionLabel,
-                 std::string slotName,
-                 SaveCallback onSave,
-                 ConflictCallback onConflict)
-        : CapturePage(Idcs{9301, 9303, 9302, 9380, 9381},
-                      std::move(actionLabel),
-                      std::move(slotName),
-                      std::move(onSave),
-                      std::move(onConflict))
+    PressKeyPage(std::string actionLabel, std::string slotName, SaveCallback onSave, ConflictCallback onConflict,
+                 bool allowMouseWheel = false)
+        : CapturePage(Idcs{9301, 9303, 9302, 9380, 9381}, std::move(actionLabel), std::move(slotName),
+                      std::move(onSave), std::move(onConflict)),
+          m_allowMouseWheel(allowMouseWheel)
     {
     }
 
@@ -30,10 +20,13 @@ class PressKeyPage : public CapturePage
     void OnSimulate(OptionsShell& shell) override;
 
   protected:
-    const char* PromptKey()  const override { return "STR_DISP_OPT_CAP_PRESS_KEY"; }
+    const char* PromptKey() const override { return "STR_DISP_OPT_CAP_PRESS_KEY"; }
     const char* PromptVerb() const override { return "key"; }
     Result InterpretKey(unsigned nChar, int& outPackedCode, int& outModifier) const override;
     bool IsBareModifierCode(int packedCode) const override;
+
+  private:
+    bool m_allowMouseWheel;
 };
 
 } // namespace Poseidon

--- a/engine/Poseidon/UI/Settings/ContextControlsConfig.cpp
+++ b/engine/Poseidon/UI/Settings/ContextControlsConfig.cpp
@@ -1,6 +1,7 @@
 #include <Poseidon/UI/Settings/ContextControlsConfig.hpp>
 
 #include <Poseidon/Input/InputBinding.hpp>
+#include <Poseidon/Input/InputDeviceConstants.hpp>
 #include <Poseidon/Input/InputSubsystem.hpp>
 #include <Poseidon/Input/UserActionDesc.hpp>
 #include <Poseidon/IO/ParamFile/ParamFile.hpp>
@@ -8,11 +9,13 @@
 
 #include <Poseidon/Foundation/Strings/RString.hpp>
 
+#include <vector>
+
 namespace Poseidon
 {
 namespace
 {
-constexpr int kContextControlsVersion = 3;
+constexpr int kContextControlsVersion = 4;
 constexpr int kGamepadButtonA = 0;
 constexpr int kGamepadButtonB = 1;
 constexpr int kGamepadButtonX = 2;
@@ -206,6 +209,42 @@ void ApplyContextDefaults(InputContext ctx, InputProfile& profile)
             break;
     }
 }
+
+bool IsKeyboardMouseBinding(const InputBinding& binding)
+{
+    if (!binding.code.valid())
+        return true;
+    const int device = InputBindingDevice(binding.code.toLegacy());
+    return device == INPUT_DEVICE_KEYBOARD || device == INPUT_DEVICE_MOUSE || device == INPUT_DEVICE_MOUSE_AXIS;
+}
+
+void AddMapWheelToEmptySlot(InputProfile& profile, UserAction action, InputCode wheel)
+{
+    std::vector<InputBinding> bindings = profile.GetBindingEntries(action);
+    if (bindings.empty() || profile.HasBinding(action, wheel))
+        return;
+
+    int visibleCount = 0;
+    for (InputBinding& binding : bindings)
+    {
+        if (!IsKeyboardMouseBinding(binding))
+            continue;
+        if (visibleCount == 2)
+            break;
+        ++visibleCount;
+        if (!binding.code.valid())
+        {
+            binding = InputBinding(wheel);
+            profile.ClearBindings(action);
+            for (const InputBinding& replacement : bindings)
+                profile.Bind(action, replacement);
+            return;
+        }
+    }
+
+    if (visibleCount == 1)
+        profile.Bind(action, wheel);
+}
 } // namespace
 
 void ContextControlsConfig::LoadDefaults()
@@ -276,6 +315,12 @@ bool ContextControlsConfig::Load(const std::string& path)
 
                 profile.Bind(static_cast<UserAction>(a), InputBinding(code, modifier, ActivationMode::OnHold, scale));
             }
+        }
+
+        if (version < 4)
+        {
+            AddMapWheelToEmptySlot(profile, UAMapZoomIn, InputCode::MouseWheelDown());
+            AddMapWheelToEmptySlot(profile, UAMapZoomOut, InputCode::MouseWheelUp());
         }
     }
 

--- a/engine/Poseidon/UI/Settings/ControlsConfig.cpp
+++ b/engine/Poseidon/UI/Settings/ControlsConfig.cpp
@@ -24,15 +24,15 @@ RString ModName(const UserActionDesc& desc)
     return RString("key") + RString(desc.name) + RString("_mod");
 }
 
-// True if the packed binding belongs in controls.cfg (keyboard scancodes
-// or mouse buttons).  Joystick-class entries (STICK / STICK_AXIS /
+// True if the packed binding belongs in controls.cfg (keyboard or mouse).
+// Joystick-class entries (STICK / STICK_AXIS /
 // STICK_POV) are persisted via GamepadConfig instead.
 bool IsKbmCode(int packedCode)
 {
     if (packedCode < 0)
         return false;
     int dev = packedCode & INPUT_DEVICE_MASK;
-    return dev == INPUT_DEVICE_KEYBOARD || dev == INPUT_DEVICE_MOUSE;
+    return dev == INPUT_DEVICE_KEYBOARD || dev == INPUT_DEVICE_MOUSE || dev == INPUT_DEVICE_MOUSE_AXIS;
 }
 } // namespace
 

--- a/tests/fixtures/cfg/contextControls_v3_map_wheel.cfg
+++ b/tests/fixtures/cfg/contextControls_v3_map_wheel.cfg
@@ -1,0 +1,16 @@
+contextControlsVersion=3;
+ctxInfantryMapZoomIn[]={87};
+ctxInfantryMapZoomIn_mod[]={-1};
+ctxInfantryMapZoomIn_scale[]={1.000000};
+ctxInfantryMapZoomOut[]={86,0};
+ctxInfantryMapZoomOut_mod[]={-1,-1};
+ctxInfantryMapZoomOut_scale[]={1.000000,1.000000};
+ctxMenuMapZoomIn[]={87,4};
+ctxMenuMapZoomIn_mod[]={-1,-1};
+ctxMenuMapZoomIn_scale[]={1.000000,1.000000};
+ctxEditorMapZoomIn[]={0,4};
+ctxEditorMapZoomIn_mod[]={-1,-1};
+ctxEditorMapZoomIn_scale[]={1.000000,1.000000};
+ctxEditorMapZoomOut[]={};
+ctxEditorMapZoomOut_mod[]={};
+ctxEditorMapZoomOut_scale[]={};

--- a/tests/fixtures/stringtable/STRINGTABLE_MAINMENU.utf8.csv
+++ b/tests/fixtures/stringtable/STRINGTABLE_MAINMENU.utf8.csv
@@ -45,3 +45,5 @@ STR_DISP_OPT_MOUSE_SENSITIVITY_X_DESC,Horizontal mouse sensitivity. Range 0.5x t
 STR_DISP_OPT_MOUSE_SENSITIVITY_Y_DESC,Vertical mouse sensitivity. Range 0.5x to 2.0x.
 STR_DISP_OPT_MOUSE_DPI,Mouse DPI
 STR_DISP_OPT_MOUSE_DPI_DESC,Set this to your mouse's DPI (or close). Fine-tune with sensitivity for a smoother feel.
+STR_INPUT_DEVICE_MOUSE_WHEEL_UP,Mouse wheel up
+STR_INPUT_DEVICE_MOUSE_WHEEL_DOWN,Mouse wheel down

--- a/tests/integration/ingame/map_zoom.test.sqf
+++ b/tests/integration/ingame/map_zoom.test.sqf
@@ -1,7 +1,8 @@
-// Map zoom must follow rebinds: the map polls the bound actions, not hardcoded numpad
-// keycodes. Rebind Map Zoom In to a new key; assert that key zooms and the old numpad
-// key no longer does. (The mouse-wheel path in OnMouseZChanged is unchanged.)
-// Scancodes: K 14, Numpad+ 87.
+// Map zoom follows keyboard and mouse-wheel bindings while preserving its defaults.
+_keyK = 14
+_keyNumpadPlus = 87
+_wheelUp = 1048580
+_wheelDown = 1048581
 triSetLanguage "English"
 triSimFrames 15
 
@@ -11,24 +12,45 @@ triSimFrames 5
 _s0 = triMapGetScale
 triAssertGt [_s0, 0]
 
-triBindAction ["MapZoomIn", 14]
+triMapWheel 1
+_s3 = triMapGetScale
+triAssertGt [_s3, _s0]
+
+triMapSetScale _s0
+triMapWheel -1
+_s4 = triMapGetScale
+triAssertLt [_s4, _s0]
+
+triMapSetScale _s0
+
+triBindAction ["MapZoomIn", _keyK]
 triSimFrames 2
 
-// The new key zooms the map in (scale decreases).
-triKeyDown 14
+triKeyDown _keyK
 triSimFrames 20
-triKeyUp 14
+triKeyUp _keyK
 _s1 = triMapGetScale
 triAssertLt [_s1, _s0]
 
-// The old numpad+ is no longer bound to Map Zoom In, so from the same baseline it
-// does not zoom the map (broken state: it would zoom in and the scale would drop).
 triMapSetScale _s0
 triSimFrames 2
-triKeyDown 87
+triKeyDown _keyNumpadPlus
 triSimFrames 20
-triKeyUp 87
+triKeyUp _keyNumpadPlus
 _s2 = triMapGetScale
 triAssertEq [_s2, _s0]
+
+triBindAction ["MapZoomIn", _wheelUp]
+triBindAction ["MapZoomOut", _wheelDown]
+triMapSetScale _s0
+triMapWheel 1
+_s5 = triMapGetScale
+triAssertLt [_s5, _s0]
+
+triBindAction ["MapZoomIn", 0]
+triMapSetScale _s0
+triMapWheel 1
+_s6 = triMapGetScale
+triAssertEq [_s6, _s0]
 
 triEndTest

--- a/tests/unit/engine/Poseidon/Input/test_controls_category.cpp
+++ b/tests/unit/engine/Poseidon/Input/test_controls_category.cpp
@@ -57,7 +57,7 @@ TEST_CASE("ControlsCategory: Fire shows in OnFoot/Vehicles/Pilot/Gunner, not Com
     CHECK_FALSE(IsActionInControlsCategory(UAFire, ControlsCategoryCommon));
 }
 
-TEST_CASE("ControlsCategory: MapZoom lives in Common with numpad defaults", "[Input][ControlsCategory]")
+TEST_CASE("ControlsCategory: MapZoom lives in Common with numpad and wheel defaults", "[Input][ControlsCategory]")
 {
     CHECK(IsActionInControlsCategory(UAMapZoomIn, ControlsCategoryCommon));
     CHECK(IsActionInControlsCategory(UAMapZoomOut, ControlsCategoryCommon));
@@ -72,7 +72,9 @@ TEST_CASE("ControlsCategory: MapZoom lives in Common with numpad defaults", "[In
         return false;
     };
     CHECK(hasKey(UAMapZoomIn, SDL_SCANCODE_KP_PLUS));
+    CHECK(hasKey(UAMapZoomIn, INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_DOWN));
     CHECK(hasKey(UAMapZoomOut, SDL_SCANCODE_KP_MINUS));
+    CHECK(hasKey(UAMapZoomOut, INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_UP));
 }
 
 TEST_CASE("ControlsCategory: Perform Action is bindable in Gunner (#133)", "[Input][ControlsCategory]")

--- a/tests/unit/engine/Poseidon/Input/test_input_codes.cpp
+++ b/tests/unit/engine/Poseidon/Input/test_input_codes.cpp
@@ -1,6 +1,7 @@
 #include <SDL3/SDL_scancode.h>
 #include <SDL3/SDL_keycode.h>
 #include <Poseidon/Input/InputDeviceConstants.hpp>
+#include <Poseidon/Input/InputCode.hpp>
 #include <Poseidon/Input/KeyInput.hpp>
 #include <catch2/catch_test_macros.hpp>
 
@@ -60,6 +61,9 @@ TEST_CASE("Input device masks are distinct", "[input]")
     REQUIRE(INPUT_DEVICE_STICK == 0x00020000);
     REQUIRE(INPUT_DEVICE_STICK_AXIS == 0x00030000);
     REQUIRE(INPUT_DEVICE_STICK_POV == 0x00040000);
+    REQUIRE(INPUT_DEVICE_MOUSE_AXIS == 0x00100000);
     REQUIRE((INPUT_DEVICE_MOUSE & INPUT_DEVICE_MASK) == INPUT_DEVICE_MOUSE);
     REQUIRE((INPUT_DEVICE_STICK & INPUT_DEVICE_MASK) == INPUT_DEVICE_STICK);
+    REQUIRE(InputCode::MouseWheelUp().toLegacy() == 0x00100004);
+    REQUIRE(InputCode::MouseWheelDown().toLegacy() == 0x00100005);
 }

--- a/tests/unit/engine/Poseidon/UI/Settings/test_contextControlsConfig.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_contextControlsConfig.cpp
@@ -96,6 +96,47 @@ TEST_CASE("ContextControlsConfig: Save then Load preserves an empty positional s
     std::filesystem::remove(path);
 }
 
+TEST_CASE("ContextControlsConfig: version 3 adds map wheel bindings to available keyboard or mouse slots",
+          "[Settings][ContextControlsConfig]")
+{
+    REQUIRE_FIXTURE("cfg/contextControls_v3_map_wheel.cfg");
+    ContextControlsConfig migrated;
+    REQUIRE(migrated.Load(GET_FIXTURE("cfg/contextControls_v3_map_wheel.cfg")));
+    CHECK(migrated.migratedOnLoad);
+
+    const auto& infantryZoomIn = migrated.profiles[(int)InputContext::Infantry].GetBindingEntries(UAMapZoomIn);
+    REQUIRE(infantryZoomIn.size() == 2);
+    CHECK(infantryZoomIn[0].code == InputCode::Key(SDL_SCANCODE_KP_PLUS));
+    CHECK(infantryZoomIn[1].code == InputCode::MouseWheelDown());
+
+    const auto& infantryZoomOut = migrated.profiles[(int)InputContext::Infantry].GetBindingEntries(UAMapZoomOut);
+    REQUIRE(infantryZoomOut.size() == 2);
+    CHECK(infantryZoomOut[0].code == InputCode::Key(SDL_SCANCODE_KP_MINUS));
+    CHECK(infantryZoomOut[1].code == InputCode::MouseWheelUp());
+
+    const auto& menuZoomIn = migrated.profiles[(int)InputContext::Menu].GetBindingEntries(UAMapZoomIn);
+    REQUIRE(menuZoomIn.size() == 2);
+    CHECK(menuZoomIn[0].code == InputCode::Key(SDL_SCANCODE_KP_PLUS));
+    CHECK(menuZoomIn[1].code == InputCode::Key(SDL_SCANCODE_A));
+
+    const auto& editorZoomIn = migrated.profiles[(int)InputContext::Editor].GetBindingEntries(UAMapZoomIn);
+    REQUIRE(editorZoomIn.size() == 2);
+    CHECK(editorZoomIn[0].code == InputCode::MouseWheelDown());
+    CHECK(editorZoomIn[1].code == InputCode::Key(SDL_SCANCODE_A));
+    CHECK(migrated.profiles[(int)InputContext::Editor].BindingCount(UAMapZoomOut) == 0);
+
+    const std::string path = TmpPath("context_controls_v3_map_wheel_migrated.cfg");
+    REQUIRE(migrated.Save(path));
+
+    ContextControlsConfig reloaded;
+    REQUIRE(reloaded.Load(path));
+    CHECK_FALSE(reloaded.migratedOnLoad);
+    CHECK(reloaded.profiles[(int)InputContext::Infantry].BindingCount(UAMapZoomIn) == 2);
+    CHECK(reloaded.profiles[(int)InputContext::Infantry].BindingCount(UAMapZoomOut) == 2);
+
+    std::filesystem::remove(path);
+}
+
 // A real, full contextControls.cfg captured from a version-2 user profile, from
 // before several actions existed. Loading and copying the profiles is the path
 // InputSubsystem::LoadKeys runs: listed bindings are preserved, and actions the
@@ -137,7 +178,7 @@ TEST_CASE("ContextControlsConfig: an older config keeps its bindings and default
 // added since (map zoom, cheat entry). It parses across every context; the actions
 // it lists are kept, the ones it predates are seeded to their defaults, and a save
 // then reload comes up current with the fill persisted.
-TEST_CASE("ContextControlsConfig: a full version-2 config parses and migrates to 3",
+TEST_CASE("ContextControlsConfig: a full version-2 config parses and migrates to 4",
           "[Settings][ContextControlsConfig]")
 {
     REQUIRE_FIXTURE("cfg/contextControls_v2_full.cfg");

--- a/tests/unit/engine/Poseidon/UI/Settings/test_controlsConfig.cpp
+++ b/tests/unit/engine/Poseidon/UI/Settings/test_controlsConfig.cpp
@@ -54,7 +54,8 @@ TEST_CASE("ControlsConfig: LoadDefaults seeds keyboard / mouse entries from User
         {
             int code = descs[i].keys[j];
             int dev = code & 0x00ff0000;
-            if (code >= 0 && (dev == 0x00000000 || dev == 0x00010000))
+            if (code >= 0 &&
+                (dev == INPUT_DEVICE_KEYBOARD || dev == INPUT_DEVICE_MOUSE || dev == INPUT_DEVICE_MOUSE_AXIS))
                 expected++;
         }
         CAPTURE(i, expected);
@@ -64,7 +65,7 @@ TEST_CASE("ControlsConfig: LoadDefaults seeds keyboard / mouse entries from User
         for (int j = 0; j < c.bindings[i].Size(); j++)
         {
             int dev = c.bindings[i][j] & 0x00ff0000;
-            CHECK((dev == 0x00000000 || dev == 0x00010000));
+            CHECK((dev == INPUT_DEVICE_KEYBOARD || dev == INPUT_DEVICE_MOUSE || dev == INPUT_DEVICE_MOUSE_AXIS));
         }
     }
 }
@@ -79,6 +80,8 @@ TEST_CASE("ControlsConfig: Save filters out joystick-class entries", "[Settings]
     src.bindings[UAFire].Add(29);          // SDL_SCANCODE_LCTRL
     src.bindings[UAFire].Add(0x20000 + 7); // STICK + 7 — should be dropped on save
     src.bindings[UAFire].Add(0x10000 + 1); // mouse btn 1 — kept (KB&M class)
+    src.bindings[UAFire].Add(INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_UP);
+    src.modifiers[UAFire].Add(-1);
     src.modifiers[UAFire].Add(-1);
     src.modifiers[UAFire].Add(-1);
     src.modifiers[UAFire].Add(-1);
@@ -88,9 +91,10 @@ TEST_CASE("ControlsConfig: Save filters out joystick-class entries", "[Settings]
     ControlsConfig dst;
     REQUIRE(dst.Load(path));
     // Joystick-class entry got filtered; keyboard + mouse survive.
-    REQUIRE(dst.bindings[UAFire].Size() == 2);
+    REQUIRE(dst.bindings[UAFire].Size() == 3);
     CHECK(dst.bindings[UAFire][0] == 29);
     CHECK(dst.bindings[UAFire][1] == 0x10000 + 1);
+    CHECK(dst.bindings[UAFire][2] == INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_UP);
 
     std::filesystem::remove(path);
 }

--- a/tests/unit/engine/Poseidon/UI/test_displayUI.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_displayUI.cpp
@@ -34,6 +34,12 @@ TEST_CASE("displayUI names double-tap keyboard and mouse bindings", "[UI][displa
     CHECK(std::string((const char*)GetKeyName(InputBindingDoubleTapCode(INPUT_DEVICE_MOUSE + 1))).find("2x ") == 0);
 }
 
+TEST_CASE("displayUI names mouse wheel bindings", "[UI][displayUI]")
+{
+    CHECK(std::string((const char*)GetKeyName(INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_UP)) == "Mouse wheel up");
+    CHECK(std::string((const char*)GetKeyName(INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_DOWN)) == "Mouse wheel down");
+}
+
 TEST_CASE("stalled client abort uses a disconnect-only debriefing", "[UI][multiplayer][disconnect]")
 {
     CHECK(ResolveClientDebriefingMode(true, true, false) == ClientDebriefingMode::DisconnectOnly);

--- a/tests/unit/engine/Poseidon/UI/test_gamepad_page.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_gamepad_page.cpp
@@ -136,6 +136,8 @@ TEST_CASE("GamepadPage: device filter rejects keyboard scancodes and mouse butto
     CHECK_FALSE(page.Filter((int)SDL_SCANCODE_LCTRL));
     CHECK_FALSE(page.Filter(INPUT_DEVICE_MOUSE + 1));
     CHECK_FALSE(page.Filter(INPUT_DEVICE_MOUSE + 2));
+    CHECK_FALSE(page.Filter(INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_UP));
+    CHECK_FALSE(page.Filter(INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_DOWN));
     CHECK_FALSE(page.Filter(-1));
     CHECK_FALSE(page.Filter(0));
 }

--- a/tests/unit/engine/Poseidon/UI/test_kbm_page.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_kbm_page.cpp
@@ -17,6 +17,7 @@
 #include <Poseidon/UI/Locale/Stringtable/Stringtable.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
 #include <filesystem>
 #include <SDL3/SDL_scancode.h>
 #include <catch2/catch_message.hpp>
@@ -34,14 +35,11 @@ namespace
 class UserKeysSnapshot
 {
   public:
-    UserKeysSnapshot()
-        : savedContext(InputSubsystem::Instance().GetContext()),
-          savedMenuProfile(InputSubsystem::Instance().GetProfile(InputContext::Menu)),
-          savedInfantryProfile(InputSubsystem::Instance().GetProfile(InputContext::Infantry)),
-          savedCarProfile(InputSubsystem::Instance().GetProfile(InputContext::CarDriver)),
-          savedTankProfile(InputSubsystem::Instance().GetProfile(InputContext::TankDriver)),
-          savedShipProfile(InputSubsystem::Instance().GetProfile(InputContext::ShipDriver))
+    UserKeysSnapshot() : savedContext(InputSubsystem::Instance().GetContext())
     {
+        auto& sub = InputSubsystem::Instance();
+        for (int c = 0; c < (int)InputContext::Count; ++c)
+            savedProfiles[c] = sub.GetProfile((InputContext)c);
         for (int i = 0; i < UAN; i++)
             saved[i] = GInput.userKeys[i];
     }
@@ -49,22 +47,15 @@ class UserKeysSnapshot
     {
         auto& sub = InputSubsystem::Instance();
         sub.SetContext(savedContext);
-        sub.GetProfile(InputContext::Menu) = savedMenuProfile;
-        sub.GetProfile(InputContext::Infantry) = savedInfantryProfile;
-        sub.GetProfile(InputContext::CarDriver) = savedCarProfile;
-        sub.GetProfile(InputContext::TankDriver) = savedTankProfile;
-        sub.GetProfile(InputContext::ShipDriver) = savedShipProfile;
+        for (int c = 0; c < (int)InputContext::Count; ++c)
+            sub.GetProfile((InputContext)c) = savedProfiles[c];
         for (int i = 0; i < UAN; i++)
             GInput.userKeys[i] = saved[i];
     }
 
   private:
     InputContext savedContext;
-    InputProfile savedMenuProfile;
-    InputProfile savedInfantryProfile;
-    InputProfile savedCarProfile;
-    InputProfile savedTankProfile;
-    InputProfile savedShipProfile;
+    std::array<InputProfile, (int)InputContext::Count> savedProfiles;
     AutoArray<int> saved[UAN];
 };
 
@@ -107,7 +98,7 @@ int RowForCommonAction(UserAction action)
 }
 } // namespace
 
-TEST_CASE("KbmPage: device filter accepts keyboard scancodes, mouse buttons", "[UI][KbmPage]")
+TEST_CASE("KbmPage: device filter accepts keyboard and mouse bindings", "[UI][KbmPage]")
 {
     TestableKbmPage page;
     // Keyboard scancodes (low values).
@@ -117,6 +108,8 @@ TEST_CASE("KbmPage: device filter accepts keyboard scancodes, mouse buttons", "[
     // Mouse buttons (INPUT_DEVICE_MOUSE = 0x40000).
     CHECK(page.Filter(INPUT_DEVICE_MOUSE + 1));
     CHECK(page.Filter(INPUT_DEVICE_MOUSE + 2));
+    CHECK(page.Filter(INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_UP));
+    CHECK(page.Filter(INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_DOWN));
     // Negative codes are rejected.
     CHECK_FALSE(page.Filter(-1));
 }
@@ -298,5 +291,36 @@ TEST_CASE("KbmPage: vehicle movement capture writes driver profiles", "[UI][KbmP
         CHECK(bindings[0].code.toLegacy() == doubleH);
         CHECK_FALSE(profile.HasBinding(UAMoveForward, InputCode::Key(SDL_SCANCODE_W)));
         CHECK(profile.HasBinding(UAMoveForward, InputCode::Key(SDL_SCANCODE_UP)));
+    }
+}
+
+TEST_CASE("KbmPage: replacing conflicts swaps map wheel directions", "[UI][KbmPage]")
+{
+    UserKeysSnapshot snap;
+    TestableKbmPage page;
+    page.Provider().SetRowValue(0, (int)ControlsCategoryCommon);
+
+    auto& sub = InputSubsystem::Instance();
+    for (int c = 0; c < (int)InputContext::Count; ++c)
+    {
+        InputProfile& profile = sub.GetProfile((InputContext)c);
+        profile.ClearBindings(UAMapZoomIn);
+        profile.Bind(UAMapZoomIn, InputCode::Key(SDL_SCANCODE_KP_PLUS));
+        profile.Bind(UAMapZoomIn, InputCode::MouseWheelDown());
+        profile.ClearBindings(UAMapZoomOut);
+        profile.Bind(UAMapZoomOut, InputCode::Key(SDL_SCANCODE_KP_MINUS));
+        profile.Bind(UAMapZoomOut, InputCode::MouseWheelUp());
+    }
+
+    page.Capture(UAMapZoomIn, 1, InputCode::MouseWheelUp().toLegacy(), -1, true);
+    page.Capture(UAMapZoomOut, 1, InputCode::MouseWheelDown().toLegacy(), -1, true);
+
+    for (int c = 0; c < (int)InputContext::Count; ++c)
+    {
+        const InputProfile& profile = sub.GetProfile((InputContext)c);
+        CHECK(profile.HasBinding(UAMapZoomIn, InputCode::MouseWheelUp()));
+        CHECK_FALSE(profile.HasBinding(UAMapZoomIn, InputCode::MouseWheelDown()));
+        CHECK(profile.HasBinding(UAMapZoomOut, InputCode::MouseWheelDown()));
+        CHECK_FALSE(profile.HasBinding(UAMapZoomOut, InputCode::MouseWheelUp()));
     }
 }

--- a/tests/unit/engine/Poseidon/UI/test_press_key_page.cpp
+++ b/tests/unit/engine/Poseidon/UI/test_press_key_page.cpp
@@ -48,7 +48,7 @@ class HeldKey
 class TestPressKeyPage : public PressKeyPage
 {
   public:
-    explicit TestPressKeyPage(CaptureResult& result)
+    explicit TestPressKeyPage(CaptureResult& result, bool allowMouseWheel = false)
         : PressKeyPage(
               "Test Action", "Primary",
               [&result](int packedCode, int modifier, bool replaceConflict)
@@ -58,7 +58,7 @@ class TestPressKeyPage : public PressKeyPage
                   result.replaceConflict = replaceConflict;
                   ++result.saveCalls;
               },
-              [](int, int) { return UAN; })
+              [](int, int) { return UAN; }, allowMouseWheel)
     {
     }
 
@@ -147,6 +147,27 @@ TEST_CASE("PressKeyPage simulate captures a pending mouse button", "[UI][PressKe
 
     CHECK(result.saveCalls == 1);
     CHECK(result.savedCode == INPUT_DEVICE_MOUSE + 2);
+    CHECK(result.savedModifier == -1);
+}
+
+TEST_CASE("PressKeyPage captures mouse wheel direction when enabled", "[UI][PressKeyPage]")
+{
+    TestableOptionsShell shell;
+    CaptureResult result;
+    auto page = std::make_unique<TestPressKeyPage>(result, true);
+    TestPressKeyPage* raw = page.get();
+
+    shell.PushPage(std::move(page));
+
+    GInput.mouse.deltaZ = -1.0f;
+    raw->Simulate(shell);
+    GInput.mouse.deltaZ = 0.0f;
+
+    REQUIRE_FALSE(raw->Listening());
+    raw->OnButtonClicked(shell, 9301);
+
+    CHECK(result.saveCalls == 1);
+    CHECK(result.savedCode == INPUT_DEVICE_MOUSE_AXIS + INPUT_MOUSE_WHEEL_DOWN);
     CHECK(result.savedModifier == -1);
 }
 


### PR DESCRIPTION
Make mouse-wheel directions bindable for map zoom while keeping the current defaults. Migrate available keyboard and mouse slots without replacing custom bindings.

<img width="1311" height="1039" alt="image" src="https://github.com/user-attachments/assets/89ddf313-8f64-4d17-aa0b-16abf0dbcb23" />
