### PR TITLE
Let Alt+F4 quit while a mission has user input disabled

### DIFF
--- a/engine/Poseidon/Core/Application.cpp
+++ b/engine/Poseidon/Core/Application.cpp
@@ -83,6 +83,11 @@ bool Application::IsInGameplay() const
                                                 GWorld && GWorld->IsUIEnabled(), progressActive);
 }
 
+bool Application::IsUserInputEnabled() const
+{
+    return !GWorld || GWorld->IsUserInputEnabled();
+}
+
 Engine* Application::CreateGraphicsEngine(const GraphicsEngineParams& /*params*/)
 {
     // Default: headless dummy engine (server, tools)

--- a/engine/Poseidon/Core/Application.hpp
+++ b/engine/Poseidon/Core/Application.hpp
@@ -73,6 +73,10 @@ class Application
     // are valid game shortcuts. False in menus, briefing, the Esc dialog, and loading.
     bool IsInGameplay() const;
 
+    // False while a script holds disableUserInput: the keyboard buffer is dropped
+    // whole, so no key reaches the game until it is released.
+    bool IsUserInputEnabled() const;
+
     // Windows handles (public for now - backwards compatibility)
     HINSTANCE m_hInstance = 0;
     HWND m_hwnd = 0;
@@ -169,9 +173,11 @@ class Application
 // A window close request (the OS turns Alt+F4 into one on Windows) is honoured unless
 // Alt is held during active gameplay, where Alt+F4 is a real in-game shortcut, not a
 // quit. The title-bar X / taskbar close / menu Quit carry no Alt and always close.
-inline bool ShouldHonorWindowClose(bool altDown, bool inGameplay)
+// Disabled user input is the exception: the shortcut cannot fire and neither can the
+// Esc menu, so ignoring the close leaves a fullscreen player no way out at all.
+inline bool ShouldHonorWindowClose(bool altDown, bool inGameplay, bool userInputEnabled)
 {
-    return !(altDown && inGameplay);
+    return !(altDown && inGameplay && userInputEnabled);
 }
 
 // Runtime gate that feeds ShouldHonorWindowClose. A world with enabled UI is gameplay only

--- a/engine/PoseidonGL33/SDLEventWindow.hpp
+++ b/engine/PoseidonGL33/SDLEventWindow.hpp
@@ -105,7 +105,7 @@ class SDLEventWindow
                 // standard desktop quit and must close — as do the title-bar X / taskbar
                 // / menu Quit, which carry no Alt.
                 const bool altDown = (SDL_GetModState() & SDL_KMOD_ALT) != 0;
-                if (!::Poseidon::ShouldHonorWindowClose(altDown, GApp->IsInGameplay()))
+                if (!::Poseidon::ShouldHonorWindowClose(altDown, GApp->IsInGameplay(), GApp->IsUserInputEnabled()))
                 {
                     LOG_INFO(Input, "SDLEventWindow: ignoring Alt+F4 close (valid in-game shortcut)");
                     continue;

--- a/tests/unit/engine/Poseidon/Core/test_window_close.cpp
+++ b/tests/unit/engine/Poseidon/Core/test_window_close.cpp
@@ -8,8 +8,9 @@ using Poseidon::ShouldReportInGameplayForWindowClose;
 // Alt+F4 must quit from non-game contexts (menus, briefing, the Esc dialog) but
 // stay a valid in-game shortcut (Alt = freelook, F4 = select unit 4) during active
 // gameplay. On Windows the OS turns Alt+F4 into a window-close request, so the
-// window layer decides whether to honour a close from (altDown, inGameplay): honour
-// unless Alt is held AND the player is in active gameplay.
+// window layer decides whether to honour a close from (altDown, inGameplay,
+// userInputEnabled): honour unless Alt is held AND the player is in active gameplay
+// AND the game can actually receive the shortcut.
 //
 // ShouldHonorWindowClose is the pure predicate tested here.  IsInGameplay() is
 // the runtime gate that feeds inGameplay — tested via triInGameplay in the
@@ -24,12 +25,25 @@ using Poseidon::ShouldReportInGameplayForWindowClose;
 TEST_CASE("Alt+F4 window close is honoured everywhere except active gameplay", "[core][application][window]")
 {
     // No Alt: always a deliberate close (title-bar X, taskbar, menu Quit).
-    REQUIRE(ShouldHonorWindowClose(false, false)); // menu, plain close
-    REQUIRE(ShouldHonorWindowClose(false, true));  // in-game, deliberate X / taskbar
+    REQUIRE(ShouldHonorWindowClose(false, false, true)); // menu, plain close
+    REQUIRE(ShouldHonorWindowClose(false, true, true));  // in-game, deliberate X / taskbar
 
     // Alt held: quit from menus/briefing/Esc; reserved as a shortcut only in gameplay.
-    REQUIRE(ShouldHonorWindowClose(true, false));      // the fix: Alt+F4 in a menu quits
-    REQUIRE_FALSE(ShouldHonorWindowClose(true, true)); // Alt+F4 in gameplay = shortcut, ignored
+    REQUIRE(ShouldHonorWindowClose(true, false, true));      // the fix: Alt+F4 in a menu quits
+    REQUIRE_FALSE(ShouldHonorWindowClose(true, true, true)); // Alt+F4 in gameplay = shortcut, ignored
+}
+
+TEST_CASE("Alt+F4 quits while a script holds disableUserInput", "[core][application][window]")
+{
+    // KeyboardState::Update drops the whole key buffer while input is disabled, so the
+    // F4 half of the shortcut never reaches the game and Esc cannot open the interrupt
+    // menu either. Keeping the close ignored there strands a fullscreen player, which is
+    // what a CTI mission does to anyone it blocks.
+    REQUIRE(ShouldHonorWindowClose(/*altDown*/ true, /*inGameplay*/ true, /*userInputEnabled*/ false));
+
+    // Input disabled outside gameplay is unchanged: the close was already honoured.
+    REQUIRE(ShouldHonorWindowClose(/*altDown*/ true, /*inGameplay*/ false, /*userInputEnabled*/ false));
+    REQUIRE(ShouldHonorWindowClose(/*altDown*/ false, /*inGameplay*/ true, /*userInputEnabled*/ false));
 }
 
 TEST_CASE("startup splash/progress is not treated as active gameplay for Alt+F4",
@@ -43,7 +57,8 @@ TEST_CASE("startup splash/progress is not treated as active gameplay for Alt+F4"
     REQUIRE(ShouldHonorWindowClose(/*altDown*/ true,
                                    ShouldReportInGameplayForWindowClose(/*hasWorld*/ true, /*introMode*/ false,
                                                                         /*uiEnabled*/ true,
-                                                                        /*startupProgressActive*/ true)));
+                                                                        /*startupProgressActive*/ true),
+                                   /*userInputEnabled*/ true));
 
     // Once progress is gone, the same non-intro world with UI enabled is real gameplay;
     // this preserves the existing Alt+F4 shortcut behavior.
@@ -53,5 +68,6 @@ TEST_CASE("startup splash/progress is not treated as active gameplay for Alt+F4"
                                          ShouldReportInGameplayForWindowClose(/*hasWorld*/ true,
                                                                               /*introMode*/ false,
                                                                               /*uiEnabled*/ true,
-                                                                              /*startupProgressActive*/ false)));
+                                                                              /*startupProgressActive*/ false),
+                                         /*userInputEnabled*/ true));
 }


