### PR TITLE
Fix flaky and stale Trident tests

### DIFF
--- a/engine/Poseidon/UI/Controls/UIControlsBase.cpp
+++ b/engine/Poseidon/UI/Controls/UIControlsBase.cpp
@@ -1,6 +1,7 @@
 #include <Poseidon/Foundation/Strings/Mbcs.hpp>
 #include <Poseidon/Foundation/Containers/Array.hpp>
 #include <Poseidon/Foundation/Framework/DebugLog.hpp>
+#include <Poseidon/Foundation/Framework/Log.hpp>
 #include <Poseidon/Foundation/Math/Interpol.hpp>
 #include <Poseidon/Foundation/Math/Math3D.hpp>
 #include <Poseidon/Foundation/Math/Math3DP.hpp>
@@ -192,6 +193,7 @@ void IControl::PlaySound(SoundPars& pars)
 {
     if (pars.name.GetLength() > 0)
     {
+        LOG_DEBUG(UI, "control sound '{}'", (const char*)pars.name);
         // float volume = GSoundsys->GetSpeechVolCoef();
         IWave* wave = GSoundScene->OpenAndPlayOnce2D(pars.name, pars.vol, pars.freq, false);
         if (wave)

--- a/engine/Trident/src/client/instance.rs
+++ b/engine/Trident/src/client/instance.rs
@@ -6,9 +6,14 @@ use crate::protocol::Event;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::io::AsyncBufReadExt;
 use tokio::process::{Child, Command};
+
+/// Lines the game has written to stdout, in order. Filled by the same task that
+/// drains the stdout pipe into `game_stdout.log`.
+pub type LogTap = Arc<Mutex<Vec<String>>>;
 
 /// A running game instance with a connected harness client.
 pub struct GameInstance {
@@ -18,9 +23,24 @@ pub struct GameInstance {
     game_binary: PathBuf,
     work_dir: PathBuf,
     config: ClientConfig,
+    log_tap: LogTap,
 }
 
 impl GameInstance {
+    /// How many stdout lines the game has written so far. Pass the value back to
+    /// [`Self::log_lines_since`] to look at only what followed.
+    pub fn log_mark(&self) -> usize {
+        self.log_tap.lock().map_or(0, |tap| tap.len())
+    }
+
+    /// Stdout lines the game wrote after `mark`.
+    pub fn log_lines_since(&self, mark: usize) -> Vec<String> {
+        self.log_tap.lock().map_or_else(
+            |_| Vec::new(),
+            |tap| tap.get(mark..).unwrap_or_default().to_vec(),
+        )
+    }
+
     /// Spawn a game instance with `--harness <port>` and optional extra args.
     /// Uses the provided [`ClientConfig`] for connection timeouts and retry behaviour.
     ///
@@ -138,17 +158,23 @@ impl GameInstance {
             )
         })?;
 
+        let log_tap: LogTap = Arc::new(Mutex::new(Vec::new()));
         let actual_port = if auto_port {
-            read_harness_port(&mut process, stdout_log, config.connect_timeout)
-                .await
-                .with_context(|| {
-                    format!(
-                        "while waiting for HARNESS_PORT from '{}' cwd='{}' args='--harness {port} {}'",
-                        binary.display(),
-                        work_dir.display(),
-                        extra_args.join(" ")
-                    )
-                })?
+            read_harness_port(
+                &mut process,
+                stdout_log,
+                log_tap.clone(),
+                config.connect_timeout,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "while waiting for HARNESS_PORT from '{}' cwd='{}' args='--harness {port} {}'",
+                    binary.display(),
+                    work_dir.display(),
+                    extra_args.join(" ")
+                )
+            })?
         } else {
             port
         };
@@ -160,6 +186,7 @@ impl GameInstance {
             game_binary: binary,
             work_dir,
             config: config.clone(),
+            log_tap,
         };
 
         instance.connect_with_retry().await?;
@@ -360,6 +387,7 @@ pub fn find_game_binary(game_dir: &Path, named: Option<&str>) -> Result<PathBuf>
 async fn read_harness_port(
     process: &mut Child,
     log_file: Option<std::fs::File>,
+    log_tap: LogTap,
     timeout: Duration,
 ) -> Result<u16> {
     let stdout = process
@@ -395,6 +423,9 @@ async fn read_harness_port(
                                 if let Some(w) = writer.as_mut() {
                                     use tokio::io::AsyncWriteExt;
                                     let _ = w.write_all(format!("{l}\n").as_bytes()).await;
+                                }
+                                if let Ok(mut tap) = log_tap.lock() {
+                                    tap.push(l);
                                 }
                             }
                         });
@@ -432,6 +463,7 @@ mod tests {
             game_binary: PathBuf::from("sh"),
             work_dir: PathBuf::new(),
             config: ClientConfig::default(),
+            log_tap: Arc::new(Mutex::new(Vec::new())),
         };
 
         let started = Instant::now();

