### PR TITLE
Fixes ESCAPE key nor working in the key capturing conflict confirmation page

### DIFF
--- a/engine/Poseidon/UI/Options/CapturePage.cpp
+++ b/engine/Poseidon/UI/Options/CapturePage.cpp
@@ -78,6 +78,20 @@ class ConflictStatus final : public C3DStatic
   private:
     std::string m_colorMask;
 };
+
+class CaptureButton final : public C3DActiveText
+{
+  public:
+    CaptureButton(ControlsContainer* parent, int idc, const ParamEntry& cls) : C3DActiveText(parent, idc, cls) {}
+
+    void OnMouseMove(float x, float y, bool active = true) override
+    {
+        if (active && IsVisible() && IsEnabled())
+            _parent->FocusCtrl(IDC());
+
+        C3DActiveText::OnMouseMove(x, y, active);
+    }
+};
 } // namespace
 
 CapturePage::CapturePage(Idcs idcs, std::string actionLabel, std::string slotName, SaveCallback onSave,
@@ -181,6 +195,10 @@ Control* CapturePage::OnCreateControl(OptionsShell& shell, int /*type*/, int idc
 {
     if (idc == m_idcs.status)
         return new ConflictStatus(&shell, idc, cls);
+
+    if (idc == m_idcs.save || idc == m_idcs.retry || idc == m_idcs.cancel)
+        return new CaptureButton(&shell, idc, cls);
+
     return nullptr;
 }
 

--- a/engine/Poseidon/UI/Options/CapturePage.cpp
+++ b/engine/Poseidon/UI/Options/CapturePage.cpp
@@ -144,9 +144,8 @@ bool CapturePage::OnKeyDown(OptionsShell& shell, unsigned nChar)
         return false;
     if (nChar == SDLK_ESCAPE)
     {
-        if (m_state == Listening)
-            Resolve(shell, false);
-        return true; // eat in Captured state — avoids race with synthetic key tap from triGpadButton
+        Resolve(shell, false);
+        return true;
     }
 
     if (m_state != Listening)


### PR DESCRIPTION
Note: the original comment that I deleted mentions some problem with gamepad.

The comment suggests that the user might press some gamepad button to cancel this page unwillingly.

However, if some gamepad button imitates ESC then it will never be captured. And once some key is captured, and is already used, then the only two buttons that are supposed to work on this page are ENTER - to execute selected button and ESCAPE to go back to previous menu.

I don't have gamepad to test this. So please look into this yourself and verify that I didn't break anything. If I did, well I guess we should find some other way to fix this issue.