### PR TITLE
Fix stretched cursor on widescreen

### DIFF
--- a/engine/Poseidon/UI/Controls/CursorLayout.cpp
+++ b/engine/Poseidon/UI/Controls/CursorLayout.cpp
@@ -1,0 +1,47 @@
+#include <Poseidon/UI/Controls/CursorLayout.hpp>
+
+#include <Poseidon/Foundation/Common/FltOpts.hpp>
+#include <Poseidon/UI/LayoutCanvas.hpp>
+
+namespace Poseidon
+{
+namespace CursorLayout
+{
+Rect ComputeRect(const Metrics& cursor, float mouseScrX, float mouseScrY, int viewportWidth, int viewportHeight)
+{
+    // A cursor keeps its declared shape only when both axes scale off the same
+    // viewport edge.
+    const float cursorPxW = LayoutCanvas::FractionOfHeight(cursor.width) * viewportHeight;
+    const float cursorPxH = LayoutCanvas::FractionOfHeight(cursor.height) * viewportHeight;
+
+    Rect rect;
+    rect.x = toInt(mouseScrX * viewportWidth - cursor.hotspotX * cursorPxW);
+    rect.y = toInt(mouseScrY * viewportHeight - cursor.hotspotY * cursorPxH);
+    rect.w = toInt(cursorPxW);
+    rect.h = toInt(cursorPxH);
+    return rect;
+}
+
+Size RescaleForFOV(const Size& canvasSize, float leftFOV, float topFOV)
+{
+    Size size;
+    size.w = canvasSize.w * (LayoutCanvas::kBaseLeftFov / leftFOV);
+    size.h = canvasSize.h * (LayoutCanvas::kBaseTopFov / topFOV);
+    return size;
+}
+
+Size ProjectedSize(float layoutUnits, float leftFOV, float topFOV)
+{
+    const Size canvasSize{LayoutCanvas::FractionOfWidth(layoutUnits), LayoutCanvas::FractionOfHeight(layoutUnits)};
+    return RescaleForFOV(canvasSize, leftFOV, topFOV);
+}
+
+float SquareWidthFraction(float heightFraction, int viewportWidth, int viewportHeight)
+{
+    if (viewportWidth <= 0)
+        return heightFraction;
+    return heightFraction * viewportHeight / viewportWidth;
+}
+
+} // namespace CursorLayout
+} // namespace Poseidon

--- a/engine/Poseidon/UI/Controls/CursorLayout.hpp
+++ b/engine/Poseidon/UI/Controls/CursorLayout.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+namespace Poseidon
+{
+namespace CursorLayout
+{
+// Cursor geometry as declared by CfgWrapperUI >> Cursors: size in layout units,
+// hotspot as a fraction of the drawn size.
+struct Metrics
+{
+    float width = 0.0f;
+    float height = 0.0f;
+    float hotspotX = 0.0f;
+    float hotspotY = 0.0f;
+};
+
+struct Rect
+{
+    int x = 0;
+    int y = 0;
+    int w = 0;
+    int h = 0;
+};
+
+// mouseScrX/mouseScrY are 0..1 across the 2D viewport (Engine::Width2D/Height2D).
+Rect ComputeRect(const Metrics& cursor, float mouseScrX, float mouseScrY, int viewportWidth, int viewportHeight);
+
+// A size held as 0..1 fractions of the viewport.
+struct Size
+{
+    float w = 0.0f;
+    float h = 0.0f;
+};
+
+// Rescale a size authored against the layout canvas onto the canvas the given
+// FOV half-extents actually project.
+Size RescaleForFOV(const Size& canvasSize, float leftFOV, float topFOV);
+
+// Size of a world-projected cursor of layoutUnits square.
+Size ProjectedSize(float layoutUnits, float leftFOV, float topFOV);
+
+// Fraction of the viewport width covering the same number of device pixels as
+// heightFraction covers of the viewport height.
+float SquareWidthFraction(float heightFraction, int viewportWidth, int viewportHeight);
+
+} // namespace CursorLayout
+} // namespace Poseidon

