### PR TITLE
Keep --log-file across restarts, and stop writing an empty one

### DIFF
--- a/apps/cwr/Server/ServerApplication.cpp
+++ b/apps/cwr/Server/ServerApplication.cpp
@@ -6,7 +6,6 @@
 #include <Poseidon/Foundation/Platform/FPUSetup.hpp>
 #include <Poseidon/Foundation/Platform/PoseidonInit.hpp>
 #include <Poseidon/Foundation/Platform/AppConfig.hpp>
-#include <Poseidon/Foundation/Platform/GamePaths.hpp>
 #include <Poseidon/Core/Application.hpp>
 #include <Poseidon/Core/Version.hpp>
 #include <Poseidon/Core/Config/Config.hpp>
@@ -32,7 +31,6 @@
 #include <exception>
 #include <string>
 #include <vector>
-#include <Poseidon/Foundation/Common/GamePaths.hpp>
 #include <Poseidon/Foundation/Framework/AppFrame.hpp>
 #include <Poseidon/Foundation/Framework/DebugLog.hpp>
 #include <Poseidon/Foundation/Framework/GlobalAlive.hpp>
@@ -43,7 +41,6 @@
 
 #ifndef _WIN32
 #include <csignal>
-#include <chrono>
 #include <thread>
 #include <unistd.h>
 
@@ -66,7 +63,6 @@ using namespace Poseidon;
 #include <memory>
 
 #include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/sinks/basic_file_sink.h>
 
 #include <mimalloc.h>
 
@@ -264,35 +260,9 @@ bool ServerApplication::CreateServerConsole()
 
         std::vector<spdlog::sink_ptr> sinks{console_sink};
 
-        try
-        {
-            auto now = std::chrono::system_clock::now();
-            auto tt = std::chrono::system_clock::to_time_t(now);
-            std::tm tm{};
-#ifdef _WIN32
-            localtime_s(&tm, &tt);
-#else
-            localtime_r(&tt, &tm);
-#endif
-            char timestamp[32];
-            std::snprintf(timestamp, sizeof(timestamp), "%04d%02d%02d_%02d%02d%02d", tm.tm_year + 1900, tm.tm_mon + 1,
-                          tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
-
-            int port = AppConfig::Instance().GetNetworkPort();
-            std::string logPath =
-                GamePaths::Instance().UserDir() + "server_" + timestamp + "_" + std::to_string(port) + ".log";
-
-            auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logPath, true);
-            file_sink->set_level(spdlog::level::debug);
-            file_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
-            sinks.push_back(file_sink);
-            LOG_INFO(Core, "Server log: {}", logPath);
-        }
-        catch (const spdlog::spdlog_ex& ex)
-        {
-            LOG_WARN(Core, "File logging not available: {}", ex.what());
-        }
-
+        // No file sink: this logger is registered and never fetched, since every
+        // LOG_ macro goes to the engine's own category loggers. The server's log
+        // file comes from GameBase, like every other app's.
         auto server_logger = std::make_shared<spdlog::logger>("Server", sinks.begin(), sinks.end());
         server_logger->set_level(spdlog::level::debug);
         try

--- a/engine/Poseidon/Foundation/Logging/Logging.cpp
+++ b/engine/Poseidon/Foundation/Logging/Logging.cpp
@@ -590,7 +590,10 @@ void LoggingSystem::Initialize(const char* logLevel, const char* categoryFilter,
                 std::filesystem::create_directories(p.parent_path(), ec);
             }
 
-            auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFile, true);
+            // Appended: a path given on the command line is one somebody keeps,
+            // and truncating it loses every session before the last restart. The
+            // per-run file below can truncate — its name is never reused.
+            auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFile, false);
             auto formatter = std::make_unique<spdlog::pattern_formatter>();
             formatter->add_flag<PoseidonFormatter>('*', this, /*colored=*/false);
             formatter->set_pattern("[%Y-%m-%d %H:%M:%S.%e] %*%v");