### PR DESCRIPTION
Fixes #141. Reproduced on Linux (GL33) with the key pressed by hand.

A window close is ignored during gameplay when Alt is held, so that the F4
keypress reaches the game: Alt is freelook and F4 selects unit 4. That reasoning
stops holding once a script calls `disableUserInput`. `KeyboardState::Update`
then clears every key and drops the buffer, so F4 never arrives — and neither
does anything else: with input disabled, Esc does not open `IDD_INTERRUPT` (49),
while the same key on the same session with input enabled opens it and closes it
again. The close request is the only way out left, and it is discarded.

## Measured

Same mission, same state, the same key pressed by hand:

| build | user input | discards logged | result |
| --- | --- | --- | --- |
| without this change | disabled | 2 | window stays |
| with it | disabled | 0 | exits, code 0 |
| with it | enabled | 2 | ignored |

The count comes from the handler's own line, so a row reading 2 is a close that
arrived with Alt registered and was deliberately thrown away, not a keypress that
went missing:

```
[INPUT] SDLEventWindow: ignoring Alt+F4 close (valid in-game shortcut)
```

The third row is the one that guards against overcorrecting. With input enabled
the predicate is the same expression as before, and Alt+F4 is still a shortcut.

Esc is left alone on purpose — blocking it is what `disableUserInput` is for. The
difference is that a mission may take the game's controls, not the desktop's
request to close the program.

## Verification

- New case in `test_window_close.cpp`. Checked that it fails with the predicate
  reverted:

  ```
  test_window_close.cpp:42: FAILED:
    REQUIRE( ShouldHonorWindowClose( true, true, false) )
  with expansion:  false
  ```

- `ctest` is 3953/3953 on `linux-x64-clang-rwdi`.
- `ShouldHonorWindowClose` has one caller outside the tests. `EngineDummy`
  handles the close itself and never consults the predicate, so the server and
  the tools are unchanged, and with no world the new accessor returns true, which
  is the old answer.
- The new input is read through `Application` rather than folded into
  `IsInGameplay`, which also feeds `triInGameplay` and the harness `in_gameplay`
  field.

Not exercised here: Windows and macOS.
