### PR TITLE
Correct the dist directory named in the Linux build guide

### DIFF
--- a/docs/build/linux.md
+++ b/docs/build/linux.md
@@ -101,7 +101,7 @@ cmake --preset linux-x64-clang-rwdi
 cmake --build build/linux-x64-clang-rwdi
 ```
 
-Note that these may take a while, especially the first time they are run. Afterwards, the binaries will be available in the `dist/linux-x64-clang-rwdi` directory. For example, `dist/linux-x64-clang-rwdi/PoseidonGame` is the full game binary.
+Note that these may take a while, especially the first time they are run. Afterwards, the binaries will be available in the `dist/x64-linux-rwdi` directory. For example, `dist/x64-linux-rwdi/PoseidonGame` is the full game binary.
 
 ## Install binaries alongside game data
 


### PR DESCRIPTION
`docs/build/linux.md` tells readers the binaries land in
`dist/linux-x64-clang-rwdi`, but that directory is never created.

`CMakeLists.txt` rewrites the preset name when it derives `DIST_DIR`, so
`linux-x64-clang-rwdi` becomes `x64-linux-rwdi`. A local build of that preset
produces `dist/x64-linux-rwdi`, and the build workflow reads the same form
through `CWR_DIST_DIR`.

Point the guide at the directory the build actually produces, in both the
sentence and the `PoseidonGame` example beside it.