### PR TITLE
Remove dead `.gitattributes` rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,13 +3,6 @@
 # the same shared working tree alternate between CRLF and LF.
 * text=auto eol=lf
 
-# Force CRLF line endings for Windows-specific files
-*.vcxproj text eol=crlf
-*.vcxproj.filters text eol=crlf
-*.sln text eol=crlf
-*.bat text eol=crlf
-*.cmd text eol=crlf
-
 # C/C++ source files use LF on every platform.
 *.c text eol=lf
 *.cpp text eol=lf
@@ -21,32 +14,3 @@
 
 # Makefiles must use LF
 Makefile text eol=lf
-
-# Binary files
-*.lib binary
-*.obj binary
-*.exe binary
-*.dll binary
-*.pdb binary
-*.suo binary
-*.user binary
-*.ncb binary
-*.aps binary
-*.sdf binary
-*.opensdf binary
-*.db binary
-*.opendb binary
-packages/** filter=lfs diff=lfs merge=lfs -text
-release/** filter=lfs diff=lfs merge=lfs -text
-
-# Menu / options resource files under BIN/ are small TEXT config (BIS resource
-# syntax + stringtables), not binary game data.  The blanket packages/** rule
-# above pins them in LFS with -text (no line-ending normalization), which left
-# them flip-flopping CRLF<->LF and showing unreadable LFS-pointer diffs.  Take
-# them OUT of LFS and normalize to LF so they diff/merge as text and stay
-# stable.  Binary RESOURCE.BIN in the same dir keeps the packages/** LFS rule.
-packages/**/BIN/*.hpp text eol=lf !filter !diff !merge
-packages/**/BIN/STRINGTABLE_MAINMENU.utf8.csv text eol=lf !filter !diff !merge
-packages/README.md text eol=lf !filter !diff !merge
-tests/fixtures/mods-stress/**/*.pbo filter=lfs diff=lfs merge=lfs -text
-tests/fixtures/mods-faguss/** filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
None of them can fire: `/packages` is gitignored, `release/` and the fixture trees do not exist, and no tracked file matches the binary or CRLF rules. `text=auto` already detects binary content.