### PR TITLE
Keep the class name alive while comparing it

### DIFF
--- a/engine/Poseidon/Game/Commands/GameStateExtTest.cpp
+++ b/engine/Poseidon/Game/Commands/GameStateExtTest.cpp
@@ -262,7 +262,8 @@ GameValue TriHornPlayerVehicle(const GameState* /*state*/)
     EntityAI* veh = GWorld->GetRealPlayer()->Brain()->GetVehicle();
     if (!veh)
         return GameValue("FAIL:no_vehicle");
-    const char* vtype = veh->GetType() ? (const char*)veh->GetType()->GetName() : "?";
+    const RString vtypeName = veh->GetType() ? veh->GetType()->GetName() : RString("?");
+    const char* vtype = vtypeName;
     if (veh == static_cast<EntityAI*>(GWorld->GetRealPlayer()))
     {
         LOG_INFO(Core, "[tri] triHornPlayerVehicle: on foot (vehicle='{}')", vtype);

--- a/engine/Poseidon/World/Viewer.cpp
+++ b/engine/Poseidon/World/Viewer.cpp
@@ -269,7 +269,7 @@ void World::ReloadViewerCore(LODShapeWithShadow* shape, const char* classDesc)
 
     Object* obj = _cameraOn;
     VehicleWithAI* camAI = dyn_cast<VehicleWithAI>(obj);
-    const char* camName = camAI ? camAI->GetType()->GetName() : "";
+    const RString camName = camAI ? camAI->GetType()->GetName() : RString();
     if (!strcmpi(camName, viewClass))
     {
         Object* cobj = _cameraOn;


### PR DESCRIPTION
`EntityType::GetName` returns `RString` by value, so binding a `const char*` to it
dangles. ASan reports a heap-use-after-free in `ReloadViewerCore`; same shape in
`TriHornPlayerVehicle`. Both sites now hold the `RString`; an empty one still
yields `""`.

No unit test - only a sanitizer build can see it. ASan reports before, clean after.