### PR TITLE
Initialize the vertex table min/max dirty flag

### DIFF
--- a/engine/Poseidon/Graphics/Rendering/Primitives/Vertex.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Primitives/Vertex.cpp
@@ -18,6 +18,7 @@ VertexTable::VertexTable()
     _minMax[1] = VZero;
     _bCenter = VZero;
     _bRadius = 0;
+    _minMaxDirty = false;
 }
 
 VertexTable::VertexTable(int nPos)
@@ -27,6 +28,7 @@ VertexTable::VertexTable(int nPos)
     _minMax[1] = VZero;
     _bCenter = VZero;
     _bRadius = 0;
+    _minMaxDirty = false;
 }
 
 VertexTable::VertexTable(const VertexTable& src)
@@ -121,6 +123,7 @@ void VertexTable::DoConstruct(const VertexTable& src)
     _minMax[1] = src._minMax[1];
     _bCenter = src._bCenter;
     _bRadius = src._bRadius;
+    _minMaxDirty = src._minMaxDirty;
 }
 
 int VertexTable::AddVertex(Vector3Par pos, Vector3Par norm, ClipFlags clip, float u, float v,

--- a/tests/unit/engine/Poseidon/Graphics/Rendering/test_primitives.cpp
+++ b/tests/unit/engine/Poseidon/Graphics/Rendering/test_primitives.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
+#include <cstring>
+#include <new>
 #include <Poseidon/Graphics/Rendering/Primitives/Vertex.hpp>
 #include <Poseidon/Graphics/Rendering/Primitives/Poly.hpp>
 #include <Poseidon/Graphics/Rendering/Primitives/Edges.hpp>
@@ -45,6 +47,35 @@ TEST_CASE("VertexTable - construction and vertex management", "[rendering][verte
         VertexTable vt(3);
         VertexTable vt2(vt);
         REQUIRE(vt2.NVertex() == 3);
+    }
+}
+
+TEST_CASE("VertexTable - min/max cache state does not depend on prior memory", "[rendering][vertex]")
+{
+    // MinMaxDynamic either returns the cached box or rescans, decided by _minMaxDirty, so
+    // constructing over two differently filled buffers must still answer identically.
+    auto minMaxOver = [](unsigned char fill, Vector3& min, Vector3& max)
+    {
+        alignas(VertexTable) unsigned char storage[sizeof(VertexTable)];
+        memset(storage, fill, sizeof(storage));
+        VertexTable* vt = new (storage) VertexTable(2);
+        vt->SetPos(0) = Vector3(-1, -2, -3);
+        vt->SetPos(1) = Vector3(4, 5, 6);
+        Vector3 minMax[2];
+        vt->MinMaxDynamic(minMax);
+        min = minMax[0];
+        max = minMax[1];
+        vt->~VertexTable();
+    };
+
+    Vector3 zeroedMin, zeroedMax, poisonedMin, poisonedMax;
+    minMaxOver(0x00, zeroedMin, zeroedMax);
+    minMaxOver(0xBE, poisonedMin, poisonedMax);
+
+    for (int i = 0; i < 3; i++)
+    {
+        REQUIRE(poisonedMin[i] == Catch::Approx(zeroedMin[i]));
+        REQUIRE(poisonedMax[i] == Catch::Approx(zeroedMax[i]));
     }
 }
 


### PR DESCRIPTION
`VertexTable::_minMaxDirty` is never set by any constructor and not copied by
`DoConstruct`, so `RecalculateNormals` and `MinMaxDynamic` read an indeterminate
value. UBSan: `Shape.cpp:1884: load of value 190, not a valid value for 'bool'`.
A1 fixes it the same way.

Test builds the table over `0x00`- and `0xBE`-filled storage and requires the
same answer; without the fix it returns `-1` vs `0`.