### PR TITLE
Gameplay enhancement: Reloading redundancy

### DIFF
--- a/engine/Poseidon/AI/VehicleAIPilot.cpp
+++ b/engine/Poseidon/AI/VehicleAIPilot.cpp
@@ -1223,6 +1223,7 @@ static void GetReloadActions(EntityAI* veh, UIActions& actions, int iSlot, const
     const Magazine* magazine = slot._magazine;
     const MagazineType* mType = magazine ? magazine->_type : nullptr;
     bool empty = false;
+
     if (mType && slot._mode >= 0 && slot._mode < mType->_modes.Size())
     {
         const WeaponModeType* mode = mType->_modes[slot._mode];
@@ -1235,10 +1236,10 @@ static void GetReloadActions(EntityAI* veh, UIActions& actions, int iSlot, const
         {
             // do not offer reload HandGrenade etc.
         }
-        else
+        else if (magazine->_ammo < mType->_maxAmmo)
         {
             // magazine of the same type
-            int best = veh->FindBestMagazine(mType, 0);
+            int best = veh->FindBestMagazine(mType, magazine->_ammo);
             if (best >= 0)
             {
                 float prior = empty ? 1.5 : 0.35;

--- a/engine/Poseidon/World/Entities/Infantry/SoldierOldActions.cpp
+++ b/engine/Poseidon/World/Entities/Infantry/SoldierOldActions.cpp
@@ -208,23 +208,26 @@ void Soldier::KeyboardPilot(float deltaT, SimulationImportance prec)
             const MagazineSlot& slot = GetMagazineSlot(_currentWeapon);
             const Magazine* magazine = slot._magazine;
             const MagazineType* mType = magazine ? magazine->_type : nullptr;
-            int best = FindMagazineByType(slot._muzzle, mType);
-            if (best >= 0)
+            if (magazine->_ammo < mType->_maxAmmo)
             {
-                const Magazine* magazine = GetMagazine(best);
-                RString muzzleID = slot._weapon->GetName() + RString("|") + slot._muzzle->GetName();
-                Ref<ActionContextDefault> context = new ActionContextDefault;
-                context->function = MFReload;
-                context->param = magazine->_creator;
-                context->param2 = magazine->_id;
-                context->param3 = muzzleID;
-                if (PlayAction(magazine->_type->_reloadAction, context))
+                int best = FindBestMagazine(mType, magazine->_ammo);
+                if (best >= 0)
                 {
-                    PlayReloadMagazineSound(_currentWeapon, slot._muzzle);
-                }
-                else
-                {
-                    ReloadMagazineTimed(_currentWeapon, best, false);
+                    const Magazine* magazine = GetMagazine(best);
+                    RString muzzleID = slot._weapon->GetName() + RString("|") + slot._muzzle->GetName();
+                    Ref<ActionContextDefault> context = new ActionContextDefault;
+                    context->function = MFReload;
+                    context->param = magazine->_creator;
+                    context->param2 = magazine->_id;
+                    context->param3 = muzzleID;
+                    if (PlayAction(magazine->_type->_reloadAction, context))
+                    {
+                        PlayReloadMagazineSound(_currentWeapon, slot._muzzle);
+                    }
+                    else
+                    {
+                        ReloadMagazineTimed(_currentWeapon, best, false);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Cancels reloading and hide reload option in menu, if the gun has maximum amount of bullets or if there isn't any other magazine with higher number of bullets.

This fixes the fact that game allows player to reload magazine even if there isn't any other magazine to use or all other magazines have lower amount of ammo which in all cases results in no change and just wasting time. Therefore I find this option to be redundant and decided to remove it.