### PR TITLE
Read drop positions as heights above the surface

### DIFF
--- a/engine/Poseidon/Graphics/Rendering/Effects/Smokes.cpp
+++ b/engine/Poseidon/Graphics/Rendering/Effects/Smokes.cpp
@@ -2549,7 +2549,7 @@ GameValue ParticleDrop(const GameState* state, GameValuePar oper1)
         }
         else
         {
-            if (!GetVector3(Position, Array[5]))
+            if (!::GetPos(Position, Array[5]))
             {
                 state->SetError(EvalGen);
                 return GameValue();

--- a/tests/integration/missions/drop_particle.Demo/mission.sqm
+++ b/tests/integration/missions/drop_particle.Demo/mission.sqm
@@ -1,0 +1,51 @@
+version=11;
+class Mission
+{
+	randomSeed=340995;
+	class Intel
+	{
+	};
+	class Groups
+	{
+		items=1;
+		class Item0
+		{
+			side="WEST";
+			class Vehicles
+			{
+				items=1;
+				class Item0
+				{
+					position[]={6710.527832,82.907585,5408.891602};
+					id=0;
+					side="WEST";
+					vehicle="SoldierWB";
+					player="PLAYER COMMANDER";
+					leader=1;
+					skill=0.600000;
+				};
+			};
+		};
+	};
+};
+class Intro
+{
+	randomSeed=565763;
+	class Intel
+	{
+	};
+};
+class OutroWin
+{
+	randomSeed=11027971;
+	class Intel
+	{
+	};
+};
+class OutroLoose
+{
+	randomSeed=8297475;
+	class Intel
+	{
+	};
+};

--- a/tests/integration/missions/drop_particle.Demo/particle_pos.sqs
+++ b/tests/integration/missions/drop_particle.Demo/particle_pos.sqs
@@ -1,0 +1,3 @@
+dropReports = dropReports + 1
+dropReportedZ = _this select 2
+exit

--- a/tests/integration/scripting/drop_particle_height.test.sqf
+++ b/tests/integration/scripting/drop_particle_height.test.sqf
@@ -1,0 +1,17 @@
+// A standalone drop position is [x, y, height above the surface], and the
+// particle reports its own height back to its onTimer script in the same form.
+
+triSimFrames 30
+
+dropReports = 0
+dropReportedZ = -1e6
+groundPos = getPos player
+
+drop ["cl_basic", "", "Billboard", 0.05, 0.6, [(groundPos select 0) + 2, (groundPos select 1), 5], [0,0,0], 0, 1, 0.001, 0, [1,1], [[1,1,1,1],[1,1,1,0]], [0], 0, 0, "particle_pos.sqs", "", ""]
+
+triSimFrames 6
+
+triAssertGt [dropReports, 0]
+triAssertNear [dropReportedZ, 5, 2]
+
+triEndTest

--- a/tests/integration/scripting/drop_particle_height.test.toml
+++ b/tests/integration/scripting/drop_particle_height.test.toml
@@ -1,0 +1,5 @@
+tags = ["scripting", "fizzy-443"]
+binary = "PoseidonGame"
+mission = "tests/integration/missions/drop_particle.Demo"
+timeout = 180
+extra_args = ["--dev"]

--- a/tests/integration/scripting/fired_nearest_object.test.sqf
+++ b/tests/integration/scripting/fired_nearest_object.test.sqf
@@ -1,0 +1,23 @@
+// A "fired" handler can find the round it was told about: nearestObject with the
+// handler's ammo type resolves the shell at the muzzle while the handler runs.
+
+triSimFrames 30
+
+player removeAllEventHandlers "fired"
+
+firedAmmo = ""
+firedType = ""
+firedNull = ""
+firedDist = 1e10
+
+player addEventHandler ["fired", {firedAmmo = _this select 4; _shot = nearestObject [_this select 0, _this select 4]; firedNull = format["%1", isNull _shot]; firedType = format["%1", typeOf _shot]; firedDist = (_this select 0) distance _shot}]
+
+triAssertEq [triFirePlayerWeapon, "OK"]
+triSimFrames 2
+
+triAssertNe [firedAmmo, ""]
+triAssertEq [firedNull, "false"]
+triAssertEq [firedType, firedAmmo]
+triAssertLt [firedDist, 10]
+
+triEndTest

--- a/tests/integration/scripting/fired_nearest_object.test.toml
+++ b/tests/integration/scripting/fired_nearest_object.test.toml
@@ -1,0 +1,5 @@
+tags = ["scripting", "fizzy-443"]
+binary = "PoseidonGame"
+mission = "tests/integration/missions/action_menu_weapon.Demo"
+timeout = 180
+extra_args = ["--dev"]

--- a/tests/unit/engine/Poseidon/Graphics/Rendering/test_smokes.cpp
+++ b/tests/unit/engine/Poseidon/Graphics/Rendering/test_smokes.cpp
@@ -15,7 +15,7 @@ TEST_CASE("smokes.hpp compiles", "[rendering][effects]")
     SUCCEED("header included successfully");
 }
 
-TEST_CASE("drop absolute-position particle arrays use legacy vector parsing", "[rendering][effects][drop]")
+TEST_CASE("drop vector arrays map script axes onto engine axes", "[rendering][effects][drop]")
 {
     GameArrayType array;
     array.Add(GameValue(100.0f));


### PR DESCRIPTION
A standalone `drop` position is an ordinary script position, so its third element is a height above the terrain. It was taken as an absolute height, which sank every scripted particle by the terrain elevation.

Should fix some tracers (ČSLA) scripts for example :pray:.