### PR TITLE
Log an abstract entity type once per type

### DIFF
--- a/engine/Poseidon/AI/AIGroupImpl.cpp
+++ b/engine/Poseidon/AI/AIGroupImpl.cpp
@@ -39,6 +39,20 @@
 
 namespace Poseidon
 {
+namespace
+{
+// The center channel is shared by every group on a side, so a command from another group is
+// expected there.
+void ReportForeignRadioCommand(bool fromThisGroup, bool channelCenter)
+{
+    if (fromThisGroup)
+        return;
+
+    const char* channel = channelCenter ? "center" : "group";
+    LOG_WARN_ONCE_PER(AI, channel, "Radio command in the {} channel was sent by another group", channel);
+}
+} // namespace
+
 using namespace Foundation;
 
 // Parameters
@@ -200,7 +214,7 @@ bool AIGroup::CommandSent(AIUnit* to, Command::Message message, bool channelCent
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        AI_ERROR(msgCmd->GetFrom() == this);
+        ReportForeignRadioCommand(msgCmd->GetFrom() == this, channelCenter);
         if (msgCmd->IsTo(to) && msgCmd->GetCmdMessage() == message)
         {
             return true;
@@ -213,7 +227,7 @@ bool AIGroup::CommandSent(AIUnit* to, Command::Message message, bool channelCent
         AI_ERROR(dynamic_cast<RadioMessageCommand*>(msg));
         RadioMessageCommand* msgCmd = static_cast<RadioMessageCommand*>(msg);
         AI_ERROR(msgCmd);
-        AI_ERROR(msgCmd->GetFrom() == this);
+        ReportForeignRadioCommand(msgCmd->GetFrom() == this, channelCenter);
         if (msgCmd->IsTo(to) && msgCmd->GetCmdMessage() == message)
         {
             return true;

--- a/engine/Poseidon/AI/VehicleAI.cpp
+++ b/engine/Poseidon/AI/VehicleAI.cpp
@@ -1121,7 +1121,12 @@ EntityAI::EntityAI(EntityAIType* type, bool fullCreate)
     }
 
     AI_ERROR(type);
-    AI_ERROR(!type->IsAbstract());
+    // Islands legitimately place scope-0 objects.
+    if (type && type->IsAbstract())
+    {
+        LOG_WARN_ONCE_PER(AI, type->GetName(), "Entity created from abstract type '{}' (logged once per type)",
+                          (const char*)type->GetName());
+    }
     AI_ERROR(_shape == type->_shape);
 
     if (fullCreate)

--- a/engine/Poseidon/Foundation/Framework/Log.hpp
+++ b/engine/Poseidon/Foundation/Framework/Log.hpp
@@ -49,6 +49,15 @@ inline spdlog::logger* Get(Poseidon::Foundation::LogCategory cat)
 }
 } // namespace LogDetail
 
+namespace Poseidon::Foundation
+{
+// True the first time a call site is reached with a given key. Keys accumulate for the process
+// lifetime, so log with a bounded key set such as a config class name.
+bool LogOnceForKey(const void* site, const char* key);
+
+void ForgetLogOnceKeys();
+} // namespace Poseidon::Foundation
+
 #define LOG_TRACE(category, ...) \
     LogDetail::Get(::Poseidon::Foundation::LogCategory::category)->log(spdlog::source_loc{}, spdlog::level::trace, __VA_ARGS__)
 #define LOG_DEBUG(category, ...) \
@@ -59,3 +68,10 @@ inline spdlog::logger* Get(Poseidon::Foundation::LogCategory cat)
     LogDetail::Get(::Poseidon::Foundation::LogCategory::category)->log(spdlog::source_loc{}, spdlog::level::warn, __VA_ARGS__)
 #define LOG_ERROR(category, ...) \
     LogDetail::Get(::Poseidon::Foundation::LogCategory::category)->log(spdlog::source_loc{}, spdlog::level::err, __VA_ARGS__)
+
+#define LOG_WARN_ONCE_PER(category, key, ...)                           \
+    {                                                                   \
+        static const char logOnceSite = 0;                              \
+        if (::Poseidon::Foundation::LogOnceForKey(&logOnceSite, (key))) \
+            LOG_WARN(category, __VA_ARGS__);                            \
+    }

--- a/engine/Poseidon/Foundation/Logging/Logging.cpp
+++ b/engine/Poseidon/Foundation/Logging/Logging.cpp
@@ -22,6 +22,7 @@
 #include <ctime>
 #include <mutex>
 #include <ratio>
+#include <set>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -816,4 +817,25 @@ void LoggingSystem::InitializeFromConfig(const char* appPrefix)
     }
 }
 
+} // namespace Poseidon::Foundation
+
+namespace Poseidon::Foundation
+{
+namespace
+{
+std::mutex g_logOnceLock;
+std::set<std::pair<const void*, std::string>, std::less<>> g_logOnceKeys;
+} // namespace
+
+bool LogOnceForKey(const void* site, const char* key)
+{
+    const std::lock_guard<std::mutex> lock(g_logOnceLock);
+    return g_logOnceKeys.emplace(site, key ? key : "").second;
+}
+
+void ForgetLogOnceKeys()
+{
+    const std::lock_guard<std::mutex> lock(g_logOnceLock);
+    g_logOnceKeys.clear();
+}
 } // namespace Poseidon::Foundation

--- a/tests/unit/engine/Poseidon/AI/test_vehicle_ai.cpp
+++ b/tests/unit/engine/Poseidon/AI/test_vehicle_ai.cpp
@@ -189,3 +189,27 @@ TEST_CASE("NET_ERROR / AI_ERROR log and continue", "[network][logerror][.]")
     AI_ERROR(2 + 2 == 5);  // fails — LOG_ERROR(AI,      "... check failed: 2 + 2 == 5")
     SUCCEED("neither macro aborted the process");
 }
+
+// One log line per key at a call site, however many times that site is reached.
+TEST_CASE("LogOnceForKey - one report per key per site", "[logging][logonce]")
+{
+    using Poseidon::Foundation::ForgetLogOnceKeys;
+    using Poseidon::Foundation::LogOnceForKey;
+
+    static const char siteA = 0;
+    static const char siteB = 0;
+
+    ForgetLogOnceKeys();
+
+    CHECK(LogOnceForKey(&siteA, "FDF_MastoLightRed"));
+    CHECK_FALSE(LogOnceForKey(&siteA, "FDF_MastoLightRed"));
+    CHECK_FALSE(LogOnceForKey(&siteA, "FDF_MastoLightRed"));
+
+    CHECK(LogOnceForKey(&siteA, "FDF_MastoLightWhite"));
+    CHECK_FALSE(LogOnceForKey(&siteA, "FDF_MastoLightWhite"));
+
+    CHECK(LogOnceForKey(&siteB, "FDF_MastoLightRed"));
+
+    ForgetLogOnceKeys();
+    CHECK(LogOnceForKey(&siteA, "FDF_MastoLightRed"));
+}


### PR DESCRIPTION
An island can place objects whose class carries `scope = private`, and every instance logged a check failure naming neither the type nor the object. `LOG_WARN_ONCE_PER` keeps any call site to one line per key making logger elss annoying by default.