### PR TITLE
Porting land clipping and object instancing (perf) improvements

### DIFF
--- a/engine/Poseidon/Graphics/Core/Engine.hpp
+++ b/engine/Poseidon/Graphics/Core/Engine.hpp
@@ -359,6 +359,16 @@ class Engine : public IGraphicsEngine
     /// from the sun's NightEffect; the lit shaders fade the shadow darkness by it.
     virtual void SetShadowMapSunFactor(float /*factor01*/) {}
 
+    // Upload the terrain height grid as a GPU texture. Default no-op for headless backends.
+    virtual void SetTerrainHeightmap(const float* /*heights*/, int /*width*/, int /*height*/, float /*invGrid*/) {}
+
+    // True when the backend snaps land-clipped geometry to the terrain in the vertex
+    // shader; when so, the render path skips the CPU land-clip deform. Default off.
+    virtual bool LandClipInVS() const { return false; }
+    // Land-clip params for the next draw: enable (1 = VS conforms) and the shape's model-space
+    // bounding centre (the VS samples the terrain there as the ClipLandKeep reference).
+    virtual void SetLandClipParams(float /*enable*/, Vector3Par /*boundingCenter*/) {}
+
   private:
     Engine(const Engine& src); // no copy
     void operator=(const Engine& src);
@@ -433,6 +443,7 @@ class Engine : public IGraphicsEngine
     virtual bool InstancedRunAdd(const Matrix4& /*modelToWorld*/) { return false; }
     virtual void BeginInstancedRunUpload() {}
     virtual bool EndInstancedRun() { return true; }
+    virtual bool InstancedRunActive() const { return false; }
 
     // Explicit pass-kind routing.  Producers (Man::DrawProxies for first-person,
     // vehicle cockpit draw, etc.) wrap a draw scope with `SetPassKindHint(Cockpit)`

--- a/engine/Poseidon/Graphics/Core/Engine.hpp
+++ b/engine/Poseidon/Graphics/Core/Engine.hpp
@@ -360,14 +360,17 @@ class Engine : public IGraphicsEngine
     virtual void SetShadowMapSunFactor(float /*factor01*/) {}
 
     // Upload the terrain height grid as a GPU texture. Default no-op for headless backends.
-    virtual void SetTerrainHeightmap(const float* /*heights*/, int /*width*/, int /*height*/, float /*invGrid*/) {}
+    virtual void SetTerrainHeightmap(const float* /*heights*/, int /*width*/, int /*height*/, float /*invGrid*/,
+                                     float /*invLandGrid*/)
+    {
+    }
 
     // True when the backend snaps land-clipped geometry to the terrain in the vertex
     // shader; when so, the render path skips the CPU land-clip deform. Default off.
     virtual bool LandClipInVS() const { return false; }
-    // Land-clip params for the next draw: enable (1 = VS conforms) and the shape's model-space
+    // Land-clip params for the next draw: mode and the shape's model-space
     // bounding centre (the VS samples the terrain there as the ClipLandKeep reference).
-    virtual void SetLandClipParams(float /*enable*/, Vector3Par /*boundingCenter*/) {}
+    virtual void SetLandClipParams(float /*mode*/, Vector3Par /*boundingCenter*/) {}
 
   private:
     Engine(const Engine& src); // no copy

--- a/engine/Poseidon/Graphics/Rendering/Primitives/Vertex.hpp
+++ b/engine/Poseidon/Graphics/Rendering/Primitives/Vertex.hpp
@@ -80,8 +80,9 @@ using Poseidon::Foundation::RemoveLLinks;
 
 enum VBType
 {
-	VBDynamic, // animated, re-uploaded every frame
-	VBStatic, // never animated, uploaded once
+	VBDynamic, // vertices change every frame; re-uploaded every draw
+	VBStatic, // vertices never change; uploaded once
+	VBOnDemand, // vertices are stable but may change occasionally
 };
 
 class VertexBuffer : public RemoveLLinks

--- a/engine/Poseidon/Graphics/Rendering/Shape/Shape.hpp
+++ b/engine/Poseidon/Graphics/Rendering/Shape/Shape.hpp
@@ -517,6 +517,15 @@ class Shape: public Poseidon::VertexTable
 	void SetPhase( float time, float baseTime ); // interpolate between two nearest phases
 
 	bool IsAnimated() const {return _phase.Size()>1;}
+
+	// True when land clip deforms this shape's vertices
+	bool HasDeformingLandClip() const
+	{
+		// The all-ClipLandOn case is baked via SurfaceSplit, so it is excluded.
+		return (GetOrHints() & (ClipLandKeep | ClipLandOn)) &&
+		       (GetAndHints() & ClipLandMask) != ClipLandOn;
+	}
+
 	void SetPhaseIndex( int index );
 	int NAnimationPhases() const {return _phase.Size();}
 
@@ -875,6 +884,8 @@ class LODShape: public RefCountWithLinks
 	void SetAutoCenter( bool autoCenter ) {_autoCenter=autoCenter;}
 	void AllowAnimation( bool allow=true ) {_allowAnimation=allow;} // non static usage detected
 	bool GetAllowAnimation() const {return _allowAnimation;} // non static usage detected
+	// True when land clip is the only reason the shape is animated
+	bool IsLandClipOnlyAnim() const;
 
 	void OptimizeRendering();
 	void CalculateBoundingSphere();

--- a/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Shape/ShapeDraw.cpp
@@ -376,7 +376,11 @@ void LODShape::OptimizeRendering()
         if (optimizeHW)
         {
             const RStringB tentString("tent");
-            VBType type = shape->GetAllowAnimation() ? VBDynamic : VBStatic;
+            VBType type = VBStatic;
+            if (shape->GetAllowAnimation())
+            {
+                type = shape->IsLandClipOnlyAnim() ? VBOnDemand : VBDynamic;
+            }
             if (shape->GetPropertyDammage() == tentString)
             {
                 type = VBDynamic;

--- a/engine/Poseidon/Graphics/Rendering/Shape/ShapeLOD.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Shape/ShapeLOD.cpp
@@ -179,6 +179,27 @@ void LODShape::CalculateHints()
     }
 }
 
+bool LODShape::IsLandClipOnlyAnim() const
+{
+    // Land clip is the only reason the shape is animated, so a land-clip vertex shader can
+    // position it and the render geometry stays stable. Decals (CPU-conformed) and animated
+    // lights disqualify it.
+    bool otherAnim = (_orHints & ClipDecalMask) != 0;
+    if ((_orHints & ClipLightMask) == (_andHints & ClipLightMask))
+    {
+        switch (_orHints & ClipLightMask)
+        {
+            case ClipLightSky:
+            case ClipLightCloud:
+            case ClipLightStars:
+            case ClipLightLine:
+                otherAnim = true;
+                break;
+        }
+    }
+    return _allowAnimation && (_orHints & ClipLandMask) != 0 && !otherAnim;
+}
+
 void LODShape::DefineMinMax(int level)
 {
     Shape* oShape = LevelOpaque(level);

--- a/engine/Poseidon/World/Scene/Object.cpp
+++ b/engine/Poseidon/World/Scene/Object.cpp
@@ -378,13 +378,38 @@ void Object::Animate(int level)
     ApplyLandClip(level);
 }
 
