### PR TITLE
Give the dummy texture a defined size

### DIFF
--- a/engine/Poseidon/Graphics/Dummy/TextureDummy.hpp
+++ b/engine/Poseidon/Graphics/Dummy/TextureDummy.hpp
@@ -14,11 +14,11 @@ class TextureDummy : public Texture
   private:
     SRef<ITextureSource> _src;
 
-    bool _glideEmulation;
-    int _aRatio;
-    int _w, _h;
+    bool _glideEmulation = false;
+    int _aRatio = 0;
+    int _w = 0, _h = 0;
 
-    int _nMipmaps;
+    int _nMipmaps = 0;
     PacLevelMem _mipmaps[MAX_MIPMAPS];
 
     int Init();

--- a/tests/unit/engine/Poseidon/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/CMakeLists.txt
@@ -150,6 +150,7 @@ set(POSEIDON_TEST_SOURCES
     Graphics/test_fan_decompose.cpp
     Graphics/test_zbias_math.cpp
     Graphics/test_mipmap_layout.cpp
+    Graphics/test_texture_dummy_size.cpp
     Graphics/test_gl_state_cache_audit.cpp
     Graphics/test_ibo_bind_audit.cpp
     Graphics/test_buffer_usage_audit.cpp

--- a/tests/unit/engine/Poseidon/Graphics/test_texture_dummy_size.cpp
+++ b/tests/unit/engine/Poseidon/Graphics/test_texture_dummy_size.cpp
@@ -1,0 +1,20 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cstring>
+#include <new>
+#include <Poseidon/Graphics/Dummy/TextureDummy.hpp>
+
+using Poseidon::TextureDummy;
+
+TEST_CASE("TextureDummy reports a defined size before a source is loaded", "[graphics][texture]")
+{
+    // Mipmap selection reads AWidth/AHeight, and Init leaves them untouched when the
+    // texture source cannot be created, so construction has to define them.
+    alignas(TextureDummy) unsigned char storage[sizeof(TextureDummy)];
+    memset(storage, 0xBE, sizeof(storage));
+    TextureDummy* texture = new (storage) TextureDummy();
+
+    REQUIRE(texture->AWidth(0) == 0);
+    REQUIRE(texture->AHeight(0) == 0);
+
+    texture->~TextureDummy();
+}


### PR DESCRIPTION
`TextureDummy` leaves its scalars uninitialised and `Init` returns early without
setting the size when the texture source is missing, so `PrepareTexture`
multiplies garbage: `DrawPoly.cpp:59: signed integer overflow: -1094795586 *
-1094795586`. Dummy backend only, so it affects headless and CI runs, not
gameplay. Zero is safe - that value is only shifted and compared.

Test requires a zero size over `0xBE` storage. A 220-model sanitizer sweep goes
from 198 reports to 0.