### PR TITLE
Report a bad model instead of aborting the viewer

### DIFF
--- a/engine/Poseidon/Asset/Formats/P3D/P3DModelLoad.cpp
+++ b/engine/Poseidon/Asset/Formats/P3D/P3DModelLoad.cpp
@@ -1,0 +1,46 @@
+#include <Poseidon/Asset/Formats/P3D/P3DModelLoad.hpp>
+
+#include <Poseidon/Asset/Formats/P3D/MLODLoader.hpp>
+#include <Poseidon/Asset/Formats/P3D/ODOLLoader.hpp>
+
+#include <exception>
+
+namespace Poseidon::Asset::Formats
+{
+
+bool TryLoadP3D(const std::string& path, Poseidon::Model::Model& model, FormatInfo& format, std::string& error)
+{
+    try
+    {
+        format = P3DFormatDetector::DetectFormat(path);
+        if (!format.isSupported)
+        {
+            error = format.errorMessage;
+            return false;
+        }
+
+        if (format.signature == "ODOL")
+        {
+            model = ODOLLoader::load(path);
+        }
+        else if (format.signature == "MLOD")
+        {
+            model = MLODLoader::load(path);
+        }
+        else
+        {
+            error = "Unknown P3D signature: " + format.signature;
+            return false;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        error = e.what();
+        return false;
+    }
+
+    error.clear();
+    return true;
+}
+
+} // namespace Poseidon::Asset::Formats

--- a/engine/Poseidon/Asset/Formats/P3D/P3DModelLoad.hpp
+++ b/engine/Poseidon/Asset/Formats/P3D/P3DModelLoad.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <Poseidon/Asset/Formats/Common/FormatDetector.hpp>
+#include <Poseidon/World/Model/Model.hpp>
+#include <string>
+
+namespace Poseidon::Asset::Formats
+{
+
+// The P3D readers report malformed input by throwing. Callers that sit on an engine
+// entry point cannot let that escape, so this reports the failure instead.
+bool TryLoadP3D(const std::string& path, Poseidon::Model::Model& model, FormatInfo& format, std::string& error);
+
+} // namespace Poseidon::Asset::Formats

--- a/engine/Poseidon/World/Viewer.cpp
+++ b/engine/Poseidon/World/Viewer.cpp
@@ -15,9 +15,8 @@
 #include <Poseidon/Foundation/Platform/AppConfig.hpp>
 #include <cstdlib>
 
-#include <Poseidon/Asset/Formats/Common/FormatDetector.hpp>
+#include <Poseidon/Asset/Formats/P3D/P3DModelLoad.hpp>
 #include <cmath>
-#include <stdexcept>
 #include <string>
 #include <Poseidon/Foundation/Common/FltOpts.hpp>
 #include <Poseidon/Foundation/Framework/Log.hpp>
@@ -30,13 +29,6 @@
 #include <Poseidon/Foundation/platform.hpp>
 
 using namespace Poseidon;
-namespace Poseidon
-{
-using Poseidon::Asset::Formats::FormatInfo;
-using Poseidon::Asset::Formats::P3DFormatDetector;
-} // namespace Poseidon
-#include <Poseidon/Asset/Formats/P3D/ODOLLoader.hpp>
-#include <Poseidon/Asset/Formats/P3D/MLODLoader.hpp>
 #include <Poseidon/World/Model/ShapeAdapter.hpp>
 #include <Poseidon/Foundation/Logging/Logging.hpp>
 #include <Poseidon/World/Simulation/Animation/RtAnimation.hpp>
@@ -446,22 +438,13 @@ void World::ReloadViewer(void* buf, int len, const char* classDesc)
 
 void World::ReloadViewer(const char* filename, const char* classDesc)
 {
-    auto formatInfo = P3DFormatDetector::DetectFormat(filename);
-    if (!formatInfo.isSupported)
-    {
-        LOG_WARN(Core, "Unsupported P3D format for {}: {}", filename, formatInfo.errorMessage);
-        throw std::runtime_error(formatInfo.errorMessage);
-    }
-
     Poseidon::Model::Model model;
-    if (formatInfo.signature == "ODOL")
-        model = Poseidon::Asset::Formats::ODOLLoader::load(filename);
-    else if (formatInfo.signature == "MLOD")
-        model = Poseidon::Asset::Formats::MLODLoader::load(filename);
-    else
+    Poseidon::Asset::Formats::FormatInfo format;
+    std::string error;
+    if (!Poseidon::Asset::Formats::TryLoadP3D(filename, model, format, error))
     {
-        LOG_WARN(Core, "Unknown P3D signature '{}' for {}", formatInfo.signature, filename);
-        throw std::runtime_error("Unknown P3D signature: " + formatInfo.signature);
+        LOG_ERROR(Core, "Cannot load model {}: {}", filename, error);
+        return;
     }
 
     model.compile();
@@ -470,11 +453,12 @@ void World::ReloadViewer(const char* filename, const char* classDesc)
     if (!shape || shape->NLevels() == 0)
     {
         delete shape;
-        throw std::runtime_error("New pipeline produced empty shape for " + std::string(filename));
+        LOG_ERROR(Core, "Cannot load model {}: no levels of detail", filename);
+        return;
     }
 
-    LOG_INFO(Core, "New pipeline loaded {} ({} v{}, {} LODs)", filename, formatInfo.signature,
-             formatInfo.GetVersionString(), shape->NLevels());
+    LOG_INFO(Core, "New pipeline loaded {} ({} v{}, {} LODs)", filename, format.signature, format.GetVersionString(),
+             shape->NLevels());
 
     shape->OptimizeShapes();
     shape->CheckForcedProperties();

--- a/tests/unit/engine/Poseidon/Asset/Formats/test_p3d_model_load.cpp
+++ b/tests/unit/engine/Poseidon/Asset/Formats/test_p3d_model_load.cpp
@@ -1,0 +1,88 @@
+#include <catch2/catch_test_macros.hpp>
+#include <Poseidon/Asset/Formats/P3D/P3DModelLoad.hpp>
+#include "test_fixtures.hpp"
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+// Removes the file even when an assertion aborts the case.
+class TempModelFile
+{
+  public:
+    explicit TempModelFile(const char* name) : _path(GET_TEMP_FILE(name)) {}
+    ~TempModelFile() { TestFixtures::CleanupTempFile(_path.c_str()); }
+
+    TempModelFile(const TempModelFile&) = delete;
+    TempModelFile& operator=(const TempModelFile&) = delete;
+
+    const std::string& Path() const { return _path; }
+
+  private:
+    std::string _path;
+};
+
+void Put32(std::vector<char>& out, uint32_t value)
+{
+    for (int i = 0; i < 4; i++)
+    {
+        out.push_back(static_cast<char>((value >> (8 * i)) & 0xFF));
+    }
+}
+
+// A model that passes format detection - MLOD 1.1 with one SP3X level - but carries
+// rubbish where the LOD's TAGG section belongs, which is how the readers are made to
+// throw mid-parse.
+std::string WriteTruncatedMlod(const std::string& path)
+{
+    std::vector<char> bytes;
+    const char magic[4] = {'M', 'L', 'O', 'D'};
+    bytes.insert(bytes.end(), magic, magic + 4);
+    Put32(bytes, 0x101);
+    Put32(bytes, 1);
+    const char lodMagic[4] = {'S', 'P', '3', 'X'};
+    bytes.insert(bytes.end(), lodMagic, lodMagic + 4);
+    Put32(bytes, 0x1C);
+    Put32(bytes, 0);
+    Put32(bytes, 0);
+    Put32(bytes, 0);
+    Put32(bytes, 0);
+    for (int i = 0; i < 64; i++)
+    {
+        bytes.push_back(static_cast<char>(0xCD));
+    }
+
+    std::ofstream file(path, std::ios::binary);
+    file.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+    file.close();
+    return path;
+}
+
+} // namespace
+
+TEST_CASE("TryLoadP3D reports a malformed model instead of throwing", "[asset][p3d]")
+{
+    const TempModelFile temp("truncated_mlod.p3d");
+    const std::string path = WriteTruncatedMlod(temp.Path());
+
+    Poseidon::Model::Model model;
+    Poseidon::Asset::Formats::FormatInfo format;
+    std::string error;
+    bool loaded = true;
+    REQUIRE_NOTHROW(loaded = Poseidon::Asset::Formats::TryLoadP3D(path, model, format, error));
+    REQUIRE_FALSE(loaded);
+    REQUIRE_FALSE(error.empty());
+}
+
+TEST_CASE("TryLoadP3D reports a missing model instead of throwing", "[asset][p3d]")
+{
+    Poseidon::Model::Model model;
+    Poseidon::Asset::Formats::FormatInfo format;
+    std::string error;
+    bool loaded = true;
+    REQUIRE_NOTHROW(loaded = Poseidon::Asset::Formats::TryLoadP3D("no_such_model.p3d", model, format, error));
+    REQUIRE_FALSE(loaded);
+}

--- a/tests/unit/engine/Poseidon/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/CMakeLists.txt
@@ -213,6 +213,7 @@ list(APPEND POSEIDON_TEST_SOURCES
     Asset/Formats/test_wrp.cpp
     Asset/Formats/RTM/test_rtm_reader.cpp
     Asset/Formats/test_rtm.cpp
+    Asset/Formats/test_p3d_model_load.cpp
     Asset/Formats/test_paa.cpp
     Asset/Formats/test_pac.cpp
     


### PR DESCRIPTION
The P3D readers throw on malformed input and no caller catches it, so opening a
damaged model reaches `std::terminate` (exit 134). `PoseidonTools` already
handles the same file cleanly.

`TryLoadP3D` returns a status instead, so `ReloadViewer` no longer throws and its
two callers need no handling. `MLODLoader` unchanged. Viewer path only - the
in-game legacy reader tolerates these files.

Test writes its own malformed MLOD and requires a reported failure; without the
catch it throws the same message the real files produce.