--- a/engine/Trident/src/scenarios/integration.rs
+++ b/engine/Trident/src/scenarios/integration.rs
@@ -788,26 +788,29 @@ fn normalize_condition_failure(result: &str) -> String {
     }
 }
 
-fn parse_triscreenshot_label(stmt: &str) -> Option<String> {
-    let rest = stmt.trim().strip_prefix("triScreenshot")?.trim_start();
+fn parse_quoted_argument(stmt: &str, verb: &str) -> Option<String> {
+    let rest = stmt.trim().strip_prefix(verb)?.trim_start();
     let mut chars = rest.chars();
     if chars.next()? != '"' {
         return None;
     }
-
-    let mut label = String::new();
+    let mut arg = String::new();
     while let Some(c) = chars.next() {
         if c == '"' {
             if matches!(chars.clone().next(), Some('"')) {
                 chars.next();
-                label.push('"');
+                arg.push('"');
                 continue;
             }
-            return Some(label);
+            return Some(arg);
         }
-        label.push(c);
+        arg.push(c);
     }
     None
+}
+
+fn parse_triscreenshot_label(stmt: &str) -> Option<String> {
+    parse_quoted_argument(stmt, "triScreenshot")
 }
 
 async fn wait_for_screenshot_file(
@@ -1554,6 +1557,7 @@ async fn run_sqf_test(
     let statements = parse_statements(&sqf_code);
     let mut post_check_ran = false;
     let mut screenshot_seq = 0usize;
+    let mut log_mark = 0usize;
     for (i, stmt) in statements.iter().enumerate() {
         // Pre-shutdown injection: before sending a known game-exit
         // verb, run the I-20 post-check while the connection is live.
@@ -1610,6 +1614,41 @@ async fn run_sqf_test(
             .await;
             if let Some(message) = finish_condition_failure(&mut game, start, stmt, outcome).await {
                 return Ok(message);
+            }
+            continue;
+        }
+
+        // Harness-side statements: the game never sees these.  They read the
+        // stdout the runner already captures, so a scenario can assert on what
+        // the game logged.
+        if stmt.trim() == "triLogMark" {
+            log_mark = game.log_mark();
+            continue;
+        }
+        if let Some(needle) = parse_quoted_argument(stmt, "triAssertLogAbsent") {
+            // The drain task reads the stdout pipe on its own schedule, so a
+            // line the game wrote during the previous statement can still be in
+            // flight.  Let it land before deciding the log is clean.
+            tokio::time::sleep(effective_cfg.poll_interval).await;
+            let hits: Vec<String> = game
+                .log_lines_since(log_mark)
+                .into_iter()
+                .filter(|line| line.contains(&needle))
+                .collect();
+            if !hits.is_empty() {
+                game.kill_after_failure().await;
+                let elapsed = start.elapsed();
+                return Ok(ScenarioResult {
+                    passed: false,
+                    message: format!(
+                        "{} — FAIL:logged {} time(s), first: {} ({:.1}s)",
+                        stmt,
+                        hits.len(),
+                        hits[0].trim(),
+                        elapsed.as_secs_f64()
+                    ),
+                    duration: elapsed,
+                });
             }
             continue;
         }
@@ -2878,6 +2917,25 @@ triAssertDisplay 9099
         assert_eq!(
             parse_condition_statement("triSimUntil { triSceneReady }", "triSimUntil"),
             Some(String::from("triSceneReady"))
+        );
+    }
+
+    #[test]
+    fn parse_quoted_argument_reads_needle_and_rejects_other_verbs() {
+        assert_eq!(
+            parse_quoted_argument(
+                r#"triAssertLogAbsent "control sound""#,
+                "triAssertLogAbsent"
+            ),
+            Some("control sound".to_string())
+        );
+        assert_eq!(
+            parse_quoted_argument("triAssertLogAbsent", "triAssertLogAbsent"),
+            None
+        );
+        assert_eq!(
+            parse_quoted_argument(r#"triScreenshot "shot""#, "triAssertLogAbsent"),
+            None
         );
     }
 

--- a/tests/integration/ingame/vehicles/vehicle_turbo.test.sqf
+++ b/tests/integration/ingame/vehicles/vehicle_turbo.test.sqf
@@ -1,6 +1,8 @@
 // The Turbo modifier (Shift + forward) must speed a vehicle up: Turbo promotes
 // MoveForward to fast-forward, read per input context by the pilots. Two fresh
 // Jeeps cover the same ground so Shift + W can be compared with W alone.
+// Both runs accelerate for the same simulated time and stop short of the Jeep's
+// top speed, where the two runs converge and terrain decides the reading.
 // Scancodes: forward W 26, Left Shift 225.
 
 triSetLanguage "English"
@@ -12,8 +14,9 @@ triSimFrames 10
 _startPos = getPos turboCar
 _startDir = getDir turboCar
 
+_startTime = time
 triKeyDown 26
-triSimFrames 90
+while {(time - _startTime) < 4} do { triSimFrames 3 }
 _sW = speed turboCar
 triKeyUp 26
 triAssertGt [_sW, 1]
@@ -28,9 +31,10 @@ deleteVehicle turboCar
 triSimFrames 15
 if ((driver _turboCar) != player) then { "FAIL:player did not enter the fresh fixture vehicle" } else { "OK" }
 
+_turboTime = time
 triKeyDown 26
 triKeyDown 225
-triSimFrames 90
+while {(time - _turboTime) < 4} do { triSimFrames 3 }
 _sT = speed _turboCar
 triKeyUp 225
 triKeyUp 26

--- a/tests/integration/ui/main_menu/animated_notebook_hover_audio.test.sqf
+++ b/tests/integration/ui/main_menu/animated_notebook_hover_audio.test.sqf
@@ -2,26 +2,15 @@ triSetLanguage "English"
 triAssertEq [(triDisplay), 0]
 
 triCursorMoveControl 102
-triSimFrames 90
-_baseline = triAudioActive2D
+triSimFrames 30
 
-triClick 102
+// The notebook animates open under a cursor that never moves, so no row may
+// take hover and play its enter sound. triInvokeButton opens the shell without
+// a click of its own, leaving the whole window free of control sounds.
+triLogMark
+triInvokeButton 102
 triAssertEq [(triDisplay), 9099]
-
-_clickFinished = false
-_frames = 0
-while {!_clickFinished && _frames < 30} do {
-    triSimFrames 1;
-    _clickFinished = triAudioActive2D == _baseline;
-    _frames = _frames + 1;
-}
-triAssertEq [_clickFinished, true]
-
-_peak = _baseline
-for "_i" from 0 to 49 do {
-    triSimFrames 1;
-    if (triAudioActive2D > _peak) then {_peak = triAudioActive2D};
-}
-triAssertEq [_peak, _baseline]
+triSimFrames 50
+triAssertLogAbsent "control sound"
 
 triEndTest

--- a/tests/integration/ui/main_menu/animated_notebook_hover_audio.test.toml
+++ b/tests/integration/ui/main_menu/animated_notebook_hover_audio.test.toml
@@ -1,1 +1,2 @@
-timeout = 30
+extra_args = ["--log-level", "debug", "--log-categories", "ui"]
+timeout = 60

--- a/tests/integration/ui/main_menu/mods_catalog.test.sqf
+++ b/tests/integration/ui/main_menu/mods_catalog.test.sqf
@@ -73,9 +73,11 @@ triAssertEq [(triGetModsSortColumn), 0]
 triSortMods 3
 triScreenshot "mods_table_wired"
 
+// The guidance sentence gets reworded, so pin it by stringtable row, not wording.
 triSetLanguage "Czech"
 triWaitFrames 2
-triAssertIncludes [(triVisibleTexts), "Enter stáhne (pokud nejsou stažené) a načte vybrané mody."]
+triAssertIncludes [(triVisibleTexts), "Hledat:"]
+triAssertIncludes [(triVisibleTexts), (localize "STR_DISP_MODS_GUIDANCE")]
 
 // Cancel closes the MODS notebook and returns to the main menu.
 triClick 2

--- a/tests/integration/ui/main_menu/mods_download.test.sqf
+++ b/tests/integration/ui/main_menu/mods_download.test.sqf
@@ -5,7 +5,7 @@
 //
 //  Part 2: triOpenModDownload injects synthetic
 //  tasks + a FAKE in-process transport (no network/disk) so the two bars, the
-//  "N / N addons" overall line and the Complete path are exercised offline and
+//  "N / N" overall line and the Complete path are exercised offline and
 //  deterministically. The agnostic DownloadProgress/Worker/View components are
 //  unit-tested; this proves they render through the real notebook controls.
 
@@ -41,7 +41,7 @@ triClick 125                 // IDC_MODS_DOWNLOAD_GO — start the (fake) downlo
 triAssertIncludes [(triVisibleTexts), "Estrazione."] // unpacking remains visibly active after download
 triScreenshot "03_unpacking"
 triAssertIncludes [(triVisibleTexts), "Completato"]   // localized status line; auto-retries until the worker finishes + is polled
-triAssertIncludes [(triVisibleTexts), "3 / 3 addons   100%"]
+triAssertIncludes [(triVisibleTexts), "3 / 3   100%"]
 triAssertIncludes [(triVisibleTexts), "Continua"]     // the action button relabels on success
 triAssertIncludes [(triVisibleTexts), "Indietro"]     // completed downloads can return without activation
 triScreenshot "04_download_complete"


### PR DESCRIPTION
The menu world's ambience, the host frame rate and reworded on-screen text all moved under these assertions. Assert on a control-sound log line the runner taps from stdout, time the drive in simulated seconds, and read the active row.

Fixes some flaky tests on CI (at least I hope). :pray: 