+namespace
+{
+// RAII guard for the render-draw land clip state.
+class LandClipScope
+{
+  public:
+    explicit LandClipScope(bool active) : _prev(_active) { _active = active; }
+    ~LandClipScope() { _active = _prev; }
+
+    // True when we're currently rendering the object and the render backend handles the land clip
+    static bool SkipCpuLandClip() { return _active && GEngine->LandClipInVS(); }
+
+  private:
+    const bool _prev;
+    static bool _active;
+};
+bool LandClipScope::_active = false;
+} // namespace
+
 void Object::ApplyLandClip(int level)
 {
+    if (LandClipScope::SkipCpuLandClip())
+    {
+        return;
+    }
+
     Shape* shape = _shape->Level(level);
     // check if object needs surface animation
     if ((shape->GetAndHints() & ClipLandMask) == ClipLandOn)
     {
         // no animation required: will be done during SurfaceSplit
+        return;
     }
     else if ((shape->GetOrHints() & (ClipLandKeep | ClipLandOn)) && GLOB_LAND)
     {
@@ -453,26 +478,28 @@ void Object::AnimatedMinMax(int level, Vector3* minMax)
         return;
     }
 
-    // default implementation - slow, but robust
-    Animate(level);
+    {
+        LandClipScope lc(false);
+        Animate(level);
 
-    Shape* shape = GetShape()->Level(level);
-    if (_isDestroyed && _destroyPhase > 0 && GetDestructType() != DestructTree)
-    {
-        // set minmax box and sphere
-        Vector3Val min = shape->MinOrig();
-        Vector3Val max = shape->MaxOrig();
-        // some space on borders required
-        Vector3Val cnt = (min + max) * 0.5f;
-        const float sFactor = 1.1;
-        minMax[0] = cnt + (min - cnt) * sFactor;
-        minMax[1] = cnt + (max - cnt) * sFactor;
+        Shape* shape = GetShape()->Level(level);
+        if (_isDestroyed && _destroyPhase > 0 && GetDestructType() != DestructTree)
+        {
+            // set minmax box and sphere
+            Vector3Val min = shape->MinOrig();
+            Vector3Val max = shape->MaxOrig();
+            // some space on borders required
+            Vector3Val cnt = (min + max) * 0.5f;
+            const float sFactor = 1.1;
+            minMax[0] = cnt + (min - cnt) * sFactor;
+            minMax[1] = cnt + (max - cnt) * sFactor;
+        }
+        else
+        {
+            shape->MinMaxDynamic(minMax);
+        }
+        Deanimate(level);
     }
-    else
-    {
-        shape->MinMaxDynamic(minMax);
-    }
-    Deanimate(level);
 
     if (cacheable)
     {
@@ -484,6 +511,14 @@ void Object::AnimatedMinMax(int level, Vector3* minMax)
 
 void Object::AnimatedBSphere(int level, Vector3& bCenter, float& bRadius, bool isAnimated)
 {
+    if (GEngine->LandClipInVS() && HasLandClip(level))
+    {
+        Vector3 mm[2];
+        AnimatedMinMax(level, mm);
+        bCenter = (mm[0] + mm[1]) * 0.5f;
+        bRadius = (mm[1] - mm[0]).Size() * 0.5f;
+        return;
+    }
     // isAnimated should be set
     // when function is called inside Animate/Deanimate block
     // default implementation - slow, but robust
@@ -521,6 +556,11 @@ void Object::Deanimate(int level)
 
 void Object::RestoreLandClip(int level)
 {
+    if (LandClipScope::SkipCpuLandClip())
+    {
+        return;
+    }
+
     Shape* shape = _shape->Level(level);
     if ((shape->GetAndHints() & ClipLandMask) == ClipLandOn)
     {
@@ -893,6 +933,7 @@ void Object::Draw(int forceLOD, ClipFlags clipFlags, const FrameBase& pos)
 
     // test if reference points to valid object
     // get object position in clipping coordinates
+    LandClipScope lcDraw(true);
     Animate(forceLOD);
 
     if (clipFlags)
@@ -919,6 +960,7 @@ void Object::Draw(int forceLOD, ClipFlags clipFlags, const FrameBase& pos)
 
     float constFog = -1;
     bool skip = false;
+    if (!GEngine->InstancedRunActive())
     {
         const render::LegacySpec specT = render::SplitLegacy(special);
         if (!render::Has(specT.routing, render::Routing::FogDisabled))
@@ -964,6 +1006,12 @@ void Object::Draw(int forceLOD, ClipFlags clipFlags, const FrameBase& pos)
 
         sShape->PrepareTextures(z2, special);
         // perform actual drawing
+
+        if (GEngine->LandClipInVS() && (sShape->GetOrHints() & ClipLandMask) != 0)
+        {
+            float enable = sShape->HasDeformingLandClip() ? 1.0f : 0.0f;
+            GEngine->SetLandClipParams(enable, _shape->BoundingCenter());
+        }
 
         // if neccessary, split it
         if (render::Has(specT.routing, render::Routing::OnSurface) &&

--- a/engine/Poseidon/World/Scene/Object.cpp
+++ b/engine/Poseidon/World/Scene/Object.cpp
@@ -397,6 +397,17 @@ class LandClipScope
 bool LandClipScope::_active = false;
 } // namespace
 
+bool Object::RenderHandlesLandClip()
+{
+    return LandClipScope::SkipCpuLandClip();
+}
+
+Object::LandClipMode Object::GetLandClipMode(int level) const
+{
+    Shape* shape = _shape->LevelOpaque(level);
+    return shape && shape->HasDeformingLandClip() ? LandClipVertex : LandClipNone;
+}
+
 void Object::ApplyLandClip(int level)
 {
     if (LandClipScope::SkipCpuLandClip())
@@ -1007,10 +1018,9 @@ void Object::Draw(int forceLOD, ClipFlags clipFlags, const FrameBase& pos)
         sShape->PrepareTextures(z2, special);
         // perform actual drawing
 
-        if (GEngine->LandClipInVS() && (sShape->GetOrHints() & ClipLandMask) != 0)
+        if (GEngine->LandClipInVS())
         {
-            float enable = sShape->HasDeformingLandClip() ? 1.0f : 0.0f;
-            GEngine->SetLandClipParams(enable, _shape->BoundingCenter());
+            GEngine->SetLandClipParams(float(GetLandClipMode(forceLOD)), _shape->BoundingCenter());
         }
 
         // if neccessary, split it

--- a/engine/Poseidon/World/Scene/Object.cpp
+++ b/engine/Poseidon/World/Scene/Object.cpp
@@ -485,19 +485,33 @@ void Object::ApplyLandClip(int level)
     }
 }
 
-void Object::AnimatedMinMax(int level, Vector3* minMax)
+bool Object::AnimBBoxCacheable(int level) const
 {
     // The engine reuses the "animate" path for both real animation and snapping a shape to the
     // landscape surface (ClipLand). A land-clipped shape does not move after level load, so its
     // bounds are fixed and can be cached (excluding damage/destruction).
     const bool destroying = _isDestroyed && _destroyPhase > 0;
-    const bool cacheable = HasLandClip(level) && GetTotalDammage() == 0 && !destroying;
-    if (cacheable && _animBBoxLevel == level)
+    return HasLandClip(level) && GetTotalDammage() == 0 && !destroying;
+}
+
+bool Object::CachedAnimatedMinMax(int level, Vector3* minMax) const
+{
+    if (_animBBoxLevel != level || !AnimBBoxCacheable(level))
     {
-        minMax[0] = _animBBoxMin;
-        minMax[1] = _animBBoxMax;
+        return false;
+    }
+    minMax[0] = _animBBoxMin;
+    minMax[1] = _animBBoxMax;
+    return true;
+}
+
+void Object::AnimatedMinMax(int level, Vector3* minMax)
+{
+    if (CachedAnimatedMinMax(level, minMax))
+    {
         return;
     }
+    const bool cacheable = AnimBBoxCacheable(level);
 
     {
         LandClipScope lc(false);
@@ -535,10 +549,18 @@ void Object::AnimatedBSphere(int level, Vector3& bCenter, float& bRadius, bool i
     if (GEngine->LandClipInVS() && HasLandClip(level))
     {
         Vector3 mm[2];
-        AnimatedMinMax(level, mm);
-        bCenter = (mm[0] + mm[1]) * 0.5f;
-        bRadius = (mm[1] - mm[0]).Size() * 0.5f;
-        return;
+        bool haveBounds = CachedAnimatedMinMax(level, mm);
+        if (!haveBounds && !isAnimated)
+        {
+            AnimatedMinMax(level, mm);
+            haveBounds = true;
+        }
+        if (haveBounds)
+        {
+            bCenter = (mm[0] + mm[1]) * 0.5f;
+            bRadius = (mm[1] - mm[0]).Size() * 0.5f;
+            return;
+        }
     }
     // isAnimated should be set
     // when function is called inside Animate/Deanimate block

--- a/engine/Poseidon/World/Scene/Object.cpp
+++ b/engine/Poseidon/World/Scene/Object.cpp
@@ -243,6 +243,16 @@ bool Object::IsAnimatedShadow(int level) const
     return false;
 }
 
+bool Object::DeformsSharedShape(int level) const
+{
+    Shape* shape = _shape->Level(level);
+    if (!shape || shape->NFaces() <= 0)
+    {
+        return false;
+    }
+    return _isDestroyed && _destroyPhase > 0 && GetDestructType() != DestructTree;
+}
+
 bool Object::HasLandClip(int level) const
 {
     Shape* shape = _shape->Level(level);

--- a/engine/Poseidon/World/Scene/Object.hpp
+++ b/engine/Poseidon/World/Scene/Object.hpp
@@ -306,6 +306,7 @@ public:
 
 	virtual bool IsAnimated( int level ) const; // appearence changed with Animate
 	virtual bool IsAnimatedShadow( int level ) const; // shadow changed with Animate
+	virtual bool DeformsSharedShape( int level ) const;
 
 	// True when the shape snaps to the landscape surface (ClipLandKeep/ClipLandOn).
 	virtual bool HasLandClip( int level ) const;

--- a/engine/Poseidon/World/Scene/Object.hpp
+++ b/engine/Poseidon/World/Scene/Object.hpp
@@ -301,6 +301,8 @@ public:
 
 	// Get min-max of object after animate. Default (generic) implementation may be slow when shape is complex.
 	virtual void AnimatedMinMax( int level, Vector3 *minMax );
+	bool AnimBBoxCacheable( int level ) const;
+	bool CachedAnimatedMinMax( int level, Vector3 *minMax ) const;
 	// Get bounding sphere of object after animate. Default (generic) implementation may be slow when shape is complex.
 	virtual void AnimatedBSphere( int level, Vector3 &bCenter, float &bRadius, bool isAnimated );
 

--- a/engine/Poseidon/World/Scene/Object.hpp
+++ b/engine/Poseidon/World/Scene/Object.hpp
@@ -308,7 +308,16 @@ public:
 	virtual bool IsAnimatedShadow( int level ) const; // shadow changed with Animate
 
 	// True when the shape snaps to the landscape surface (ClipLandKeep/ClipLandOn).
-	bool HasLandClip( int level ) const;
+	virtual bool HasLandClip( int level ) const;
+
+	enum LandClipMode
+	{
+		LandClipNone = 0,
+		LandClipVertex = 1,
+		LandClipPlane = 2,
+	};
+	virtual LandClipMode GetLandClipMode( int level ) const;
+	static bool RenderHandlesLandClip();
 
 	// Change object position. Used when object is already present in landscape.
 	virtual void Move(Matrix4Par transform);

--- a/engine/Poseidon/World/Scene/ObjectClasses.cpp
+++ b/engine/Poseidon/World/Scene/ObjectClasses.cpp
@@ -411,6 +411,20 @@ bool ForestPlain::IsAnimatedShadow(int level) const
     return false;
 }
 
+bool ForestPlain::HasLandClip(int level) const
+{
+    return base::HasLandClip(level) || !(_singleMatrixT1 || _singleMatrixT2);
+}
+
+Object::LandClipMode ForestPlain::GetLandClipMode(int level) const
+{
+    if (_singleMatrixT1 || _singleMatrixT2)
+    {
+        return LandClipNone;
+    }
+    return LandClipPlane;
+}
+
 Matrix4 ForestPlain::GetInvTransform() const
 {
     if (!_singleMatrixT1 && !_singleMatrixT2)
@@ -511,6 +525,11 @@ namespace Poseidon
 {
 void ForestPlain::Animate(int level)
 {
+    if (RenderHandlesLandClip())
+    {
+        return;
+    }
+
     Shape* shape = _shape->Level(level);
     if (!shape)
     {
@@ -557,6 +576,7 @@ void ForestPlain::Animate(int level)
         float d0111 = y01 - y11;
 
         shape->InvalidateNormals();
+        shape->InvalidateBuffer();
 
         Matrix4Val toWorld = Transform();
         Matrix4Val fromWorld = GetInvTransform();
@@ -660,7 +680,19 @@ namespace Poseidon
 {
 void ForestPlain::Deanimate(int level)
 {
-    // base::Deanimate(level);
+    if (RenderHandlesLandClip() || !GEngine->LandClipInVS() || _singleMatrixT1 || _singleMatrixT2)
+    {
+        return;
+    }
+    Shape* shape = _shape->Level(level);
+    if (!shape || !shape->OriginalPosValid())
+    {
+        return;
+    }
+    shape->RestoreOriginalPos();
+    shape->RestoreMinMax();
+    shape->InvalidateNormals();
+    shape->InvalidateBuffer();
 }
 
 RoadType::RoadType() = default;

--- a/engine/Poseidon/World/Scene/ObjectClasses.hpp
+++ b/engine/Poseidon/World/Scene/ObjectClasses.hpp
@@ -187,6 +187,8 @@ class ForestPlain: public Object
 	void Animate( int level ) override;
 	Vector3 AnimatePoint( int level, int index ) const override;
 	void Deanimate( int level ) override;
+	bool HasLandClip( int level ) const override;
+	LandClipMode GetLandClipMode( int level ) const override;
 
 	float ViewDensity() const override;
 

--- a/engine/Poseidon/World/Scene/SceneDraw.cpp
+++ b/engine/Poseidon/World/Scene/SceneDraw.cpp
@@ -1672,7 +1672,7 @@ void Scene::DrawObjectsAndShadowsPass1()
             int runEnd = i + 1;
             const int headSpecial = sShape->Special() | oi->object->GetObjSpecial();
             const render::LegacySpec headSpec = render::SplitLegacy(headSpecial);
-            const bool landClip = (shape->GetOrHints() & ClipLandMask) != 0;
+            const bool landClip = (sShape->GetOrHints() & ClipLandMask) != 0;
             const bool landClipBatch = landClip && GEngine->LandClipInVS() && sShape->HasDeformingLandClip();
             const bool cheapPass = (!landClip || landClipBatch) && oi->object->Static() && sShape->NProxies() == 0 &&
                                    !render::Has(headSpec.routing, render::Routing::OnSurface) &&

--- a/engine/Poseidon/World/Scene/SceneDraw.cpp
+++ b/engine/Poseidon/World/Scene/SceneDraw.cpp
@@ -1633,15 +1633,20 @@ void Scene::DrawObjectsAndShadowsPass1()
 
 #if DRAW_OBJS
     {
-        // Instanced runs (perf effort 08): _drawMergers is shape-sorted, so
-        // identical static shapes arrive contiguously. A batchable run draws
-        // the head once inside Begin/EndInstancedRun — every TL section then
-        // renders all K instances from the WorldInstances matrix array. The
-        // predicate keeps per-object state out of batches: static, proxy-free,
-        // not OnSurface/IsColored, equal obj-special, no local lights in the
-        // scene, and a tight distance band so the head's constant-fog value
-        // is representative for the whole batch.
-        const bool noLocalLights = NLights() == 0;
+        // _drawMergers is shape-sorted, so identical static shapes arrive contiguously. A
+        // batchable run draws the head once inside Begin/EndInstancedRun; every TL section
+        // then renders all K instances from the WorldInstances matrix array.
+        LightList lightProbe(true);
+        auto litByLocalLight = [&](SortObject* o) -> bool
+        {
+            if (!o->object)
+            {
+                return false;
+            }
+            const LightList& sel = SelectLights(o->object->Transform(), o->object, o->drawLOD, lightProbe);
+            return sel.Size() > 0;
+        };
+        const int kMinInstanceRun = 2;
         for (int i = 0; i < _drawMergers.Size();)
         {
             SortObject* oi = _drawMergers[i];
@@ -1667,26 +1672,25 @@ void Scene::DrawObjectsAndShadowsPass1()
             int runEnd = i + 1;
             const int headSpecial = sShape->Special() | oi->object->GetObjSpecial();
             const render::LegacySpec headSpec = render::SplitLegacy(headSpecial);
-            const bool headBatchable = noLocalLights && oi->object->Static() && sShape->NProxies() == 0 &&
-                                       !render::Has(headSpec.routing, render::Routing::OnSurface) &&
-                                       !render::Has(headSpec.routing, render::Routing::IsColored) &&
-                                       oi->object != GWorld->CameraOn();
+            const bool landClip = (shape->GetOrHints() & ClipLandMask) != 0;
+            const bool landClipBatch = landClip && GEngine->LandClipInVS() && sShape->HasDeformingLandClip();
+            const bool cheapPass = (!landClip || landClipBatch) && oi->object->Static() && sShape->NProxies() == 0 &&
+                                   !render::Has(headSpec.routing, render::Routing::OnSurface) &&
+                                   !render::Has(headSpec.routing, render::Routing::IsColored) &&
+                                   oi->object != GWorld->CameraOn();
+            const bool lit = cheapPass && litByLocalLight(oi);
+            const bool headBatchable = cheapPass && !lit;
             if (headBatchable)
             {
                 GEngine->InstancedRunReset();
                 if (GEngine->InstancedRunAdd(oi->object->Transform()))
                 {
-                    // Fog band: keep members within ~5% of the head's distance so
-                    // the head's per-object constant fog approximates all of them.
-                    const float d2lo = oi->distance2 * 0.90f;
-                    const float d2hi = oi->distance2 * 1.10f;
                     while (runEnd < _drawMergers.Size())
                     {
                         SortObject* oj = _drawMergers[runEnd];
                         if (oj->object->GetShape() != shape || oj->drawLOD != oi->drawLOD ||
                             oj->passNum != oi->passNum || !oj->object->Static() ||
-                            (sShape->Special() | oj->object->GetObjSpecial()) != headSpecial || oj->distance2 < d2lo ||
-                            oj->distance2 > d2hi)
+                            (sShape->Special() | oj->object->GetObjSpecial()) != headSpecial || litByLocalLight(oj))
                         {
                             break;
                         }
@@ -1701,7 +1705,7 @@ void Scene::DrawObjectsAndShadowsPass1()
 
             const int runLen = runEnd - i;
             GSectionFilter = SectionClassFilter::OpaqueAndCutout;
-            if (headBatchable && runLen >= 4)
+            if (headBatchable && runLen >= kMinInstanceRun)
             {
                 GEngine->BeginInstancedRunUpload();
                 DrawSortObject(oi);

--- a/engine/Poseidon/World/Scene/SceneDraw.cpp
+++ b/engine/Poseidon/World/Scene/SceneDraw.cpp
@@ -18,6 +18,7 @@
 #include <Poseidon/Foundation/Math/MathOpt.hpp>
 #include <Poseidon/Foundation/Memory/CheckMem.hpp>
 #include <algorithm>
+#include <cstdlib>
 #include <map>
 #include <string>
 #include <vector>
@@ -868,6 +869,29 @@ static bool FarEnoughForOcclusion(const SortObject* oi)
 
 void Scene::AdjustComplexity()
 {
+    // Benchmark aid: POSEIDON_LOD_FIX freezes the adaptive detail scaler so per-frame
+    // draw-call and buffer-upload counts are reproducible. A positive numeric value pins
+    // _lodInvWidth directly (clamped to the quality band); any other value pins to the
+    // highest-detail bound. Unset = normal frame-rate-driven adaptation.
+    static const float lodFix = []() -> float
+    {
+        const char* e = std::getenv("POSEIDON_LOD_FIX");
+        if (!e)
+            return 0.0f;
+        const float v = static_cast<float>(std::atof(e));
+        return v > 0.0f ? v : -1.0f; // -1 == pin to highest detail (_minLodInvWidth)
+    }();
+    if (lodFix != 0.0f)
+    {
+        _lodInvWidth = lodFix > 0.0f ? lodFix : _minLodInvWidth;
+        saturate(_lodInvWidth, _minLodInvWidth, _maxLodInvWidth);
+        // Still assign each object's draw/shadow LOD at the pinned density; only the
+        // frame-time-driven adjustment of _lodInvWidth below is skipped.
+        AdjustComplexity(_drawObjects);
+        AdjustShadowComplexity(_drawObjects);
+        return;
+    }
+
     float oldLodInvWidth = _lodInvWidth;
 
     // adjust lodInvWidth so we are on the line given by points

--- a/engine/Poseidon/World/Scene/SceneDraw.cpp
+++ b/engine/Poseidon/World/Scene/SceneDraw.cpp
@@ -1672,9 +1672,10 @@ void Scene::DrawObjectsAndShadowsPass1()
             int runEnd = i + 1;
             const int headSpecial = sShape->Special() | oi->object->GetObjSpecial();
             const render::LegacySpec headSpec = render::SplitLegacy(headSpecial);
-            const bool landClip = (sShape->GetOrHints() & ClipLandMask) != 0;
-            const bool landClipBatch = landClip && GEngine->LandClipInVS() && sShape->HasDeformingLandClip();
-            const bool cheapPass = (!landClip || landClipBatch) && oi->object->Static() && sShape->NProxies() == 0 &&
+            const bool cpuDeform = oi->object->IsAnimated(oi->drawLOD);
+            const bool vsDeform =
+                GEngine->LandClipInVS() && oi->object->GetLandClipMode(oi->drawLOD) != Object::LandClipNone;
+            const bool cheapPass = (!cpuDeform || vsDeform) && oi->object->Static() && sShape->NProxies() == 0 &&
                                    !render::Has(headSpec.routing, render::Routing::OnSurface) &&
                                    !render::Has(headSpec.routing, render::Routing::IsColored) &&
                                    oi->object != GWorld->CameraOn();

--- a/engine/Poseidon/World/Scene/SceneDraw.cpp
+++ b/engine/Poseidon/World/Scene/SceneDraw.cpp
@@ -1675,10 +1675,10 @@ void Scene::DrawObjectsAndShadowsPass1()
             const bool cpuDeform = oi->object->IsAnimated(oi->drawLOD);
             const bool vsDeform =
                 GEngine->LandClipInVS() && oi->object->GetLandClipMode(oi->drawLOD) != Object::LandClipNone;
-            const bool cheapPass = (!cpuDeform || vsDeform) && oi->object->Static() && sShape->NProxies() == 0 &&
-                                   !render::Has(headSpec.routing, render::Routing::OnSurface) &&
-                                   !render::Has(headSpec.routing, render::Routing::IsColored) &&
-                                   oi->object != GWorld->CameraOn();
+            const bool cheapPass =
+                !oi->object->DeformsSharedShape(oi->drawLOD) && (!cpuDeform || vsDeform) && oi->object->Static() &&
+                sShape->NProxies() == 0 && !render::Has(headSpec.routing, render::Routing::OnSurface) &&
+                !render::Has(headSpec.routing, render::Routing::IsColored) && oi->object != GWorld->CameraOn();
             const bool lit = cheapPass && litByLocalLight(oi);
             const bool headBatchable = cheapPass && !lit;
             if (headBatchable)
@@ -1691,6 +1691,7 @@ void Scene::DrawObjectsAndShadowsPass1()
                         SortObject* oj = _drawMergers[runEnd];
                         if (oj->object->GetShape() != shape || oj->drawLOD != oi->drawLOD ||
                             oj->passNum != oi->passNum || !oj->object->Static() ||
+                            oj->object->DeformsSharedShape(oj->drawLOD) ||
                             (sShape->Special() | oj->object->GetObjSpecial()) != headSpecial || litByLocalLight(oj))
                         {
                             break;

--- a/engine/Poseidon/World/Terrain/LandSave.cpp
+++ b/engine/Poseidon/World/Terrain/LandSave.cpp
@@ -521,6 +521,7 @@ void Landscape::ResampleTerrain(int sampleStepLog)
     _terrainRangeLog -= sampleStepLog;
     _terrainGrid *= sampleStep;
     _invTerrainGrid = 1 / _terrainGrid;
+    _heightmapDirty = true;
 
     MakeObjectsTerrainAbsolute();
 
@@ -926,6 +927,7 @@ void Landscape::SubdivideTerrainOneStep()
     _terrainRangeLog += 1;
     _terrainGrid /= 2;
     _invTerrainGrid = 1 / _terrainGrid;
+    _heightmapDirty = true;
 }
 
 void Landscape::SubdivideTerrain(int subdivStepLog)
@@ -1017,6 +1019,7 @@ bool Landscape::LoadSubdivCache(int targetSubdivLog)
     _terrainRangeLog = cachedTerrainRangeLog;
     _terrainGrid = cachedTerrainGrid;
     _invTerrainGrid = 1.0f / _terrainGrid;
+    _heightmapDirty = true;
 
     // Adjust objects back to absolute with new terrain heights
     MakeObjectsTerrainAbsolute();

--- a/engine/Poseidon/World/Terrain/Landscape.hpp
+++ b/engine/Poseidon/World/Terrain/Landscape.hpp
@@ -449,8 +449,15 @@ class Landscape: public SerializeClass
 	// access to data and textures
 	Array2D<RawType> _data;
 
+	// re-upload _data to the GPU height texture on the next Draw
+	bool _heightmapDirty = true;
+
 	float GetData( int x, int z ) const {return RawToHeight(_data(x,z));}
-	void SetData( int x, int z, float data ) {_data(x,z)=HeightToRaw(data);}
+	void SetData( int x, int z, float data )
+	{
+		_data(x,z)=HeightToRaw(data);
+		_heightmapDirty=true;
+	}
 
 	int GetTex( int x, int z ) const {return _tex(x,z);}
 	void SetTex( int x, int z, int data ) {_tex(x,z)=data;}
@@ -694,6 +701,8 @@ class Landscape: public SerializeClass
 	void DrawHorizont(Scene &scene);
 	void DrawClouds(Scene &scene);
 	void Draw( Scene &scene );
+
+	void FlushHeightmapToRenderer();
 
 	void DrawWater(const LandBegEnd &bigRect, Scene &scene);
 	void DrawGround

--- a/engine/Poseidon/World/Terrain/LandscapeRender.cpp
+++ b/engine/Poseidon/World/Terrain/LandscapeRender.cpp
@@ -1827,8 +1827,27 @@ void Landscape::DrawClouds(Scene& scene)
     }
 }
 
+void Landscape::FlushHeightmapToRenderer()
+{
+    if (!_heightmapDirty || !_engine)
+    {
+        return;
+    }
+
+    int w = _data.GetXRange();
+    int h = _data.GetYRange();
+    if (w <= 0 || h <= 0)
+    {
+        return;
+    }
+    _engine->SetTerrainHeightmap(static_cast<const float*>(_data.RawData()), w, h, _invTerrainGrid);
+    _heightmapDirty = false;
+}
+
 void Landscape::Draw(Scene& scene)
 {
+    FlushHeightmapToRenderer();
+
     {
         Camera& camera = *scene.GetCamera();
 

--- a/engine/Poseidon/World/Terrain/LandscapeRender.cpp
+++ b/engine/Poseidon/World/Terrain/LandscapeRender.cpp
@@ -1840,7 +1840,7 @@ void Landscape::FlushHeightmapToRenderer()
     {
         return;
     }
-    _engine->SetTerrainHeightmap(static_cast<const float*>(_data.RawData()), w, h, _invTerrainGrid);
+    _engine->SetTerrainHeightmap(static_cast<const float*>(_data.RawData()), w, h, _invTerrainGrid, _invLandGrid);
     _heightmapDirty = false;
 }
 

--- a/engine/PoseidonGL33/EngineGL33.hpp
+++ b/engine/PoseidonGL33/EngineGL33.hpp
@@ -128,7 +128,7 @@ enum : int
     SlotSunEn = 20,
     SlotVpScale = 21,
     SlotHmParams0 = 22, // terrain heightmap: {invGrid, camX, camZ, camY}
-    SlotHmParams1 = 23, // land clip: {boundingCenter.xyz, enable}
+    SlotHmParams1 = 23, // land clip: {boundingCenter.xyz, mode}
     SlotTexMat0 = 24, // 4 vec4s
     SlotTexMat1 = 28, // 4 vec4s
     SlotTexCtrl = 32,
@@ -139,6 +139,7 @@ enum : int
     SlotLightAmbient = 50, // MaxLocalLights vec4: ambient * nightEffect
     SlotLightDir = 58,     // MaxLocalLights vec4: xyz beam dir (world), w = isSpot
     SlotLightVP = 66,      // 4 vec4s: light view-projection for shadow-map sampling
+    SlotLandGrid = 70,     // {invLandGrid, heightmap texels per land square, 0, 0}
 };
 
 // Per-draw cap on local lights folded into the vertex shader.
@@ -161,6 +162,7 @@ static_assert(SlotLightDiffuse >= SlotLightPos + MaxLocalLights, "SlotLightDiffu
 static_assert(SlotLightAmbient >= SlotLightDiffuse + MaxLocalLights, "SlotLightAmbient overlaps SlotLightDiffuse");
 static_assert(SlotLightDir >= SlotLightAmbient + MaxLocalLights, "SlotLightDir overlaps SlotLightAmbient");
 static_assert(SlotLightVP >= SlotLightDir + MaxLocalLights, "SlotLightVP overlaps SlotLightDir");
+static_assert(SlotLandGrid >= SlotLightVP + 4, "SlotLandGrid overlaps SlotLightVP");
 }; // namespace VSConst
 
 struct TriQueue
@@ -621,9 +623,9 @@ class EngineGL33 : public Engine
     void InitDraw(bool clear = false, PackedColor color = PackedColor(0)) override;
     void FinishDraw() override;
     void NextFrame() override;
-    void SetTerrainHeightmap(const float* heights, int width, int height, float invGrid) override;
+    void SetTerrainHeightmap(const float* heights, int width, int height, float invGrid, float invLandGrid) override;
     bool LandClipInVS() const override;
-    void SetLandClipParams(float enable, Vector3Par boundingCenter) override;
+    void SetLandClipParams(float mode, Vector3Par boundingCenter) override;
     void DrawTestPattern(const char* name) override;
 
     void Pause() override;

--- a/engine/PoseidonGL33/EngineGL33.hpp
+++ b/engine/PoseidonGL33/EngineGL33.hpp
@@ -17,6 +17,7 @@ class TextBankGL33;
 // GL33 has no D3D profiling scopes; the macro is a no-op here.
 #define PROFILE_DX_SCOPE(name)
 
+#include <cstddef>
 #include <vector>
 #include <Poseidon/Foundation/Containers/Array.hpp>
 #include <Poseidon/Foundation/Containers/StaticArray.hpp>
@@ -126,7 +127,8 @@ enum : int
     SlotSpecEn = 19,
     SlotSunEn = 20,
     SlotVpScale = 21,
-    // slots 22..23 reserved
+    SlotHmParams0 = 22, // terrain heightmap: {invGrid, camX, camZ, camY}
+    SlotHmParams1 = 23, // land clip: {boundingCenter.xyz, enable}
     SlotTexMat0 = 24, // 4 vec4s
     SlotTexMat1 = 28, // 4 vec4s
     SlotTexCtrl = 32,
@@ -148,7 +150,9 @@ static_assert(SlotView >= SlotProj + 4, "SlotView overlaps SlotProj");
 static_assert(SlotWorld >= SlotView + 4, "SlotWorld overlaps SlotView");
 static_assert(SlotSunDir >= SlotWorld + 4, "SlotSunDir overlaps SlotWorld");
 static_assert(SlotVpScale >= SlotSunEn + 1, "SlotVpScale overlaps SlotSunEn");
-static_assert(SlotTexMat0 >= SlotVpScale + 1, "SlotTexMat0 overlaps SlotVpScale");
+static_assert(SlotHmParams0 >= SlotVpScale + 1, "SlotHmParams0 overlaps SlotVpScale");
+static_assert(SlotHmParams1 >= SlotHmParams0 + 1, "SlotHmParams1 overlaps SlotHmParams0");
+static_assert(SlotTexMat0 >= SlotHmParams1 + 1, "SlotTexMat0 overlaps SlotHmParams1");
 static_assert(SlotTexMat1 >= SlotTexMat0 + 4, "SlotTexMat1 overlaps SlotTexMat0");
 static_assert(SlotTexCtrl >= SlotTexMat1 + 4, "SlotTexCtrl overlaps SlotTexMat1");
 static_assert(SlotLightCount >= SlotTexCtrl + 1, "SlotLightCount overlaps SlotTexCtrl");
@@ -201,7 +205,18 @@ struct SVertex
     Vector3P pos;
     Vector3P norm;
     Poseidon::UVPair t0;
+    // 0 rigid, 1 ClipLandKeep, 2 ClipLandOn
+    uint8_t landClip;
 };
+
+// GPU upload contract: SVertex is uploaded verbatim and read by vsTransform through
+// the SetupSVertexLayout() VAO. sizeof is the attribute stride and the offsets must
+// match the glVertexAttribPointer calls for locations 0..3.
+static_assert(sizeof(SVertex) == 36, "SVertex size must equal the VAO vertex stride");
+static_assert(offsetof(SVertex, pos) == 0, "SVertex.pos must be at offset 0 (attrib 0)");
+static_assert(offsetof(SVertex, norm) == 12, "SVertex.norm must be at offset 12 (attrib 1)");
+static_assert(offsetof(SVertex, t0) == 24, "SVertex.t0 must be at offset 24 (attrib 2)");
+static_assert(offsetof(SVertex, landClip) == 32, "SVertex.landClip must be at offset 32 (attrib 3)");
 
 // Free-function override for hot-reload — when set (typically via CLI
 // --shader-override-dir), GL33's CompileGLShader prefers
@@ -590,6 +605,9 @@ class EngineGL33 : public Engine
     void InitDraw(bool clear = false, PackedColor color = PackedColor(0)) override;
     void FinishDraw() override;
     void NextFrame() override;
+    void SetTerrainHeightmap(const float* heights, int width, int height, float invGrid) override;
+    bool LandClipInVS() const override;
+    void SetLandClipParams(float enable, Vector3Par boundingCenter) override;
     void DrawTestPattern(const char* name) override;
 
     void Pause() override;
@@ -684,6 +702,7 @@ class EngineGL33 : public Engine
     bool _shadowMapActive = false;                 // a depth pass ran this frame
     unsigned int _shadowMapTex = 0;                // GL depth texture ARRAY to sample
     int _shadowMapRes = 0;                         // its resolution
+    unsigned int _heightMapTex = 0;                // GL R32F terrain height texture
     int _shadowCascades = 0;                       // active cascade count this frame
     int _shadowOmniCount = 0;                      // leading omni (camera-sphere) tiers — distance-selected
     float _shadowMapVP[kShadowCascades * 16] = {}; // per-cascade light view-projections (column-major)
@@ -793,12 +812,13 @@ class EngineGL33 : public Engine
         return pure;
     }
     void UploadWorldInstances(const float* matrices, int count);
-    // Run accumulation: Scene adds model-to-world transforms; the engine
-    // converts (camera-relative GfxMatrix) and uploads on BeginInstancedRunUpload.
+    // Run accumulation: Scene adds model-to-world transforms; the engine converts
+    // (camera-relative GfxMatrix) and uploads on BeginInstancedRunUpload.
     void InstancedRunReset() override { _instPending = 0; }
     bool InstancedRunAdd(const Matrix4& modelToWorld) override;
     int InstancedRunPending() const { return _instPending; }
     void BeginInstancedRunUpload() override;
+    bool InstancedRunActive() const override { return _instCount > 1; }
     int _instCount = 0;
     bool _instImpure = false;
     int _instPending = 0;
@@ -925,7 +945,6 @@ class EngineGL33 : public Engine
     void SelectVertexShader(VertexShaderID vs);
     void UploadVSScreenConstants();
     void UploadVSProjection(const FrameState& frame);
-    void UploadVSViewConstants(const FrameState& frame);
     FrameState BuildFrameState(Camera* camera, LightSun* sun, int bias, const Color& fogColor, bool sunEnabled);
     PassState BuildPassState(const FrameState& frame, Poseidon::PassId passId);
     void UploadVSWorldMatrix(const float worldMatrix[16]);

--- a/engine/PoseidonGL33/EngineGL33.hpp
+++ b/engine/PoseidonGL33/EngineGL33.hpp
@@ -209,6 +209,22 @@ struct SVertex
     uint8_t landClip;
 };
 
+enum class LandClipVertexMode : uint8_t
+{
+    Rigid,
+    Keep,
+    On,
+};
+
+constexpr LandClipVertexMode ClassifyLandClipVertex(ClipFlags clip)
+{
+    if (clip & ClipLandKeep)
+        return LandClipVertexMode::Keep;
+    if (clip & ClipLandOn)
+        return LandClipVertexMode::On;
+    return LandClipVertexMode::Rigid;
+}
+
 // GPU upload contract: SVertex is uploaded verbatim and read by vsTransform through
 // the SetupSVertexLayout() VAO. sizeof is the attribute stride and the offsets must
 // match the glVertexAttribPointer calls for locations 0..3.

--- a/engine/PoseidonGL33/EngineGL33_Lifecycle.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Lifecycle.cpp
@@ -1084,6 +1084,13 @@ void EngineGL33::ShutdownGL()
     DestroyVBTL();
     DestroyVB();
 
+    if (_heightMapTex)
+    {
+        GL33Bind::OnTexDeleted(_heightMapTex);
+        glDeleteTextures(1, &_heightMapTex);
+        _heightMapTex = 0;
+    }
+
     if (_fallbackWhiteTex)
     {
         GL33Bind::OnTexDeleted(_fallbackWhiteTex);

--- a/engine/PoseidonGL33/EngineGL33_Shaders.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Shaders.cpp
@@ -87,8 +87,8 @@ layout(std140) uniform VSConstants {
     vec4 specEn;        // c19: {enabled, 0, 0, 0}
     vec4 sunEn;         // c20: {enabled, 0, 0, 0}
     vec4 vpScale;       // c21: {2/width, 2/height, 0, 0} — VSScreen only, declared here for layout parity
-    vec4 _pad22;
-    vec4 _pad23;
+    vec4 hmParams0;     // c22: terrain heightmap {invGrid, camX, camZ, camY}
+    vec4 hmParams1;     // c23: land clip {boundingCenter.xyz, enable}
     mat4 texMat0;       // c24-c27
     mat4 texMat1;       // c28-c31
     vec4 texCtrl;       // c32: {genTex0, genTex1, 0, 0}
@@ -107,9 +107,12 @@ layout(std140) uniform WorldInstances {
     mat4 worldArr[256];
 };
 
+uniform sampler2D heightMap;
+
 layout(location = 0) in vec3 pos;
 layout(location = 1) in vec3 normal;
 layout(location = 2) in vec2 uv;
+layout(location = 3) in uint landClip;
 
 out vec4 vColor;
 out vec4 vSpecColor;
@@ -118,9 +121,51 @@ out vec2 vUV1;
 out float vFogTC;
 out vec3 vWorldRel;
 
+// Terrain height (.x, absolute) and world-space slope (.yz = dY/dx, dY/dz) at absolute
+// world XZ, matching Landscape::SurfaceY (two-triangle interpolation of the height grid).
+vec3 landClipSurface(vec2 absXZ) {
+    float invGrid = hmParams0.x;
+    vec2 rel = absXZ * invGrid;
+    ivec2 sz = textureSize(heightMap, 0);
+    ivec2 base = ivec2(floor(rel));
+    ivec2 i0 = clamp(base,            ivec2(0), sz - 1);
+    ivec2 i1 = clamp(base + ivec2(1), ivec2(0), sz - 1);
+    vec2 f = rel - vec2(base);
+    float y00 = texelFetch(heightMap, ivec2(i0.x, i0.y), 0).r;
+    float y01 = texelFetch(heightMap, ivec2(i1.x, i0.y), 0).r;
+    float y10 = texelFetch(heightMap, ivec2(i0.x, i1.y), 0).r;
+    float y11 = texelFetch(heightMap, ivec2(i1.x, i1.y), 0).r;
+    float h;
+    vec2 grad;
+    if (f.x <= 1.0 - f.y) {
+        h = y00 + (y10 - y00) * f.y + (y01 - y00) * f.x;
+        grad = vec2(y01 - y00, y10 - y00);
+    } else {
+        h = y10 + (y01 - y11) - (y10 - y11) * f.x - (y01 - y11) * f.y;
+        grad = vec2(y11 - y10, y11 - y01);
+    }
+    return vec3(h, grad * invGrid);
+}
+
 void main() {
     vec4 worldPos    = worldArr[gl_InstanceID] * vec4(pos, 1.0);
     vec3 worldNormal = normalize(mat3(worldArr[gl_InstanceID]) * normal);
+    // Land clip: snap terrain-following vertices onto the heightmap (matches Object::ApplyLandClip).
+    if (hmParams1.w > 0.5 && landClip != 0u && hmParams0.x > 0.0) {
+        vec3 surf = landClipSurface(worldPos.xz + hmParams0.yz);
+        if (landClip == 2u) {
+            worldPos.y = surf.x - hmParams0.w; // ClipLandOn: pin onto surface
+        } else {
+            // ClipLandKeep: keep the authored height above the terrain sampled at the object
+            // anchor (bounding centre), the reference Object::ApplyLandClip subtracts. worldArr
+            // is camera-relative, so re-add camXZ to get the absolute anchor.
+            vec2 anchorXZ = (worldArr[gl_InstanceID] * vec4(-hmParams1.xyz, 1.0)).xz + hmParams0.yz;
+            worldPos.y = worldPos.y + surf.x - landClipSurface(anchorXZ).x;
+        }
+        worldNormal = normalize(vec3(worldNormal.x - surf.y * worldNormal.y,
+                                     worldNormal.y,
+                                     worldNormal.z - surf.z * worldNormal.y));
+    }
     vec4 viewPos     = view * worldPos;
     gl_Position      = proj * viewPos;
     vWorldRel        = worldPos.xyz; // camera-relative world pos for cascade shadow lookup
@@ -607,8 +652,8 @@ layout(std140) uniform VSConstants {
     vec4 specEn;        // c19
     vec4 sunEn;         // c20
     vec4 vpScale;       // c21 — VSScreen only, declared for layout parity
-    vec4 _pad22;
-    vec4 _pad23;
+    vec4 hmParams0;     // c22: terrain heightmap {invGrid, camX, camZ, camY}
+    vec4 hmParams1;     // c23: land clip {boundingCenter.xyz, enable}
     mat4 texMat0;       // c24-c27
     mat4 texMat1;       // c28-c31
     vec4 texCtrl;       // c32
@@ -1094,15 +1139,57 @@ void EngineGL33::UpdateShadowMapLitState()
     FlushPSConstants();
 }
 
-void EngineGL33::UploadVSViewConstants(const FrameState& frame)
+void EngineGL33::SetTerrainHeightmap(const float* heights, int width, int height, float invGrid)
 {
-    memcpy(s_vsShadow + VSConst::SlotView * 4, &frame.view, 64);
-    memcpy(s_vsShadow + VSConst::SlotSunDir * 4, frame.sunDir, 16);
-    memcpy(s_vsShadow + VSConst::SlotCamPos * 4, frame.cameraPos, 12);
-    s_vsShadow[VSConst::SlotCamPos * 4 + 3] = 0;
-    float sunEn[4] = {frame.sunEnabled ? 1.0f : 0.0f, 0, 0, 0};
-    memcpy(s_vsShadow + VSConst::SlotSunEn * 4, sunEn, 16);
-    FlushVSConstants();
+    if (!heights || width <= 0 || height <= 0)
+    {
+        return;
+    }
+
+    if (_heightMapTex == 0)
+    {
+        glGenTextures(1, &_heightMapTex);
+    }
+
+    GL33Bind::Tex2D(kUploadUnit - GL_TEXTURE0, _heightMapTex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, width, height, 0, GL_RED, GL_FLOAT, heights);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    GL33Bind::ActiveUnit(0);
+
+    // .yzw (camX/camZ/camY) are filled per frame in UploadFrameConstants
+    s_vsShadow[VSConst::SlotHmParams0 * 4 + 0] = invGrid;
+}
+
+bool EngineGL33::LandClipInVS() const
+{
+    // We need the heightmap to be loaded to do land clipping in the vertex shader.
+    return _heightMapTex != 0;
+}
+
+void EngineGL33::SetLandClipParams(float enable, Vector3Par boundingCenter)
+{
+    float v[4] = {0.0f, 0.0f, 0.0f, enable};
+    if (enable > 0.5f)
+    {
+        v[0] = boundingCenter.X();
+        v[1] = boundingCenter.Y();
+        v[2] = boundingCenter.Z();
+    }
+    float* dst = s_vsShadow + VSConst::SlotHmParams1 * 4;
+    if (memcmp(v, dst, sizeof(v)) == 0)
+    {
+        return;
+    }
+    memcpy(dst, v, sizeof(v));
+    if (!s_vsUBO)
+    {
+        return;
+    }
+    glBindBuffer(GL_UNIFORM_BUFFER, s_vsUBO);
+    glBufferSubData(GL_UNIFORM_BUFFER, VSConst::SlotHmParams1 * 4 * sizeof(float), sizeof(v), v);
 }
 
 void EngineGL33::UploadWorldInstances(const float* matrices, int count)
@@ -1309,7 +1396,16 @@ void EngineGL33::UploadFrameConstants(const FrameState& frame)
     float texCtrl[4] = {0, 0, 0, 0};
     memcpy(s_vsShadow + VSConst::SlotTexCtrl * 4, texCtrl, 16);
 
+    // Land clip reconstructs absolute world XZ (and Y) from the camera-relative worldPos.
+    s_vsShadow[VSConst::SlotHmParams0 * 4 + 1] = frame.cameraPos[0];
+    s_vsShadow[VSConst::SlotHmParams0 * 4 + 2] = frame.cameraPos[2];
+    s_vsShadow[VSConst::SlotHmParams0 * 4 + 3] = frame.cameraPos[1];
+
     FlushVSConstants();
+
+    if (_heightMapTex)
+        GL33Bind::Tex2D(3, _heightMapTex);
+    GL33Bind::ActiveUnit(0);
 
     UploadPSFogColor(Color(frame.fogColor[0], frame.fogColor[1], frame.fogColor[2], frame.fogColor[3]));
 }
@@ -1566,6 +1662,9 @@ void EngineGL33::InitPixelShaders()
         GLint locShadow = glGetUniformLocation(prog, "shadowMap");
         if (locShadow >= 0)
             glUniform1i(locShadow, 2); // shadow depth map on texture unit 2
+        GLint locHeight = glGetUniformLocation(prog, "heightMap");
+        if (locHeight >= 0)
+            glUniform1i(locHeight, 3); // terrain height map on texture unit 3
         glUseProgram(0);
     };
 

--- a/engine/PoseidonGL33/EngineGL33_Shaders.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Shaders.cpp
@@ -1210,7 +1210,7 @@ void EngineGL33::SetLandClipParams(float mode, Vector3Par boundingCenter)
     {
         return;
     }
-    glBindBuffer(GL_UNIFORM_BUFFER, s_vsUBO);
+    GL33Bind::UniformBuffer(s_vsUBO);
     glBufferSubData(GL_UNIFORM_BUFFER, VSConst::SlotHmParams1 * 4 * sizeof(float), sizeof(v), v);
 }
 

--- a/engine/PoseidonGL33/EngineGL33_Shaders.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Shaders.cpp
@@ -671,7 +671,7 @@ layout(std140) uniform VSConstants {
     vec4 sunEn;         // c20
     vec4 vpScale;       // c21 — VSScreen only, declared for layout parity
     vec4 hmParams0;     // c22: terrain heightmap {invGrid, camX, camZ, camY}
-    vec4 hmParams1;     // c23: land clip {boundingCenter.xyz, enable}
+    vec4 hmParams1;     // c23: land clip {boundingCenter.xyz, mode}
     mat4 texMat0;       // c24-c27
     mat4 texMat1;       // c28-c31
     vec4 texCtrl;       // c32

--- a/engine/PoseidonGL33/EngineGL33_Shaders.cpp
+++ b/engine/PoseidonGL33/EngineGL33_Shaders.cpp
@@ -88,7 +88,7 @@ layout(std140) uniform VSConstants {
     vec4 sunEn;         // c20: {enabled, 0, 0, 0}
     vec4 vpScale;       // c21: {2/width, 2/height, 0, 0} — VSScreen only, declared here for layout parity
     vec4 hmParams0;     // c22: terrain heightmap {invGrid, camX, camZ, camY}
-    vec4 hmParams1;     // c23: land clip {boundingCenter.xyz, enable}
+    vec4 hmParams1;     // c23: land clip {boundingCenter.xyz, mode}
     mat4 texMat0;       // c24-c27
     mat4 texMat1;       // c28-c31
     vec4 texCtrl;       // c32: {genTex0, genTex1, 0, 0}
@@ -98,6 +98,7 @@ layout(std140) uniform VSConstants {
     vec4 lightAmbient[8];   // c50-c57: ambient * nightEffect
     vec4 localLightDir[8];  // c58-c65: xyz beam dir (world), w = isSpot
     mat4 lightVP;           // c66-c69: shadow-map light view-projection (sampled per fragment)
+    vec4 landGrid;          // c70: {invLandGrid, heightmap texels per land square, 0, 0}
 };
 
 // Per-instance world matrices (perf effort 08). Plain glDrawElements has
@@ -121,37 +122,56 @@ out vec2 vUV1;
 out float vFogTC;
 out vec3 vWorldRel;
 
-// Terrain height (.x, absolute) and world-space slope (.yz = dY/dx, dY/dz) at absolute
-// world XZ, matching Landscape::SurfaceY (two-triangle interpolation of the height grid).
-vec3 landClipSurface(vec2 absXZ) {
-    float invGrid = hmParams0.x;
-    vec2 rel = absXZ * invGrid;
+vec4 heightCorners(ivec2 base, int stride) {
     ivec2 sz = textureSize(heightMap, 0);
-    ivec2 base = ivec2(floor(rel));
-    ivec2 i0 = clamp(base,            ivec2(0), sz - 1);
-    ivec2 i1 = clamp(base + ivec2(1), ivec2(0), sz - 1);
-    vec2 f = rel - vec2(base);
-    float y00 = texelFetch(heightMap, ivec2(i0.x, i0.y), 0).r;
-    float y01 = texelFetch(heightMap, ivec2(i1.x, i0.y), 0).r;
-    float y10 = texelFetch(heightMap, ivec2(i0.x, i1.y), 0).r;
-    float y11 = texelFetch(heightMap, ivec2(i1.x, i1.y), 0).r;
+    ivec2 i0 = clamp(base,                 ivec2(0), sz - 1);
+    ivec2 i1 = clamp(base + ivec2(stride), ivec2(0), sz - 1);
+    return vec4(texelFetch(heightMap, ivec2(i0.x, i0.y), 0).r,
+                texelFetch(heightMap, ivec2(i1.x, i0.y), 0).r,
+                texelFetch(heightMap, ivec2(i0.x, i1.y), 0).r,
+                texelFetch(heightMap, ivec2(i1.x, i1.y), 0).r);
+}
+
+vec3 surfaceFromCorners(vec4 c, vec2 f, float invGrid) {
     float h;
     vec2 grad;
     if (f.x <= 1.0 - f.y) {
-        h = y00 + (y10 - y00) * f.y + (y01 - y00) * f.x;
-        grad = vec2(y01 - y00, y10 - y00);
+        h = c.x + (c.z - c.x) * f.y + (c.y - c.x) * f.x;
+        grad = vec2(c.y - c.x, c.z - c.x);
     } else {
-        h = y10 + (y01 - y11) - (y10 - y11) * f.x - (y01 - y11) * f.y;
-        grad = vec2(y11 - y10, y11 - y01);
+        h = c.z + (c.y - c.w) - (c.z - c.w) * f.x - (c.y - c.w) * f.y;
+        grad = vec2(c.w - c.z, c.w - c.y);
     }
     return vec3(h, grad * invGrid);
+}
+
+vec3 landClipSurface(vec2 absXZ) {
+    vec2 rel = absXZ * hmParams0.x;
+    vec2 base = floor(rel);
+    return surfaceFromCorners(heightCorners(ivec2(base), 1), rel - base, hmParams0.x);
+}
+
+vec3 landPlaneSurface(vec2 absXZ, vec2 objAbsXZ) {
+    float invLandGrid = landGrid.x;
+    int stride = int(landGrid.y);
+    vec2 sq = floor(objAbsXZ * invLandGrid);
+    return surfaceFromCorners(heightCorners(ivec2(sq) * stride, stride), absXZ * invLandGrid - sq, invLandGrid);
+}
+
+vec3 landClipNormal(vec3 n, vec3 surf) {
+    return normalize(vec3(n.x - surf.y * n.y, n.y, n.z - surf.z * n.y));
 }
 
 void main() {
     vec4 worldPos    = worldArr[gl_InstanceID] * vec4(pos, 1.0);
     vec3 worldNormal = normalize(mat3(worldArr[gl_InstanceID]) * normal);
-    // Land clip: snap terrain-following vertices onto the heightmap (matches Object::ApplyLandClip).
-    if (hmParams1.w > 0.5 && landClip != 0u && hmParams0.x > 0.0) {
+    int lcMode = int(hmParams1.w + 0.5);
+    if (lcMode == 2 && landGrid.y > 0.0) {
+        vec2 objAbsXZ = worldArr[gl_InstanceID][3].xz + hmParams0.yz;
+        vec3 surf = landPlaneSurface(worldPos.xz + hmParams0.yz, objAbsXZ);
+        worldPos.y = surf.x + pos.y + hmParams1.y - hmParams0.w;
+        worldNormal = landClipNormal(worldNormal, surf);
+    } else if (lcMode == 1 && landClip != 0u && hmParams0.x > 0.0) {
         vec3 surf = landClipSurface(worldPos.xz + hmParams0.yz);
         if (landClip == 2u) {
             worldPos.y = surf.x - hmParams0.w; // ClipLandOn: pin onto surface
@@ -162,9 +182,7 @@ void main() {
             vec2 anchorXZ = (worldArr[gl_InstanceID] * vec4(-hmParams1.xyz, 1.0)).xz + hmParams0.yz;
             worldPos.y = worldPos.y + surf.x - landClipSurface(anchorXZ).x;
         }
-        worldNormal = normalize(vec3(worldNormal.x - surf.y * worldNormal.y,
-                                     worldNormal.y,
-                                     worldNormal.z - surf.z * worldNormal.y));
+        worldNormal = landClipNormal(worldNormal, surf);
     }
     vec4 viewPos     = view * worldPos;
     gl_Position      = proj * viewPos;
@@ -818,7 +836,7 @@ static GLuint LinkGLProgram(GLuint vs, GLuint fs, const char* name)
     return program;
 }
 
-static float s_vsShadow[280] = {}; // 70 vec4 slots — through SlotLightVP (c66-c69)
+static float s_vsShadow[284] = {}; // 71 vec4 slots through SlotLandGrid
 static float s_psShadow[108] = {}; // 27 vec4 slots — c8-c23 cascadeVP[4], c24 splits, c25 ctl, c26 camFwd
 
 static GLuint s_vsUBO = 0;
@@ -1139,7 +1157,7 @@ void EngineGL33::UpdateShadowMapLitState()
     FlushPSConstants();
 }
 
-void EngineGL33::SetTerrainHeightmap(const float* heights, int width, int height, float invGrid)
+void EngineGL33::SetTerrainHeightmap(const float* heights, int width, int height, float invGrid, float invLandGrid)
 {
     if (!heights || width <= 0 || height <= 0)
     {
@@ -1161,6 +1179,10 @@ void EngineGL33::SetTerrainHeightmap(const float* heights, int width, int height
 
     // .yzw (camX/camZ/camY) are filled per frame in UploadFrameConstants
     s_vsShadow[VSConst::SlotHmParams0 * 4 + 0] = invGrid;
+    s_vsShadow[VSConst::SlotLandGrid * 4 + 0] = invLandGrid;
+    s_vsShadow[VSConst::SlotLandGrid * 4 + 1] = invLandGrid > 0 ? invGrid / invLandGrid : 0;
+    s_vsShadow[VSConst::SlotLandGrid * 4 + 2] = 0;
+    s_vsShadow[VSConst::SlotLandGrid * 4 + 3] = 0;
 }
 
 bool EngineGL33::LandClipInVS() const
@@ -1169,10 +1191,10 @@ bool EngineGL33::LandClipInVS() const
     return _heightMapTex != 0;
 }
 
-void EngineGL33::SetLandClipParams(float enable, Vector3Par boundingCenter)
+void EngineGL33::SetLandClipParams(float mode, Vector3Par boundingCenter)
 {
-    float v[4] = {0.0f, 0.0f, 0.0f, enable};
-    if (enable > 0.5f)
+    float v[4] = {0.0f, 0.0f, 0.0f, mode};
+    if (mode > 0.5f)
     {
         v[0] = boundingCenter.X();
         v[1] = boundingCenter.Y();

--- a/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
+++ b/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
@@ -33,7 +33,8 @@ class VertexBufferGL33 : public VertexBuffer
     GLuint _vao = 0;
     GLuint _vbo = 0;
     GLuint _ibo = 0;
-    bool _dynamic = false;
+    bool _dynamic = false;          // dynamic storage: GL_DYNAMIC_DRAW + orphaning map
+    bool _reuploadPerFrame = false; // re-copy the source vertices every draw (VBDynamic)
     int _vertexCount = 0;
     int _indexCount = 0;
     AutoArray<VBSectionInfo> _sections;
@@ -93,6 +94,10 @@ void VertexBufferGL33::CopyVertices(const Shape& src)
     const UVPair* uv = &src.UV(0);
     const Vector3* pos = &src.Pos(0);
     const Vector3* norm = &src.Norm(0);
+    // ApplyLandClip clears the ClipLandKeep bit as it conforms, so read the
+    // saved original flags when a shape has been animated.
+    const bool useOrig = src.OriginalPosValid();
+    int vi = 0;
     for (int i = src.NVertex(); --i >= 0;)
     {
         sData->pos = Vector3P(pos->X(), pos->Y(), pos->Z());
@@ -102,6 +107,9 @@ void VertexBufferGL33::CopyVertices(const Shape& src)
         norm++;
         sData->t0 = *uv;
         uv++;
+        ClipFlags clip = useOrig ? src.OrigClip(vi) : src.Clip(vi);
+        sData->landClip = (clip & ClipLandKeep) ? 1 : ((clip & ClipLandOn) ? 2 : 0);
+        vi++;
         sData++;
     }
 
@@ -116,7 +124,8 @@ bool VertexBufferGL33::Init(const Shape& src, VBType type)
         return false;
     }
 
-    _dynamic = (type == VBDynamic);
+    _dynamic = (type != VBStatic);
+    _reuploadPerFrame = (type == VBDynamic);
     _vertexCount = src.NVertex();
 
     // Core profile requires a non-zero VAO bound before any
@@ -206,9 +215,9 @@ bool VertexBufferGL33::Init(const Shape& src, VBType type)
     return true;
 }
 
-void VertexBufferGL33::Update(const Shape& src, bool dynamic)
+void VertexBufferGL33::Update(const Shape& src, bool forceUpdate)
 {
-    if (_dynamic || dynamic || bufferDirty)
+    if (_reuploadPerFrame || forceUpdate || bufferDirty)
     {
         CopyVertices(src);
         bufferDirty = false;

--- a/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
+++ b/engine/PoseidonGL33/EngineGL33_VertexBuffer.cpp
@@ -108,7 +108,7 @@ void VertexBufferGL33::CopyVertices(const Shape& src)
         sData->t0 = *uv;
         uv++;
         ClipFlags clip = useOrig ? src.OrigClip(vi) : src.Clip(vi);
-        sData->landClip = (clip & ClipLandKeep) ? 1 : ((clip & ClipLandOn) ? 2 : 0);
+        sData->landClip = static_cast<uint8_t>(ClassifyLandClipVertex(clip));
         vi++;
         sData++;
     }

--- a/engine/PoseidonGL33/GLVertexAttribLayouts.hpp
+++ b/engine/PoseidonGL33/GLVertexAttribLayouts.hpp
@@ -67,6 +67,8 @@ inline void SetupSVertexLayout()
     glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, stride, reinterpret_cast<void*>(offsetof(SVertex, norm)));
     glEnableVertexAttribArray(2);
     glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, stride, reinterpret_cast<void*>(offsetof(SVertex, t0)));
+    glEnableVertexAttribArray(3);
+    glVertexAttribIPointer(3, 1, GL_UNSIGNED_BYTE, stride, reinterpret_cast<void*>(offsetof(SVertex, landClip)));
 }
 
 } // namespace Poseidon::render::vao

--- a/tests/unit/engine/Poseidon/CMakeLists.txt
+++ b/tests/unit/engine/Poseidon/CMakeLists.txt
@@ -146,6 +146,7 @@ set(POSEIDON_TEST_SOURCES
     Graphics/test_model_renderer.cpp
     Graphics/test_gl33_rendering.cpp
     Graphics/test_gl33_bind_cache.cpp
+    Graphics/test_gl33_land_clip.cpp
     Graphics/test_gl33_state_cache.cpp
     Graphics/test_fan_decompose.cpp
     Graphics/test_zbias_math.cpp

--- a/tests/unit/engine/Poseidon/Graphics/test_gl33_land_clip.cpp
+++ b/tests/unit/engine/Poseidon/Graphics/test_gl33_land_clip.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <Poseidon/Graphics/Rendering/Shape/Shape.hpp>
+#include <Poseidon/World/Scene/ObjectClasses.hpp>
 #include <PoseidonGL33/EngineGL33.hpp>
 
 using namespace Poseidon;
@@ -39,4 +40,21 @@ TEST_CASE("LODShape identifies land clip as its only animation", "[Graphics][GL3
 
     shape.SetHints(ClipLandKeep | ClipLightSky, ClipLandKeep | ClipLightSky);
     CHECK_FALSE(shape.IsLandClipOnlyAnim());
+}
+
+TEST_CASE("Objects select their GPU land-clip mode", "[Graphics][GL33][LandClip]")
+{
+    Ref<LODShapeWithShadow> lod = new LODShapeWithShadow();
+    Shape* level = new Shape();
+    level->SetHints(ClipNone, ClipNone);
+    lod->AddShape(level, 0.0f);
+
+    Ref<ObjectPlain> object = new ObjectPlain(lod, 1);
+    CHECK(object->GetLandClipMode(0) == Object::LandClipNone);
+
+    level->SetHints(ClipLandKeep, ClipNone);
+    CHECK(object->GetLandClipMode(0) == Object::LandClipVertex);
+
+    Ref<ForestPlain> forest = new ForestPlain(lod, 2);
+    CHECK(forest->GetLandClipMode(0) == Object::LandClipPlane);
 }

--- a/tests/unit/engine/Poseidon/Graphics/test_gl33_land_clip.cpp
+++ b/tests/unit/engine/Poseidon/Graphics/test_gl33_land_clip.cpp
@@ -1,0 +1,42 @@
+#include <catch2/catch_test_macros.hpp>
+#include <Poseidon/Graphics/Rendering/Shape/Shape.hpp>
+#include <PoseidonGL33/EngineGL33.hpp>
+
+using namespace Poseidon;
+
+TEST_CASE("GL33 classifies land-clip vertex modes", "[Graphics][GL33][LandClip]")
+{
+    CHECK(ClassifyLandClipVertex(ClipNone) == LandClipVertexMode::Rigid);
+    CHECK(ClassifyLandClipVertex(ClipLandKeep) == LandClipVertexMode::Keep);
+    CHECK(ClassifyLandClipVertex(ClipLandOn) == LandClipVertexMode::On);
+}
+
+TEST_CASE("Shape identifies deforming land clip", "[Graphics][GL33][LandClip]")
+{
+    Shape shape;
+
+    shape.SetHints(ClipNone, ClipNone);
+    CHECK_FALSE(shape.HasDeformingLandClip());
+
+    shape.SetHints(ClipLandKeep, ClipNone);
+    CHECK(shape.HasDeformingLandClip());
+
+    shape.SetHints(ClipLandOn, ClipLandOn);
+    CHECK_FALSE(shape.HasDeformingLandClip());
+}
+
+TEST_CASE("LODShape identifies land clip as its only animation", "[Graphics][GL33][LandClip]")
+{
+    LODShape shape;
+    shape.SetHints(ClipLandKeep, ClipLandKeep);
+    CHECK_FALSE(shape.IsLandClipOnlyAnim());
+
+    shape.AllowAnimation();
+    CHECK(shape.IsLandClipOnlyAnim());
+
+    shape.SetHints(ClipLandKeep | ClipDecalNormal, ClipLandKeep | ClipDecalNormal);
+    CHECK_FALSE(shape.IsLandClipOnlyAnim());
+
+    shape.SetHints(ClipLandKeep | ClipLightSky, ClipLandKeep | ClipLightSky);
+    CHECK_FALSE(shape.IsLandClipOnlyAnim());
+}

--- a/tests/unit/engine/Poseidon/Graphics/test_gl33_rendering.cpp
+++ b/tests/unit/engine/Poseidon/Graphics/test_gl33_rendering.cpp
@@ -238,14 +238,6 @@ TEST_CASE("PSConstants: constColor slot and white default", "[Graphics][GL33][su
     REQUIRE(def.constColor[3] == 1.0f);
 }
 
-TEST_CASE("SVertex: correct size for static mesh upload", "[Graphics][GL33]")
-{
-    REQUIRE(sizeof(SVertex) == 32);
-    REQUIRE(offsetof(SVertex, pos) == 0);
-    REQUIRE(offsetof(SVertex, norm) == 12);
-    REQUIRE(offsetof(SVertex, t0) == 24);
-}
-
 // Engine Constants Tests (shared across backends)
 
 TEST_CASE("SpecToPassId covers all spec flag bits", "[Graphics][GL33]")
@@ -867,11 +859,8 @@ TEST_CASE("SurfaceInfoGL33::CalculateSize: non-square texture", "[Graphics][GL33
 }
 
 // SVertex Layout Tests — must match vsTransform GLSL attribute layout
-
-TEST_CASE("SVertex: size is 32 bytes (pos+norm+uv)", "[GL33][VertexBuffer]")
-{
-    REQUIRE(sizeof(SVertex) == 32);
-}
+// (size and offsets are enforced at compile time by static_asserts next to the
+// SVertex definition in EngineGL33.hpp)
 
 TEST_CASE("SVertex: member offsets match VAO attribute pointers", "[GL33][VertexBuffer]")
 {

--- a/tests/unit/engine/Poseidon/World/test_object_animated_bounds.cpp
+++ b/tests/unit/engine/Poseidon/World/test_object_animated_bounds.cpp
@@ -30,6 +30,12 @@ class CountingObject : public ObjectPlain
 
     int AnimateCalls() const { return _animateCalls; }
 
+    void MarkDestroyed()
+    {
+        _isDestroyed = true;
+        _destroyPhase = 255;
+    }
+
   private:
     int _animateCalls = 0;
 };
@@ -65,4 +71,27 @@ TEST_CASE("Object caches undamaged land-clipped bounds", "[World][Object][Bounds
     object->SetDammage(0.5f);
     object->AnimatedMinMax(0, bounds);
     REQUIRE(object->AnimateCalls() == 2);
+}
+
+TEST_CASE("Destroyed objects report shared shape deformation", "[World][Object][Instancing]")
+{
+    Ref<LODShapeWithShadow> lod = new LODShapeWithShadow();
+    Shape* level = new Shape();
+    lod->AddShape(level, 0.0f);
+
+    Ref<CountingObject> object = new CountingObject(lod, 1);
+    CHECK_FALSE(object->DeformsSharedShape(0));
+
+    Poly face;
+    face.Init();
+    face.SetN(0);
+    level->AddFace(face);
+    CHECK_FALSE(object->DeformsSharedShape(0));
+
+    object->SetDestructType(DestructBuilding);
+    object->MarkDestroyed();
+    CHECK(object->DeformsSharedShape(0));
+
+    object->SetDestructType(DestructTree);
+    CHECK_FALSE(object->DeformsSharedShape(0));
 }

--- a/tests/unit/engine/Poseidon/World/test_object_animated_bounds.cpp
+++ b/tests/unit/engine/Poseidon/World/test_object_animated_bounds.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <Poseidon/Graphics/Dummy/EngineDummy.hpp>
 #include <Poseidon/Graphics/Rendering/Shape/Shape.hpp>
 #include <Poseidon/World/Scene/Object.hpp>
 #include <Poseidon/World/Terrain/Landscape.hpp>
@@ -15,6 +16,22 @@ class GlobalLandscapeScope
 
   private:
     Landscape* _previous;
+};
+
+class GlobalEngineScope
+{
+  public:
+    explicit GlobalEngineScope(Engine* engine) : _previous(GEngine) { GEngine = engine; }
+    ~GlobalEngineScope() { GEngine = _previous; }
+
+  private:
+    Engine* _previous;
+};
+
+class LandClipEngine : public EngineDummy
+{
+  public:
+    bool LandClipInVS() const override { return true; }
 };
 
 class CountingObject : public ObjectPlain
@@ -94,4 +111,28 @@ TEST_CASE("Destroyed objects report shared shape deformation", "[World][Object][
 
     object->SetDestructType(DestructTree);
     CHECK_FALSE(object->DeformsSharedShape(0));
+}
+
+TEST_CASE("Animated bounds do not nest object animation", "[World][Object][Bounds]")
+{
+    LandClipEngine engine;
+    GlobalEngineScope globalEngine(&engine);
+    Landscape landscape(nullptr, nullptr);
+    GlobalLandscapeScope globalLandscape(&landscape);
+
+    Ref<LODShapeWithShadow> lod = new LODShapeWithShadow();
+    Shape* level = new Shape();
+    level->SetHints(ClipLandOn, ClipLandOn);
+    SetBounds(*level, Vector3(1, 2, 3), Vector3(4, 5, 6));
+    lod->AddShape(level, 0.0f);
+
+    Ref<CountingObject> object = new CountingObject(lod, 1);
+    object->SetDestructType(DestructBuilding);
+    object->MarkDestroyed();
+
+    Vector3 center;
+    float radius = 0;
+    object->AnimatedBSphere(0, center, radius, true);
+
+    CHECK(object->AnimateCalls() == 0);
 }


### PR DESCRIPTION
As usual @paavohuhtala cherry-pick of original commits, I had to cherry-pick some later one, but since they were introduced later in chain, they haven't applied smoothly, so I have manually cherry-picked the needed parts only to keep this isolated (original commits are merged in messages) and fully working. I did some refactoring, tried to add some tests and fixed one (or two?) issues found during testing.