--- a/engine/Poseidon/UI/InGame/InGameUIDrawCursor.cpp
+++ b/engine/Poseidon/UI/InGame/InGameUIDrawCursor.cpp
@@ -4,6 +4,8 @@
 #include <Poseidon/AI/AI.hpp>
 #include <Poseidon/Input/InputSubsystem.hpp>
 #include <Poseidon/UI/InGame/InGameUIImpl.hpp>
+#include <Poseidon/UI/Controls/CursorLayout.hpp>
+#include <Poseidon/UI/LayoutCanvas.hpp>
 #include <Poseidon/Graphics/Core/Engine.hpp>
 #include <Poseidon/World/Scene/Camera/Camera.hpp>
 #include <Poseidon/World/Terrain/Visibility.hpp>
@@ -35,6 +37,9 @@
 
 namespace Poseidon
 {
+
+// Size the in-game cursors are drawn at, in layout units.
+static constexpr float kCursorUnits = 32.0f;
 
 AIUnit* GetSelectedUnit(int i);
 
@@ -179,12 +184,12 @@ bool InGameUI::DrawTargetInfo(const Camera& camera, AIUnit* unit, Vector3Par dir
 
     Vector3Val mDir = camInvTransform.Rotate(dir);
 
-    // width/height assume fovLeft/fovTop = 1/0.75
     AspectSettings asp;
     GEngine->GetAspectSettings(asp);
 
-    const float mScrH = 32.0f / (800 * asp.topFOV);
-    const float mScrW = 32.0f / (800 * asp.leftFOV);
+    const CursorLayout::Size cursorSize = CursorLayout::ProjectedSize(kCursorUnits, asp.leftFOV, asp.topFOV);
+    const float mScrH = cursorSize.h;
+    const float mScrW = cursorSize.w;
 
     float cx, cy;
     {
@@ -698,11 +703,11 @@ bool InGameUI::DrawTargetInfo(const Camera& camera, AIUnit* unit, Vector3Par dir
 void InGameUI::DrawCursor(const Camera& camera, EntityAI* vehicle, Vector3Val dir, float size, Texture* texture,
                           float width, float height, PackedColor color, bool drawInTD, CursorTexts texts)
 {
-    // width/height assume fovLeft/fovTop = 1/0.75
     AspectSettings asp;
     GEngine->GetAspectSettings(asp);
-    width *= 1.0f / asp.leftFOV;
-    height *= 0.75f / asp.topFOV;
+    const CursorLayout::Size drawn = CursorLayout::RescaleForFOV({width, height}, asp.leftFOV, asp.topFOV);
+    width = drawn.w;
+    height = drawn.h;
 
     const int w3d = GLOB_ENGINE->Width();
     const int h3d = GLOB_ENGINE->Height();
@@ -1006,8 +1011,12 @@ void InGameUI::DrawHUDNonAI(const Camera& camera, Entity* vehicle, CameraType ca
 
             Matrix4Val camInvTransform = camera.GetInvTransform();
 
-            const float mScrH = 32.0 / 600;
-            const float mScrW = 32.0 / 800;
+            AspectSettings asp;
+            GEngine->GetAspectSettings(asp);
+
+            const CursorLayout::Size cursorSize = CursorLayout::ProjectedSize(kCursorUnits, asp.leftFOV, asp.topFOV);
+            const float mScrH = cursorSize.h;
+            const float mScrW = cursorSize.w;
 
             float cx, cy;
             Vector3 pos = camInvTransform.Rotate(newDir);
@@ -1523,8 +1532,8 @@ void InGameUI::DrawHUD(const Camera& camera, EntityAI* vehicle, CameraType cam)
     if (_showCursors)
     {
         // draw weapon cursor
-        const float mouseScrH = 32.0 / 600;
-        const float mouseScrW = 32.0 / 800;
+        const float mouseScrH = LayoutCanvas::FractionOfHeight(kCursorUnits);
+        const float mouseScrW = LayoutCanvas::FractionOfWidth(kCursorUnits);
 
         int weapon = vehicle->SelectedWeapon();
         if (weapon >= 0 && weapon < vehicle->NMagazineSlots() && vehicle->GetMagazineSlot(weapon)._magazine &&

--- a/engine/Poseidon/UI/LayoutCanvas.hpp
+++ b/engine/Poseidon/UI/LayoutCanvas.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace Poseidon
+{
+namespace LayoutCanvas
+{
+// UI geometry is authored in layout units against a fixed 800x600 canvas and
+// mapped onto the real viewport at draw time.
+inline constexpr float kWidth = 800.0f;
+inline constexpr float kHeight = 600.0f;
+
+inline constexpr float kRatio = kWidth / kHeight;
+
+// AspectSettings normalizes both FOV half-extents against the canvas width, so
+// the canvas itself sits at leftFOV 1 and topFOV 600/800.
+inline constexpr float kBaseLeftFov = 1.0f;
+inline constexpr float kBaseTopFov = kHeight / kWidth;
+
+constexpr float FractionOfWidth(float layoutUnits)
+{
+    return layoutUnits / kWidth;
+}
+
+constexpr float FractionOfHeight(float layoutUnits)
+{
+    return layoutUnits / kHeight;
+}
+
+} // namespace LayoutCanvas
+} // namespace Poseidon

--- a/engine/Poseidon/UI/Map/UIContainers.cpp
+++ b/engine/Poseidon/UI/Map/UIContainers.cpp
@@ -1459,7 +1459,7 @@ void ControlsContainer::DrawCursor()
     const int h = GLOB_ENGINE->Height2D();
     int mx = toInt((mouseScrX - hsX * mouseScrW) * w);
     int my = toInt((mouseScrY - hsY * mouseScrH) * h);
-    int mw = toInt(mouseScrW * w);
+    int mw = toInt(mouseScrW * (4.0f / 3.0f) * h);
     int mh = toInt(mouseScrH * h);
 
     CursorDrawDebug::Record(this, mx, my, mw, mh);

--- a/engine/Poseidon/UI/Map/UIContainers.cpp
+++ b/engine/Poseidon/UI/Map/UIContainers.cpp
@@ -1,5 +1,6 @@
 
 #include <Poseidon/UI/Controls/UIControls.hpp>
+#include <Poseidon/UI/Controls/CursorLayout.hpp>
 #include <Poseidon/Input/ControllerUiLayout.hpp>
 #include <Poseidon/Input/InputSubsystem.hpp>
 #include <Poseidon/Graphics/Core/Engine.hpp>
@@ -1448,24 +1449,23 @@ void ControlsContainer::DrawCursor()
     Texture* texture = GetCursorTexture();
 
     PackedColor color = GetCursorColor();
-    float hsX = GetCursorX();
-    float hsY = GetCursorY();
 
-    const float mouseScrH = GetCursorH() / 600;
-    const float mouseScrW = GetCursorW() / 800;
+    CursorLayout::Metrics metrics;
+    metrics.width = GetCursorW();
+    metrics.height = GetCursorH();
+    metrics.hotspotX = GetCursorX();
+    metrics.hotspotY = GetCursorY();
+
     float mouseScrX = InputSubsystem::Instance().GetCursorX() * 0.5 + 0.5;
     float mouseScrY = InputSubsystem::Instance().GetCursorY() * 0.5 + 0.5;
-    const int w = GLOB_ENGINE->Width2D();
-    const int h = GLOB_ENGINE->Height2D();
-    int mx = toInt((mouseScrX - hsX * mouseScrW) * w);
-    int my = toInt((mouseScrY - hsY * mouseScrH) * h);
-    int mw = toInt(mouseScrW * (4.0f / 3.0f) * h);
-    int mh = toInt(mouseScrH * h);
 
-    CursorDrawDebug::Record(this, mx, my, mw, mh);
+    const CursorLayout::Rect rect =
+        CursorLayout::ComputeRect(metrics, mouseScrX, mouseScrY, GLOB_ENGINE->Width2D(), GLOB_ENGINE->Height2D());
+
+    CursorDrawDebug::Record(this, rect.x, rect.y, rect.w, rect.h);
 
     MipInfo mip = GLOB_ENGINE->TextBank()->UseMipmap(texture, 0, 0);
-    GLOB_ENGINE->Draw2D(mip, color, Rect2DPixel(mx, my, mw, mh));
+    GLOB_ENGINE->Draw2D(mip, color, Rect2DPixel(rect.x, rect.y, rect.w, rect.h));
 }
 
 namespace CursorDrawDebug

--- a/engine/Poseidon/UI/Map/UIMap.cpp
+++ b/engine/Poseidon/UI/Map/UIMap.cpp
@@ -3,6 +3,8 @@
 #include <Poseidon/Core/Config/EngineConfig.hpp>
 #include <Poseidon/Core/Config/UserConfig.hpp>
 #include <Poseidon/UI/Map/UIMap.hpp>
+#include <Poseidon/UI/Controls/CursorLayout.hpp>
+#include <Poseidon/UI/LayoutCanvas.hpp>
 #include <Poseidon/UI/Locale/Stringtable/CodepageTranscode.hpp>
 #include <Poseidon/UI/Locale/Stringtable/Stringtable.hpp>
 // #include "win.h"
@@ -2162,8 +2164,8 @@ void CStaticMap::OnDraw(float alpha)
         {
             int wScreen = GLOB_ENGINE->Width2D();
             int hScreen = GLOB_ENGINE->Height2D();
-            const float mouseH = 16.0 / 600;
-            const float mouseW = 16.0 / 800;
+            const float mouseH = LayoutCanvas::FractionOfHeight(16.0f);
+            const float mouseW = CursorLayout::SquareWidthFraction(mouseH, wScreen, hScreen);
             float mouseX = 0.5 + InputSubsystem::Instance().GetCursorX() * 0.5;
             float mouseY = 0.5 + InputSubsystem::Instance().GetCursorY() * 0.5;
             PackedColor color = _parent->GetCursorColor();

--- a/engine/Poseidon/UI/Settings/AspectRatio.cpp
+++ b/engine/Poseidon/UI/Settings/AspectRatio.cpp
@@ -1,5 +1,7 @@
 #include <Poseidon/UI/Settings/AspectRatio.hpp>
 
+#include <Poseidon/UI/LayoutCanvas.hpp>
+
 #include <cmath>
 #include <limits>
 
@@ -9,9 +11,9 @@ namespace AspectRatio
 {
 namespace
 {
-constexpr float kBaseLeftFov = 1.0f;
-constexpr float kBaseTopFov = 0.75f;
-constexpr float kBaseRatio = 4.0f / 3.0f;
+constexpr float kBaseLeftFov = LayoutCanvas::kBaseLeftFov;
+constexpr float kBaseTopFov = LayoutCanvas::kBaseTopFov;
+constexpr float kBaseRatio = LayoutCanvas::kRatio;
 constexpr float kModernFullWidthUiMaxRatio = 16.0f / 9.0f;
 // Tolerance band above the 16:9 ratio so a one-or-two-pixel surplus
 // in the actual surface (NVIDIA fullscreen sometimes resolves to

--- a/engine/Poseidon/UI/Text/ScreenTextLayout.hpp
+++ b/engine/Poseidon/UI/Text/ScreenTextLayout.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Poseidon/UI/Text/FontRenderer.hpp>
+#include <Poseidon/UI/LayoutCanvas.hpp>
 
 
 namespace Poseidon
@@ -35,7 +36,7 @@ inline bool ComputeScreenTextBaseScale(float viewportHeight2D, int surfaceWidthP
         legacyFontHeight <= 0.0f)
         return false;
 
-    out->sizeH = viewportHeight2D * sizeEx * (1.0f / 600.0f) / legacyFontHeight;
+    out->sizeH = viewportHeight2D * sizeEx * (1.0f / LayoutCanvas::kHeight) / legacyFontHeight;
     out->sizeW = out->sizeH * static_cast<float>(surfaceWidthPx) * topFOV /
                  (static_cast<float>(surfaceHeightPx) * leftFOV);
     return true;

--- a/tests/unit/engine/Poseidon/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/CMakeLists.txt
@@ -467,6 +467,7 @@ list(APPEND POSEIDON_TEST_SOURCES
     UI/Controls/test_progress_bar_widget.cpp
     UI/Controls/test_control_object_rotate_devmode.cpp
     UI/Controls/test_html_table_row.cpp
+    UI/Controls/test_cursor_layout.cpp
     UI/test_button_modal_page.cpp
     UI/test_capture_page.cpp
     UI/test_confirm_page.cpp

--- a/tests/unit/engine/Poseidon/UI/Controls/test_cursor_layout.cpp
+++ b/tests/unit/engine/Poseidon/UI/Controls/test_cursor_layout.cpp
@@ -1,0 +1,223 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <Poseidon/UI/Controls/CursorLayout.hpp>
+#include <Poseidon/UI/LayoutCanvas.hpp>
+#include <Poseidon/UI/Settings/AspectRatio.hpp>
+
+#include <catch2/catch_approx.hpp>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <initializer_list>
+#include <sstream>
+#include <string>
+
+using Poseidon::CursorLayout::ComputeRect;
+using Poseidon::CursorLayout::Metrics;
+using Poseidon::CursorLayout::ProjectedSize;
+using Poseidon::CursorLayout::Rect;
+using Poseidon::CursorLayout::RescaleForFOV;
+using Poseidon::CursorLayout::Size;
+
+namespace
+{
+// CfgWrapperUI >> Cursors as shipped in packages/Game: every vanilla cursor is
+// square in layout units, and Track's geometry is shared by Move and Scroll.
+constexpr Metrics kArrow{16.0f, 16.0f, 0.0f, 0.0f};
+constexpr Metrics kTrack{24.0f, 24.0f, 0.5f, 0.5f};
+
+struct Viewport
+{
+    int w;
+    int h;
+};
+
+constexpr Viewport kWide[] = {{1600, 900}, {1920, 1080}, {2560, 1080}, {3440, 1440}};
+
+void CheckRect(const Rect& got, int x, int y, int w, int h)
+{
+    CHECK(got.x == x);
+    CHECK(got.y == y);
+    CHECK(got.w == w);
+    CHECK(got.h == h);
+}
+} // namespace
+
+TEST_CASE("LayoutCanvas: the canvas keeps its legacy dimensions", "[UI][Cursor][CursorLayout]")
+{
+    namespace Canvas = Poseidon::LayoutCanvas;
+    STATIC_REQUIRE(Canvas::kWidth == 800.0f);
+    STATIC_REQUIRE(Canvas::kHeight == 600.0f);
+    STATIC_REQUIRE(Canvas::kRatio == 4.0f / 3.0f);
+    STATIC_REQUIRE(Canvas::kBaseLeftFov == 1.0f);
+    STATIC_REQUIRE(Canvas::kBaseTopFov == 0.75f);
+}
+
+TEST_CASE("CursorLayout: square cursors stay square on wide viewports", "[UI][Cursor][CursorLayout]")
+{
+    for (const Viewport& v : kWide)
+    {
+        CAPTURE(v.w, v.h);
+        const Rect arrow = ComputeRect(kArrow, 0.5f, 0.5f, v.w, v.h);
+        CHECK(arrow.w == arrow.h);
+        const Rect track = ComputeRect(kTrack, 0.5f, 0.5f, v.w, v.h);
+        CHECK(track.w == track.h);
+    }
+
+    // 900/600 is 1.5 device pixels per layout unit, so these sizes land exact.
+    const Rect arrow16x9 = ComputeRect(kArrow, 0.5f, 0.5f, 1600, 900);
+    CHECK(arrow16x9.w == 24);
+    CHECK(arrow16x9.h == 24);
+    const Rect track16x9 = ComputeRect(kTrack, 0.5f, 0.5f, 1600, 900);
+    CHECK(track16x9.w == 36);
+    CHECK(track16x9.h == 36);
+}
+
+TEST_CASE("CursorLayout: 4:3 viewports keep the legacy geometry", "[UI][Cursor][CursorLayout]")
+{
+    CheckRect(ComputeRect(kArrow, 0.5f, 0.5f, 800, 600), 400, 300, 16, 16);
+    CheckRect(ComputeRect(kTrack, 0.5f, 0.5f, 800, 600), 388, 288, 24, 24);
+
+    CheckRect(ComputeRect(kArrow, 0.5f, 0.5f, 1024, 768), 512, 384, 20, 20);
+    CheckRect(ComputeRect(kTrack, 0.5f, 0.5f, 1024, 768), 497, 369, 31, 31);
+
+    CheckRect(ComputeRect(kArrow, 0.5f, 0.5f, 1600, 1200), 800, 600, 32, 32);
+    CheckRect(ComputeRect(kTrack, 0.5f, 0.5f, 1600, 1200), 776, 576, 48, 48);
+}
+
+TEST_CASE("CursorLayout: cursor size follows viewport height only", "[UI][Cursor][CursorLayout]")
+{
+    const Rect narrow = ComputeRect(kArrow, 0.0f, 0.0f, 1920, 1080);
+    const Rect wide = ComputeRect(kArrow, 0.0f, 0.0f, 2560, 1080);
+    CHECK(narrow.w == wide.w);
+    CHECK(narrow.h == wide.h);
+}
+
+TEST_CASE("CursorLayout: a centre hotspot follows the drawn width", "[UI][Cursor][CursorLayout]")
+{
+    CheckRect(ComputeRect(kTrack, 0.5f, 0.5f, 1600, 900), 782, 432, 36, 36);
+    CheckRect(ComputeRect(kTrack, 0.5f, 0.5f, 1920, 1080), 938, 518, 43, 43);
+    CheckRect(ComputeRect(kTrack, 0.5f, 0.5f, 3440, 1440), 1691, 691, 58, 58);
+}
+
+TEST_CASE("CursorLayout: a centred cursor stays on the pointer", "[UI][Cursor][CursorLayout]")
+{
+    for (const Viewport& v : kWide)
+    {
+        for (float mouseScrX : {0.25f, 0.5f, 0.75f})
+        {
+            CAPTURE(v.w, v.h, mouseScrX);
+            const Rect rect = ComputeRect(kTrack, mouseScrX, 0.5f, v.w, v.h);
+            const float centre = rect.x + rect.w * 0.5f;
+            CHECK(std::fabs(centre - mouseScrX * v.w) <= 1.0f);
+        }
+    }
+}
+
+TEST_CASE("CursorLayout: a zero hotspot anchors on the pointer", "[UI][Cursor][CursorLayout]")
+{
+    for (const Viewport& v : kWide)
+    {
+        CAPTURE(v.w, v.h);
+        const Rect rect = ComputeRect(kArrow, 0.25f, 0.75f, v.w, v.h);
+        CHECK(rect.x == v.w / 4);
+        CHECK(rect.y == v.h * 3 / 4);
+    }
+}
+
+TEST_CASE("CursorLayout: world cursors stay square across aspect ratios", "[UI][Cursor][CursorLayout]")
+{
+    for (const Viewport& v : kWide)
+    {
+        CAPTURE(v.w, v.h);
+        const float ratio = static_cast<float>(v.w) / static_cast<float>(v.h);
+        const Poseidon::AspectRatio::Settings asp = Poseidon::AspectRatio::BuildSettingsForRatio(ratio);
+        const Poseidon::CursorLayout::Size size = ProjectedSize(32.0f, asp.leftFOV, asp.topFOV);
+        CHECK(size.w * v.w == Catch::Approx(size.h * v.h).epsilon(0.001));
+    }
+}
+
+TEST_CASE("CursorLayout: a 4:3 viewport keeps the legacy world cursor fractions", "[UI][Cursor][CursorLayout]")
+{
+    const Poseidon::AspectRatio::Settings asp = Poseidon::AspectRatio::BuildSettingsForRatio(4.0f / 3.0f);
+    const Poseidon::CursorLayout::Size size = ProjectedSize(32.0f, asp.leftFOV, asp.topFOV);
+    CHECK(size.w == Catch::Approx(32.0f / 800));
+    CHECK(size.h == Catch::Approx(32.0f / 600));
+}
+
+TEST_CASE("CursorLayout: rescaling leaves the layout canvas untouched", "[UI][Cursor][CursorLayout]")
+{
+    const Poseidon::AspectRatio::Settings asp = Poseidon::AspectRatio::BuildSettingsForRatio(4.0f / 3.0f);
+    const Size canvasSize{32.0f / 800, 32.0f / 600};
+    const Size drawn = RescaleForFOV(canvasSize, asp.leftFOV, asp.topFOV);
+    CHECK(drawn.w == Catch::Approx(canvasSize.w));
+    CHECK(drawn.h == Catch::Approx(canvasSize.h));
+}
+
+TEST_CASE("CursorLayout: a canvas-authored square is drawn square", "[UI][Cursor][CursorLayout]")
+{
+    for (const Viewport& v : kWide)
+    {
+        CAPTURE(v.w, v.h);
+        const float ratio = static_cast<float>(v.w) / static_cast<float>(v.h);
+        const Poseidon::AspectRatio::Settings asp = Poseidon::AspectRatio::BuildSettingsForRatio(ratio);
+        const Size drawn = RescaleForFOV({32.0f / 800, 32.0f / 600}, asp.leftFOV, asp.topFOV);
+        CHECK(drawn.w * v.w == Catch::Approx(drawn.h * v.h).epsilon(0.001));
+    }
+}
+
+TEST_CASE("CursorLayout: cursor geometry comes from CursorLayout", "[UI][Cursor][CursorLayout]")
+{
+    // Every site that turns layout units into device pixels takes its geometry
+    // from CursorLayout -- a hand-inlined copy is how the world-projected cursor
+    // lost its aspect correction.
+    struct Callsite
+    {
+        const char* path;
+        const char* symbol;
+        int count;
+    };
+
+    const Callsite sites[] = {
+        {"UI/Map/UIContainers.cpp", "CursorLayout::ComputeRect(", 1},
+        {"UI/InGame/InGameUIDrawCursor.cpp", "CursorLayout::ProjectedSize(", 2},
+        {"UI/InGame/InGameUIDrawCursor.cpp", "CursorLayout::RescaleForFOV(", 1},
+        {"UI/Map/UIMap.cpp", "CursorLayout::SquareWidthFraction(", 1},
+    };
+
+    for (const Callsite& site : sites)
+    {
+        CAPTURE(site.path, site.symbol);
+        const std::filesystem::path source =
+            std::filesystem::path(TESTS_ROOT_DIR).parent_path() / "engine" / "Poseidon" / site.path;
+        std::ifstream file(source);
+        REQUIRE(file.is_open());
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        const std::string body = buffer.str();
+
+        int calls = 0;
+        for (size_t pos = body.find(site.symbol); pos != std::string::npos; pos = body.find(site.symbol, pos + 1))
+        {
+            ++calls;
+        }
+        CHECK(calls == site.count);
+    }
+}
+
+TEST_CASE("CursorLayout: SquareWidthFraction matches the height in device pixels", "[UI][Cursor][CursorLayout]")
+{
+    const float heightFraction = 16.0f / 600;
+    for (const Viewport& v : kWide)
+    {
+        CAPTURE(v.w, v.h);
+        const float widthFraction = Poseidon::CursorLayout::SquareWidthFraction(heightFraction, v.w, v.h);
+        CHECK(widthFraction * v.w == Catch::Approx(heightFraction * v.h));
+    }
+
+    // A 4:3 viewport keeps the legacy fraction untouched.
+    CHECK(Poseidon::CursorLayout::SquareWidthFraction(heightFraction, 800, 600) == Catch::Approx(16.0f / 800));
+
+    // A collapsed viewport falls back rather than dividing by zero.
+    CHECK(Poseidon::CursorLayout::SquareWidthFraction(heightFraction, 0, 600) == Catch::Approx(heightFraction));
+}


### PR DESCRIPTION
## Summary

Fix cursor scaling on widescreen by preserving the original cursor aspect ratio (4:3).

## Root Cause

Cursor scaling was based on the screen resolution without taking the original cursor aspect ratio into account. As a result, on widescreen displays the cursor was stretched disproportionately.

## Testing
Before
<img width="3439" height="1437" alt="before" src="https://github.com/user-attachments/assets/e375d1e4-fbae-41f6-ac5a-99a5cdcc76b4" />

After
<img width="3439" height="1437" alt="after" src="https://github.com/user-attachments/assets/8aa4df8f-cdac-4dcf-84cc-882198f55287" />