### PR TITLE
Fix two Linux faults that hardened builds turn fatal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ else()
 endif()
 
 if(UNIX AND NOT APPLE)
+    # A canary on every frame that holds an array or an address-taken local.
+    # clang-cl enables the same check by default through /GS, so the Windows
+    # build already has it.
+    add_compile_options(-fstack-protector-strong)
+
     # glibc bounds-checks the memory, string and stdio calls whose destination size
     # it can see, at compile time where the overflow is provable and through the
     # __*_chk entry points otherwise. Level 2 also rejects open() with O_CREAT and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,26 @@ else()
     add_compile_options(-ffunction-sections -fdata-sections)
 endif()
 
+if(UNIX AND NOT APPLE)
+    # glibc bounds-checks the memory, string and stdio calls whose destination size
+    # it can see, at compile time where the overflow is provable and through the
+    # __*_chk entry points otherwise. Level 2 also rejects open() with O_CREAT and
+    # no mode.
+    #
+    # The fortified wrappers sit behind __OPTIMIZE__, so glibc warns and turns
+    # itself off in an unoptimized build; Debug is left out. Sanitizer builds are
+    # left out because ASan interposes the same entry points.
+    if(NOT "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}" MATCHES "-fsanitize")
+        set(CWR_FORTIFY_SOURCE "2" CACHE STRING "_FORTIFY_SOURCE level for optimized builds; 0 disables")
+        if(NOT CWR_FORTIFY_SOURCE STREQUAL "0")
+            add_compile_options(
+                $<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE>
+                $<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=${CWR_FORTIFY_SOURCE}>
+            )
+        endif()
+    endif()
+endif()
+
 # Make __FILE__ repo-root-relative so log/assert lines (Fail(), DoAssert(), LOG_*)
 # read "engine/Poseidon/...:NN" instead of an absolute build-machine path. Affects only
 # the __FILE__ macro string, not debug info.

--- a/engine/Poseidon/Foundation/Common/Platform.cpp
+++ b/engine/Poseidon/Foundation/Common/Platform.cpp
@@ -157,7 +157,7 @@ bool fileCopy(const char* src, const char* dest)
     int f1 = open(sfn, O_RDONLY);
     if (f1 < 0)
         return false;
-    int f2 = open(dfn, O_CREAT | O_WRONLY | O_TRUNC);
+    int f2 = open(dfn, O_CREAT | O_WRONLY | O_TRUNC, 0666);
     if (f2 < 0)
     {
         close(f1);

--- a/engine/Poseidon/IO/ParamFile/ParamFileParse.cpp
+++ b/engine/Poseidon/IO/ParamFile/ParamFileParse.cpp
@@ -5,6 +5,7 @@
 #include <Poseidon/IO/Streams/SerializeBin.hpp>
 #include <Poseidon/Foundation/Framework/LogFlags.hpp>
 #include <ctype.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -281,12 +282,17 @@ LSError ParamFile::Parse(const char* name)
     SetName(name);
 
     // Log full absolute path of file being parsed
-    char fullPath[512];
 #ifdef _WIN32
+    char fullPath[512];
     ::GetFullPathNameA(name, sizeof(fullPath), fullPath, nullptr);
 #else
+    // realpath() may write up to PATH_MAX bytes into the buffer
+    char fullPath[PATH_MAX];
     if (!realpath(name, fullPath))
+    {
         strncpy(fullPath, name, sizeof(fullPath) - 1);
+        fullPath[sizeof(fullPath) - 1] = '\0';
+    }
 #endif
     LOG_DEBUG(Core, "ParamFile::Parse() - Loading config file: {}", fullPath);
 

--- a/tests/unit/engine/Poseidon/Foundation/Common/test_platform.cpp
+++ b/tests/unit/engine/Poseidon/Foundation/Common/test_platform.cpp
@@ -1,9 +1,16 @@
-// Unit tests for PoseidonBase platform path utilities
+// Unit tests for PoseidonBase platform utilities
 
 #include <catch2/catch_test_macros.hpp>
 #include <Poseidon/Foundation/platform.hpp>
 #include <string.h>
 #include <string>
+#ifndef _WIN32
+#include <sys/stat.h>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+#endif
 
 TEST_CASE("PATH_SEP is correct for platform", "[platform]")
 {
@@ -96,3 +103,33 @@ TEST_CASE("platformPath (std::string) normalizes separators", "[platform]")
         REQUIRE(platformPath(std::string("")).empty());
     }
 }