--- a/tests/unit/engine/Poseidon/Core/test_logging.cpp
+++ b/tests/unit/engine/Poseidon/Core/test_logging.cpp
@@ -284,6 +284,42 @@ TEST_CASE("AttachFileSink captures log lines into the file", "[logging][file]")
     fs::remove(path, ec);
 }
 
+TEST_CASE("A --log-file survives a restart", "[logging][file]")
+{
+    namespace fs = std::filesystem;
+    const fs::path dir = fs::temp_directory_path() / "cwr_logfile_append";
+    const fs::path path = dir / "server.log";
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+
+    // Two runs writing to the same path, which is what a dedicated server
+    // restarted nightly does. Opened with truncate, the second one leaves the
+    // first session gone and the file the same length it was.
+    {
+        Poseidon::Foundation::LoggingSystem logSys;
+        REQUIRE_NOTHROW(logSys.Initialize("info", "", "text", path.string().c_str()));
+        LOG_INFO(Core, "first session marker 11111");
+        logSys.Shutdown();
+    }
+    {
+        Poseidon::Foundation::LoggingSystem logSys;
+        REQUIRE_NOTHROW(logSys.Initialize("info", "", "text", path.string().c_str()));
+        LOG_INFO(Core, "second session marker 22222");
+        logSys.Shutdown();
+    }
+
+    std::ifstream in(path);
+    std::stringstream contents;
+    contents << in.rdbuf();
+    const std::string text = contents.str();
+
+    CHECK(text.find("first session marker 11111") != std::string::npos);
+    CHECK(text.find("second session marker 22222") != std::string::npos);
+
+    in.close();
+    fs::remove_all(dir, ec);
+}
+
 TEST_CASE("Initialize survives a --log-file path it cannot open", "[logging][file]")
 {
     namespace fs = std::filesystem;


### PR DESCRIPTION
Fixes #184, both halves of it. Reproduced on Linux before touching anything —
the report is from Windows, and neither of these paths has a platform branch.

## The log file is overwritten on every start

`--log-file` opens with truncate. Two runs of a 3.05 dedicated server against
the same path:

| | lines |
| --- | --- |
| after the first run | 35 |
| after the second | 35 |
| lines in common | **0** |

A server restarted nightly reaches the morning holding only the last start. It
appends now.

The per-run file is untouched and still truncates, which costs nothing: its name
carries a timestamp and a pid, so it never opens a file that already exists.

## A blank log is written on every start

`CreateServerConsole` built a file sink into a logger named `"Server"`,
registered it, and nothing ever fetched it — every `LOG_` macro goes to the
engine's own category loggers, and there is no `spdlog::get` anywhere in the
tree. The file it opened could only ever hold nothing.

Sixteen empty `server_<time>_<port>.log` had accumulated in my user directory,
one per start. One of them was written on a run that passed `--no-log-file`,
since this path never consulted the flag — which is the part of the report about
files appearing "regardless of whether override launch commands are used".

The sink is gone. The server still gets a log from where every other app gets
one: `GameBase` attaches a per-run file, names it with a timestamp and a pid, and
trims to the last ten. Checked that it still does — 33 lines, 3,656 bytes, on a
start with no `--log-file`.

Four includes went with the removed block; each was checked against `main` for
other uses first.

## Verification

- New test, `A --log-file survives a restart`, beside the other `[logging][file]`
  cases: it initialises the logging system twice against one path and looks for
  both markers. It fails on the old behaviour — the first marker is gone — and
  passes with the fix.
- The blank-file half has no test: it lives in `CreateServerConsole`, which needs
  a running server, and `tests/unit/apps/Server` has nothing that far up. Checked
  by hand instead: the count of empty files stops rising across restarts, with
  and without `--no-log-file`.
- `ctest` is 3953/3953 on `linux-x64-clang-rwdi`.