### PR TITLE
Survive script-created street lamps

### DIFF
--- a/engine/Poseidon/World/Entities/Vehicles/VehicleTypes.cpp
+++ b/engine/Poseidon/World/Entities/Vehicles/VehicleTypes.cpp
@@ -744,6 +744,12 @@ Object* NewNonAIVehicleQuiet(RString typeName, RString shapeName, bool fullCreat
     }
     else if (!strcmp(simName, "streetlamp"))
     {
+        if (shapeName.GetLength() == 0 && !type->GetShape())
+        {
+            LOG_ERROR(World, "Cannot create '{}': street lamp has no model", (const char*)typeName);
+            type->VehicleRelease();
+            return nullptr;
+        }
         v = new StreetLamp(TempShape(shapeName), dynamic_cast<StreetLampType*>(type), -1);
     }
     else if (!strcmp(simName, "seagull"))

--- a/engine/Poseidon/World/Scene/ObjectClasses.cpp
+++ b/engine/Poseidon/World/Scene/ObjectClasses.cpp
@@ -198,6 +198,8 @@ void StreetLampType::InitShape()
     const ParamEntry& par = *_par;
     _scopeLevel = 2;
     base::InitShape();
+    if (!_shape)
+        return; // abstract class without a model
     DEF_HIT(_shape, _bulbHit, "lampa", nullptr, par >> "armorBulb");
 }
 void StreetLampType::DeinitShape()
@@ -206,7 +208,8 @@ void StreetLampType::DeinitShape()
 }
 
 StreetLamp::StreetLamp(LODShapeWithShadow* shape, StreetLampType* type, int id)
-    : base(shape, type, id), _pilotLight(true), _lightPos(shape->MemoryPoint("light"))
+    : base(shape, type, id), _pilotLight(true),
+      _lightPos(GetShape() ? GetShape()->MemoryPoint("light") : VZero) // the type's shape when created by script
 {
     SetSimulationPrecision(12.1256);
     _destrType = DestructTree;

--- a/tests/integration/scripting/create_vehicle_street_lamp.test.sqf
+++ b/tests/integration/scripting/create_vehicle_street_lamp.test.sqf
@@ -1,0 +1,16 @@
+// Street lamps created by script used to crash: the lamp constructor read the
+// "light" memory point from the shape passed in, which createVehicle leaves
+// empty (the entity base falls back to the type's shape), and the abstract
+// StreetLamp class has no model at all, so its hit-point setup dereferenced a
+// null shape. The concrete classes must come back as real objects; the abstract
+// one is refused and returns objNull.
+triSimUntil { time >= 2 }
+_p = getpos player
+cwrLampWood = "StreetLampWood" createVehicle [(_p select 0) + 5, (_p select 1) + 5, 0]
+cwrLampMetal = "StreetLampMetal" createVehicle [(_p select 0) - 5, (_p select 1) + 5, 0]
+cwrLampAbstract = "StreetLamp" createVehicle [(_p select 0), (_p select 1) + 8, 0]
+triWaitFrames 8
+if (isNull cwrLampWood) exitWith { "FAIL:StreetLampWood createVehicle returned objNull" }
+if (isNull cwrLampMetal) exitWith { "FAIL:StreetLampMetal createVehicle returned objNull" }
+if (!(isNull cwrLampAbstract)) exitWith { "FAIL:abstract StreetLamp should be refused" }
+triEndTest

--- a/tests/integration/scripting/create_vehicle_street_lamp.test.toml
+++ b/tests/integration/scripting/create_vehicle_street_lamp.test.toml
@@ -1,0 +1,4 @@
+binary = "PoseidonGame"
+mission = "tests/integration/missions/action_menu_weapon.Demo"
+timeout = 60
+tags = ["headless"]


### PR DESCRIPTION
## Why

`"StreetLampWood" createVehicle [...]` (and `StreetLampMetal`) crashes with a SIGSEGV in the `StreetLamp` constructor, and referencing the abstract `StreetLamp` class crashes in `StreetLampType::InitShape`. Found while scripting a night-lighting scene; reproduces on every renderer.

## What

- `createVehicle` passes no shape name. `Entity` already falls back to the type's shape, but `StreetLamp`'s constructor read the `light` memory point from the pointer it was handed, so it dereferenced null. It now reads it from the shape the object actually ended up with.
- The abstract `StreetLamp` class has no `model`, so `StreetLampType::InitShape` set up its bulb hit point on a null shape. `InitShape` now tolerates the shapeless type (the base class already does), and `NewNonAIVehicleQuiet` refuses to create a street lamp with no model, logging an error and returning null — the same treatment the empty-model vehicle case gets.

## Verification

New `tests/integration/scripting/create_vehicle_street_lamp` creates both concrete classes and the abstract one: the concrete ones must come back as real objects, the abstract one as `objNull`. It crashes the game before the fix and passes after; `create_vehicle_empty_model` still passes.