+
+#ifndef _WIN32
+TEST_CASE("fileCopy creates the destination with a mode the umask narrows", "[platform]")
+{
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path() / ("poseidon_filecopy_" + std::to_string(nonce));
+    std::filesystem::create_directories(root);
+
+    const std::string source = (root / "source.txt").string();
+    const std::string destination = (root / "destination.txt").string();
+    {
+        std::ofstream out(source, std::ios::binary);
+        out << "payload";
+    }
+
+    const mode_t previousMask = umask(022);
+    const bool copied = fileCopy(source.c_str(), destination.c_str());
+    umask(previousMask);
+
+    REQUIRE(copied);
+
+    struct stat info;
+    REQUIRE(stat(destination.c_str(), &info) == 0);
+    REQUIRE((info.st_mode & 07777) == 0644);
+
+    std::error_code ec;
+    std::filesystem::remove_all(root, ec);
+}
+#endif

--- a/tests/unit/engine/Poseidon/IO/ParamFile/test_paramfile_parsing.cpp
+++ b/tests/unit/engine/Poseidon/IO/ParamFile/test_paramfile_parsing.cpp
@@ -6,6 +6,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <string>
+#ifndef _WIN32
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+#endif
 
 // Phase 2: ParamFile Text Parsing & Formatting
 // This file tests the parsing of text format config files and verifies that
@@ -1073,3 +1079,35 @@ TEST_CASE("ParamFile - Fixture file I/O", "[paramfile][parse][fixtures][save]")
 // - Harden parser against malformed input
 //
 // This completes Phase 2 of the ParamFile testing plan.
+
+#ifndef _WIN32
+TEST_CASE("ParamFile - Parse a file whose resolved path exceeds 512 bytes", "[paramfile][parse][paths]")
+{
+    namespace fs = std::filesystem;
+
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    fs::path root = fs::temp_directory_path() / ("poseidon_longpath_" + std::to_string(nonce));
+
+    fs::path nested = root;
+    while (nested.string().size() < 600)
+        nested /= std::string(120, 'd');
+    fs::create_directories(nested);
+
+    const fs::path configPath = nested / "config.cpp";
+    {
+        std::ofstream out(configPath, std::ios::binary);
+        out << "longPathValue = 7;\n";
+    }
+    REQUIRE(fs::canonical(configPath).string().size() > 512);
+
+    ParamFile pf;
+    REQUIRE(pf.Parse(configPath.string().c_str()) == LSOK);
+
+    ParamEntry* value = pf.FindEntry("longPathValue");
+    REQUIRE(value != nullptr);
+    REQUIRE(value->GetInt() == 7);
+
+    std::error_code ec;
+    fs::remove_all(root, ec);
+}
+#endif


### PR DESCRIPTION
Packaging the engine for Arch surfaced two faults in the POSIX paths. Both are
real bugs on their own; building with `-D_FORTIFY_SOURCE`, which distribution
build systems enable by default, is what turns them fatal.

## `open()` without a mode in `fileCopy()`

`Platform.cpp` created the destination with `O_CREAT` and only two arguments,
so the new file received whatever was on the stack as its permission bits.
Five consecutive runs of the same call produced modes 5500, 5340, 5540, 1100
and 2400 — stray setuid/setgid bits, and in the 1100 case a file its own owner
cannot read back.

This is reachable: `platform.hpp` maps `CopyFile()` onto `fileCopy()` on Linux,
and `nm` shows both `DisplayUI.cpp.o` and `OptionsUIApp.cpp.o` referencing it.
The callers copy campaign saves (`objects.sav`) and whole directory trees.

With fortification the file does not compile at all:

    error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments

## Undersized `realpath()` buffer in `ParamFile::Parse()`

`realpath()` may write up to `PATH_MAX` bytes into the caller's buffer; Parse()
passed 512. glibc's fortified wrapper checks the buffer size rather than the
resolved length, so it aborts on every call, whatever the path:

    *** buffer overflow detected ***: terminated

`Parse()` runs during configuration startup, so a fortified build of either
binary dies before reaching its main loop. Without fortification the same call
smashes the stack once the resolved path is long enough — a real 802-byte path
reproduces `*** stack smashing detected ***`.

The fallback `strncpy()` is also now terminated explicitly; it could leave the
buffer unterminated for a name of exactly the buffer length.

## Verification

Built `linux-x64-clang-rel` under makepkg's flags (`-D_FORTIFY_SOURCE=3`,
`-D_GLIBCXX_ASSERTIONS`) against 3.05 game data.

- Before: `PoseidonServer` and `PoseidonGame` both abort during startup.
  `addr2line` places the abort at `ParamFileParse.cpp:288`, reached through
  `ReadConfiguration` -> `InitializeGameConfiguration` -> `ParseConfig`.
- After: the server reaches `Dedicated server main loop started` and the client
  gets through GL33 initialisation.
- `ctest` passes 3933/3933 on an unfortified `linux-x64-clang-rwdi` build.
- `git clang-format` reports no changes.