### PR TITLE
Add perl-open to Fedora dependencies

### DIFF
--- a/docs/build/linux.md
+++ b/docs/build/linux.md
@@ -66,7 +66,7 @@ source ~/.bash_profile
 Run the following command in a terminal to install the dependencies:
 
 ```shell
-sudo dnf install autoconf-archive ccache clang clang-tools-extra git libGL-devel libtool libtool-ltdl-devel libX11-devel libXcursor-devel libXext-devel libXi-devel libXinerama-devel libxkbcommon-devel libXrandr-devel libXtst-devel perl-FindBin perl-IPC-Cmd perl-Time-Piece pkgconf python3 vcpkg wayland-devel wayland-protocols-devel
+sudo dnf install autoconf-archive ccache clang clang-tools-extra git libGL-devel libtool libtool-ltdl-devel libX11-devel libXcursor-devel libXext-devel libXi-devel libXinerama-devel libxkbcommon-devel libXrandr-devel libXtst-devel perl-FindBin perl-IPC-Cmd perl-Time-Piece perl-open pkgconf python3 vcpkg wayland-devel wayland-protocols-devel
 ```
 
 After this has completed successfully, you will need to follow the instructions in the `README.fedora` file to complete the setup for vcpkg:


### PR DESCRIPTION
I came across an error when running `cmake --preset linux-x64-clang-rwdi` on Fedora 44
```
Successfully downloaded besser82-libxcrypt-v4.5.2.tar.gz
...
-- Configuring x64-linux-clang-dbg
CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:127 (message):
    Command failed: /usr/bin/bash -c "V=1 CC='/usr/bin/clang -m64 -g' CXX='/usr/bin/clang++ -m64 -g' CC_FOR_BUILD='/usr/bin/clang -m64 -g' CPP_FOR_BUILD='/usr/bin/clang -E -m64 -g' CXX_FOR_BUILD='/usr/bin/clang++ -m64 -g' NM='/usr/bin/nm' RC='' WINDRES='' DLLTOOL='CMAKE_DLLTOOL-NOTFOUND' STRIP='/usr/bin/strip' OBJDUMP='/usr/bin/objdump' RANLIB='/usr/bin/ranlib' AR='/usr/bin/ar' LD='/usr/bin/ld' ./../src/v4.5.2-7ca15a2a8e.clean/configure \"--disable-werror\" \"lt_cv_deplibs_check_method=pass_all\" \"--prefix=/run/media/k/Linux-Storage/dev/games/CWR-CE/build/linux-x64-clang-rwdi/vcpkg_installed/x64-linux-clang/debug\" \"--bindir=\\${prefix}/../tools/libxcrypt/debug/bin\" \"--sbindir=\\${prefix}/../tools/libxcrypt/debug/sbin\" \"--libdir=\\${prefix}/lib\" \"--includedir=\\${prefix}/../include\" \"--mandir=\\${prefix}/share/libxcrypt\" \"--docdir=\\${prefix}/share/libxcrypt\" \"--datarootdir=\\${prefix}/share/libxcrypt\" \"--disable-shared\" \"--enable-static\""
    Working Directory: /home/k/.local/share/vcpkg/buildtrees/libxcrypt/x64-linux-clang-dbg
    Error code: 1
    See logs for more information:
      /home/k/.local/share/vcpkg/buildtrees/libxcrypt/config-x64-linux-clang-dbg-config.log
      /home/k/.local/share/vcpkg/buildtrees/libxcrypt/config-x64-linux-clang-dbg-out.log
      /home/k/.local/share/vcpkg/buildtrees/libxcrypt/config-x64-linux-clang-dbg-err.log
```

`config-x64-linux-clang-dbg-err.log` had the same error as https://github.com/brendangregg/FlameGraph/issues/245, and the solution for that was to install `perl-open`. After doing this with CWR-CE the build succeeded.