### PR TITLE
Resolve mod file paths that escape their own prefix

### DIFF
--- a/engine/Poseidon/IO/Streams/QBStream.cpp
+++ b/engine/Poseidon/IO/Streams/QBStream.cpp
@@ -132,9 +132,9 @@ bool ResolveModOverrideCallback(RStringB dir, void* opaque)
     return true;
 }
 
-// Collapse "<seg>/.." and strip a leading "addons" so a root-relative intro path
-// ("anims/..\addons\<island>\intro.<world>\...") maps into island <island>'s bank; "" otherwise.
-std::string NormalizeAddonBankPath(const char* name)
+// Collapse "<seg>/.." pairs into a backslash-joined path. Empty when the name holds no "..",
+// or when a ".." would climb above the first component.
+std::string CollapseParentDirs(const char* name)
 {
     if (!name || !strstr(name, ".."))
         return {};
@@ -159,17 +159,26 @@ std::string NormalizeAddonBankPath(const char* name)
         p = sep + 1;
     }
 
-    if (parts.size() < 2 || !EqualPathComponent(parts[0], "addons", 6))
-        return {};
-
     std::string out;
-    for (size_t i = 1; i < parts.size(); ++i)
+    for (const std::string& part : parts)
     {
         if (!out.empty())
             out += '\\';
-        out += parts[i];
+        out += part;
     }
     return out;
+}
+
+// Strip a leading "addons" off a collapsed path so a root-relative intro path
+// ("anims/..\addons\<island>\intro.<world>\...") maps into island <island>'s bank; "" otherwise.
+std::string NormalizeAddonBankPath(const char* name)
+{
+    const std::string collapsed = CollapseParentDirs(name);
+    const size_t sep = collapsed.find('\\');
+    if (sep == std::string::npos || !EqualPathComponent(collapsed.substr(0, sep), "addons", 6))
+        return {};
+
+    return collapsed.substr(sep + 1);
 }
 } // namespace
 
@@ -1540,6 +1549,28 @@ void QIFStreamB::AutoOpen(const char* name, IQFBankContext* context)
         }
     }
 
+    // A path can leave its own prefix and re-enter by mod folder name
+    // ("voice\..\<mod>\voice\..."); only the collapsed form names a mod root.
+    const std::string collapsed = CollapseParentDirs(name0);
+    if (!collapsed.empty())
+    {
+        QIFStream::open(collapsed.c_str());
+        if (_sharedData && !_sharedData->GetError())
+        {
+            return;
+        }
+
+        std::string collapsedAlias = ResolveModRootAlias(collapsed.c_str());
+        if (!collapsedAlias.empty())
+        {
+            QIFStream::open(collapsedAlias.c_str());
+            if (_sharedData && !_sharedData->GetError())
+            {
+                return;
+            }
+        }
+    }
+
     if (GUseFileBanks)
     {
         std::string norm = NormalizeAddonBankPath(name0);
@@ -1606,6 +1637,19 @@ bool QIFStreamB::FileExist(const char* name, IQFBankContext* context)
     if (!modAlias.empty())
     {
         return true;
+    }
+
+    const std::string collapsed = CollapseParentDirs(name);
+    if (!collapsed.empty())
+    {
+        if (QIFStream::FileExists(collapsed.c_str()))
+        {
+            return true;
+        }
+        if (!ResolveModRootAlias(collapsed.c_str()).empty())
+        {
+            return true;
+        }
     }
 
     if (GUseFileBanks)

--- a/tests/unit/engine/Poseidon/IO/Streams/test_qstream_path_resolution.cpp
+++ b/tests/unit/engine/Poseidon/IO/Streams/test_qstream_path_resolution.cpp
@@ -5,6 +5,7 @@
 // on Linux.
 
 #include <catch2/catch_test_macros.hpp>
+#include <Poseidon/Core/ModSystem.hpp>
 #include <Poseidon/IO/Filesystem/Utf8Paths.hpp>
 #include <Poseidon/IO/Streams/QBStream.hpp>
 #include <Poseidon/IO/Streams/QStream.hpp>
@@ -276,6 +277,29 @@ TEST_CASE("QIFStream FileExists - backslash path on Linux", "[qstream][path][fil
 #endif
 
 // QIFStreamB::FileExist – bank + filesystem lookup
+
+// A path naming its mod folder through a parent escape resolves into that mod.
+TEST_CASE("QIFStreamB FileExist - mod path escaping its prefix", "[qstream][path][bankexist][mod]")
+{
+    const std::filesystem::path root = std::filesystem::temp_directory_path() / "cwr_modescape";
+    const std::filesystem::path voiceDir = root / "@voicemod" / "voice" / "Jari";
+    const char payload[] = "wss";
+
+    std::error_code ec;
+    std::filesystem::remove_all(root, ec);
+    REQUIRE(std::filesystem::create_directories(voiceDir, ec));
+    REQUIRE(Poseidon::WriteFileUtf8((voiceDir / "reportstatus.wss").string().c_str(), payload, sizeof(payload)));
+
+    Poseidon::ModSystem::SetModPath((root / "@voicemod").string().c_str());
+
+    CHECK(QIFStreamB::FileExist("@voicemod\\voice\\Jari\\reportstatus.wss"));
+    CHECK(QIFStreamB::FileExist("voice\\..\\@voicemod\\voice\\Jari\\reportstatus.wss"));
+    CHECK_FALSE(QIFStreamB::FileExist("voice\\..\\@voicemod\\voice\\Adam\\reportstatus.wss"));
+    CHECK_FALSE(QIFStreamB::FileExist("..\\@voicemod\\voice\\Jari\\reportstatus.wss"));
+
+    Poseidon::ModSystem::SetModPath("");
+    std::filesystem::remove_all(root, ec);
+}
 
 TEST_CASE("QIFStreamB FileExist - filesystem fallback", "[qstream][path][bankexist]")
 {


### PR DESCRIPTION
A mod can name its own folder through a parent escape such as `voice\..\<mod>\voice\...`. The file lookup only collapsed those segments for `addons` paths, so every other escape missed and the file was never found.

Fixes issues with FDF radio protocol loading from separate directory (when mod is not in the game folder itself).