### PR TITLE
Fix for Issues #193 and #131

### DIFF
--- a/engine/Poseidon/World/Entities/Vehicles/TransportCore.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/TransportCore.cpp
@@ -1891,7 +1891,11 @@ void Transport::Draw(int level, ClipFlags clipFlags, const FrameBase& pos)
                 // vehicle gunner optics are a 4:3 vignette — stretch when bars off.
                 const bool preserve4x3 = AspectRatio::ArePillarboxBarsEnabled();
                 Draw2D(oShape, 0, GetOpticsColor(person), /*preserveAspect4x3*/ preserve4x3);
-                Object::DrawWidescreenPillarbox();
+
+                // optics use alpha blending, while open sights use alpha cutout.
+                // preserving the 4:3 aspect ratio for optics adds black pillarboxes on the sides
+                if (preserve4x3 && oShape->LevelOpaque(0)->HasBlendSections())
+                    Object::DrawWidescreenPillarbox();
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes [Issue#193](https://github.com/ofpisnotdead-com/CWR-CE/issues/193) and [Issue #131](https://github.com/ofpisnotdead-com/CWR-CE/issues/131).

The same issue was reproduced on all vehicles with a gunner's open sight, including the mounted M2, Jeep with M.2, M113, and boat. All vehicle open sights now display correctly on widescreen displays.

## Root cause
Vehicles can have either an open sight or an optical sight. Optical sights use a 4:3 mask (vignette), with the areas on the sides of the screen filled by black rectangles using `Object::DrawWidescreenPillarbox()`.

The underlying problem is that the engine does not distinguish between open sights and optical sights. From the engine's perspective, an open sight is also treated as an optical sight, causing the black pillarboxes to be drawn for open sights as well.

## Solution
Optical sights use alpha blending, while open sights use alpha cutout.

Pillarboxes should therefore only be drawn when preserving the 4:3 aspect ratio and when `LODShapeWithShadow* oShape` contains sections that use alpha blending.

## Testing
Manually tested with vanilla vehicles, including vehicles with both open and optical sights.